### PR TITLE
ci: start BiDi server before playwright tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,11 @@ jobs:
       - name: Build BiDi server
         run: just build-bidi
 
+      - name: Start BiDi server
+        run: |
+          just start-bidi &
+          sleep 3
+
       - name: Run Playwright adapter tests
         run: just test-playwright-adapter
 


### PR DESCRIPTION
## Summary
- CI の playwright-bidi-tests ジョブで、BiDi サーバーを起動せずにテストを実行していたため全テストが失敗していた
- `just build-bidi` の後にサーバーをバックグラウンドで起動するステップを追加

## Test plan
- [ ] CI の playwright-bidi-tests ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)