### PR TITLE
refactor: Remove redundant declaration reconstruction in collect_declarations

### DIFF
--- a/css/cascade/cascade.mbt
+++ b/css/cascade/cascade.mbt
@@ -119,17 +119,7 @@ pub fn collect_declarations(
   // Add declarations from matched rules
   for rule_match in matches {
     for decl in rule_match.declarations {
-      // Update specificity from the rule, keep declaration's source_order
-      // (which combines rule order and declaration order for proper cascade)
-      let updated : Declaration = {
-        property: decl.property,
-        value: decl.value,
-        origin: decl.origin,
-        importance: decl.importance,
-        specificity: rule_match.specificity,
-        source_order: decl.source_order,
-      }
-      result.push(updated)
+      result.push(decl)
     }
   }
 


### PR DESCRIPTION
This PR simplifies the cascade code by removing redundant reconstruction of Declaration in `collect_declarations`. 
Declarations produced by `Stylesheet::match_element` already include correct `specificity`, `origin`, and `source_order`, so rebuilding them again in `collect_declarations` is unnecessary.

RuleMatch is `pub(all)` and thus can be constructed externally. Depending on how it is generated, this adjustment *could* be necessary, but that does not appear to be the intended usage in this project.

The removed comments referred to the old behavior and no longer reflect the
current implementation, so they have been removed as well.