### PR TITLE
Add VRT API, flaker config checks, and CI reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,98 @@ jobs:
           path: playwright-report.json
           if-no-files-found: warn
 
+  flaker-config:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Validate flaker config tests
+        run: pnpm exec vitest run scripts/flaker-config.test.ts
+
+      - name: Build flaker config summary
+        run: just flaker-report flaker-report
+
+      - name: Publish flaker config summary
+        run: cat flaker-report/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload flaker config summary
+        uses: actions/upload-artifact@v6
+        with:
+          name: flaker-config-summary
+          path: flaker-report/*
+          if-no-files-found: error
+
+  vrt-bench:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Set up MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Update MoonBit dependencies
+        run: moon update
+
+      - name: Validate VRT bench parser tests
+        run: pnpm exec vitest run scripts/vrt-bench.test.ts
+
+      - name: Run VRT API benchmarks
+        run: just bench-vrt-report api vrt-bench
+
+      - name: Run VRT phase benchmarks
+        run: just bench-vrt-report phases vrt-bench
+
+      - name: Publish VRT bench summary
+        run: |
+          cat vrt-bench/api.md >> "$GITHUB_STEP_SUMMARY"
+          printf '\n\n' >> "$GITHUB_STEP_SUMMARY"
+          cat vrt-bench/phases.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload VRT bench summary
+        uses: actions/upload-artifact@v6
+        with:
+          name: vrt-bench-summary
+          path: vrt-bench/*
+          if-no-files-found: error
+
   playwright-paint-vrt:
     runs-on: ubuntu-latest
 
@@ -642,6 +734,8 @@ jobs:
       - wpt-webdriver-tests
       - wpt-compat-summary
       - playwright-bidi-tests
+      - flaker-config
+      - vrt-bench
       - playwright-paint-vrt
       - playwright-wpt-vrt
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,4 @@ tmp/**/*.json
 tmp/wpt-modules/
 tmp/ws-video-test.html
 .claude/
-.metrici/
+.flaker/

--- a/flaker.star
+++ b/flaker.star
@@ -1,0 +1,138 @@
+workflow(name="crater-tests", max_parallel=1)
+
+# Nodes represent coarse execution groups for affected-test scheduling.
+node(id="layout", depends_on=[])
+node(id="browser", depends_on=[])
+node(id="fullstack", depends_on=["layout", "browser"])
+
+# Paint / VRT suites
+task(
+  id="paint-vrt",
+  node="layout",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/paint-vrt.test.ts"],
+  srcs=[
+    "src/layout/**",
+    "src/paint/**",
+    "src/renderer/**",
+    "src/css/**",
+    "src/style/**",
+    "src/types/**",
+    "tests/helpers/**",
+    "real-world/**",
+  ],
+  trigger="auto",
+)
+
+task(
+  id="paint-vrt-levels",
+  node="layout",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/paint-vrt-levels.test.ts"],
+  srcs=[
+    "src/layout/**",
+    "src/paint/**",
+    "src/renderer/**",
+    "src/css/**",
+    "src/style/**",
+    "src/types/**",
+    "tests/helpers/**",
+  ],
+  needs=["paint-vrt"],
+  trigger="auto",
+)
+
+task(
+  id="wpt-vrt",
+  node="layout",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/wpt-vrt.test.ts"],
+  srcs=[
+    "src/layout/**",
+    "src/paint/**",
+    "src/renderer/**",
+    "src/css/**",
+    "src/style/**",
+    "src/types/**",
+    "tests/helpers/**",
+    "wpt-tests/**",
+  ],
+  needs=["paint-vrt"],
+  trigger="auto",
+)
+
+# Browser protocol and adapter suites
+task(
+  id="playwright-adapter",
+  node="browser",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/playwright-adapter.test.ts"],
+  srcs=["browser/**", "src/bidi/**", "src/dom/**", "src/js/**", "src/renderer/**"],
+  trigger="auto",
+)
+
+task(
+  id="bidi-e2e",
+  node="browser",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/bidi-e2e.test.ts"],
+  srcs=["browser/**", "src/bidi/**"],
+  trigger="auto",
+)
+
+task(
+  id="preact-compat",
+  node="browser",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/preact-compat.test.ts"],
+  srcs=["browser/**", "src/bidi/**", "src/dom/**", "src/js/**"],
+  needs=["playwright-adapter"],
+  trigger="auto",
+)
+
+# Full-stack scenarios split by file or describe block.
+task(
+  id="website-loading",
+  node="fullstack",
+  cmd=[
+    "pnpm",
+    "exec",
+    "playwright",
+    "test",
+    "tests/website-loading.test.ts",
+    "--grep",
+    "Website Loading Tests",
+  ],
+  srcs=["src/layout/**", "src/renderer/**", "src/css/**", "browser/**", "tests/helpers/**"],
+  needs=["paint-vrt", "playwright-adapter"],
+  trigger="auto",
+)
+
+task(
+  id="script-execution-edge-cases",
+  node="fullstack",
+  cmd=[
+    "pnpm",
+    "exec",
+    "playwright",
+    "test",
+    "tests/website-loading.test.ts",
+    "--grep",
+    "Script Execution Edge Cases",
+  ],
+  srcs=["browser/**", "src/bidi/**", "src/dom/**", "src/js/**"],
+  needs=["playwright-adapter"],
+  trigger="auto",
+)
+
+task(
+  id="browser-user-scenarios",
+  node="fullstack",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/browser-user-scenarios.test.ts"],
+  srcs=["src/layout/**", "src/renderer/**", "src/css/**", "browser/**", "tests/helpers/**"],
+  needs=["paint-vrt", "playwright-adapter"],
+  trigger="auto",
+)
+
+task(
+  id="scroll-issue",
+  node="fullstack",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/scroll-issue.test.ts"],
+  srcs=["src/layout/**", "src/renderer/**", "src/css/**", "browser/**"],
+  needs=["paint-vrt", "playwright-adapter"],
+  trigger="auto",
+)

--- a/flaker.toml
+++ b/flaker.toml
@@ -3,18 +3,18 @@ owner = "mizchi"
 name = "crater"
 
 [storage]
-path = ".metrici/data.duckdb"
+path = ".flaker/data.duckdb"
 
 [adapter]
 type = "playwright"
 
 [runner]
-default = "direct"
+type = "playwright"
 command = "pnpm exec playwright test"
 
 [affected]
-resolver = "simple"
-config = ""
+resolver = "bitflow"
+config = "flaker.star"
 
 [quarantine]
 auto = true

--- a/justfile
+++ b/justfile
@@ -255,6 +255,40 @@ wpt-vrt-baseline-update:
 bench-playwright:
     pnpm bench:playwright
 
+# Run VRT API end-to-end benchmarks
+bench-vrt:
+    npx tsx scripts/vrt-bench.ts --group api
+
+# Run VRT phase benchmarks (parse / node+layout / paint / json / diff)
+bench-vrt-phases:
+    npx tsx scripts/vrt-bench.ts --group phases
+
+# Run all VRT API benchmarks
+bench-vrt-all:
+    npx tsx scripts/vrt-bench.ts --group all
+
+# List resolved VRT benchmark indices
+bench-vrt-list group="all":
+    npx tsx scripts/vrt-bench.ts --group {{group}} --list
+
+# Run VRT benchmarks and write parsed reports
+bench-vrt-report group output_dir="vrt-bench":
+    mkdir -p {{output_dir}}
+    npx tsx scripts/vrt-bench.ts --group {{group}} --json {{output_dir}}/{{group}}.json --markdown {{output_dir}}/{{group}}.md | tee {{output_dir}}/{{group}}.log
+
+# List flaker-managed Playwright tasks
+flaker-list:
+    npx tsx scripts/flaker-config.ts --list
+
+# Validate flaker config against tracked Playwright specs
+flaker-check:
+    npx tsx scripts/flaker-config.ts --check
+
+# Render flaker config summary for CI or local inspection
+flaker-report output_dir=".flaker/report":
+    mkdir -p {{output_dir}}
+    npx tsx scripts/flaker-config.ts --check --json {{output_dir}}/summary.json --markdown {{output_dir}}/summary.md | tee {{output_dir}}/summary.log
+
 # Capture a live site into real-world/ (gitignored)
 capture-realworld *args:
     pnpm capture:realworld -- {{args}}

--- a/scripts/flaker-config.test.ts
+++ b/scripts/flaker-config.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  discoverPlaywrightSpecs,
+  parseFlakerStar,
+  summarizeFlakerConfig,
+} from "./flaker-config.ts";
+
+const tmpDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crater-flaker-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function writeFile(root: string, relativePath: string, content = ""): void {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("parseFlakerStar", () => {
+  it("parses workflow, nodes, and task commands with grep filters", () => {
+    const config = parseFlakerStar(`
+workflow(name="example", max_parallel=2)
+
+node(id="browser", depends_on=[])
+
+task(
+  id="website-loading",
+  node="browser",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/website-loading.test.ts", "--grep", "Website Loading Tests"],
+  srcs=["src/bidi/**"],
+  trigger="auto",
+)
+`);
+
+    expect(config.workflow?.name).toBe("example");
+    expect(config.workflow?.maxParallel).toBe(2);
+    expect(config.nodes).toEqual([
+      { id: "browser", dependsOn: [] },
+    ]);
+    expect(config.tasks).toHaveLength(1);
+    expect(config.tasks[0]?.cmd).toEqual([
+      "pnpm",
+      "exec",
+      "playwright",
+      "test",
+      "tests/website-loading.test.ts",
+      "--grep",
+      "Website Loading Tests",
+    ]);
+  });
+});
+
+describe("summarizeFlakerConfig", () => {
+  it("reports duplicate unfiltered ownership and unmanaged specs", () => {
+    const root = makeTempDir();
+    writeFile(root, "tests/a.test.ts");
+    writeFile(root, "tests/b.test.ts");
+    writeFile(root, "tests/c.test.ts");
+
+    const config = parseFlakerStar(`
+workflow(name="example", max_parallel=1)
+node(id="browser", depends_on=[])
+task(
+  id="task-a",
+  node="browser",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/a.test.ts"],
+  srcs=["src/**"],
+  trigger="auto",
+)
+task(
+  id="task-b",
+  node="browser",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/a.test.ts"],
+  srcs=["src/**"],
+  trigger="auto",
+)
+task(
+  id="task-c",
+  node="browser",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/b.test.ts"],
+  srcs=["src/**"],
+  trigger="auto",
+)
+`);
+
+    const summary = summarizeFlakerConfig(config, { cwd: root });
+
+    expect(summary.errors.map((issue) => issue.code)).toContain("duplicate-spec-ownership");
+    expect(summary.unmanagedSpecs).toEqual(["tests/c.test.ts"]);
+  });
+
+  it("allows shared specs when commands are split by grep", () => {
+    const root = makeTempDir();
+    writeFile(root, "tests/website-loading.test.ts");
+
+    const config = parseFlakerStar(`
+workflow(name="example", max_parallel=1)
+node(id="browser", depends_on=[])
+task(
+  id="website-loading",
+  node="browser",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/website-loading.test.ts", "--grep", "Website Loading Tests"],
+  srcs=["src/**"],
+  trigger="auto",
+)
+task(
+  id="script-edge-cases",
+  node="browser",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/website-loading.test.ts", "--grep", "Script Execution Edge Cases"],
+  srcs=["src/**"],
+  trigger="auto",
+)
+`);
+
+    const summary = summarizeFlakerConfig(config, { cwd: root });
+
+    expect(summary.errors).toEqual([]);
+    expect(summary.unmanagedSpecs).toEqual([]);
+  });
+});
+
+describe("discoverPlaywrightSpecs", () => {
+  it("ignores benchmark specs by default", () => {
+    const root = makeTempDir();
+    writeFile(root, "tests/alpha.test.ts");
+    writeFile(root, "tests/playwright-benchmark.test.ts");
+
+    expect(discoverPlaywrightSpecs(root)).toEqual(["tests/alpha.test.ts"]);
+  });
+});
+
+describe("repo flaker config", () => {
+  it("covers all managed Playwright specs without validation errors", () => {
+    const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+    const star = fs.readFileSync(path.join(repoRoot, "flaker.star"), "utf8");
+    const config = parseFlakerStar(star);
+    const summary = summarizeFlakerConfig(config, { cwd: repoRoot });
+
+    expect(summary.errors).toEqual([]);
+    expect(summary.unmanagedSpecs).toEqual([]);
+  });
+});

--- a/scripts/flaker-config.ts
+++ b/scripts/flaker-config.ts
@@ -1,0 +1,811 @@
+#!/usr/bin/env npx tsx
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_CONFIG_PATH = "flaker.star";
+const DEFAULT_TESTS_DIR = "tests";
+const DEFAULT_EXCLUDED_SPECS = ["tests/playwright-benchmark.test.ts"];
+
+type FlakerScalar = string | number;
+type FlakerValue = FlakerScalar | FlakerValue[];
+
+interface CliOptions {
+  configPath: string;
+  testsDir: string;
+  jsonOutput?: string;
+  markdownOutput?: string;
+  check: boolean;
+  listOnly: boolean;
+}
+
+interface RawCall {
+  name: string;
+  argsSource: string;
+}
+
+interface WorkflowArgs {
+  name: string;
+  max_parallel?: number;
+}
+
+interface NodeArgs {
+  id: string;
+  depends_on?: string[];
+}
+
+interface TaskArgs {
+  id: string;
+  node: string;
+  cmd: string[];
+  srcs?: string[];
+  needs?: string[];
+  trigger?: string;
+}
+
+export interface FlakerWorkflow {
+  name: string;
+  maxParallel: number;
+}
+
+export interface FlakerNode {
+  id: string;
+  dependsOn: string[];
+}
+
+export interface FlakerTask {
+  id: string;
+  node: string;
+  cmd: string[];
+  srcs: string[];
+  needs: string[];
+  trigger?: string;
+}
+
+export interface FlakerConfig {
+  workflow?: FlakerWorkflow;
+  nodes: FlakerNode[];
+  tasks: FlakerTask[];
+}
+
+export interface FlakerIssue {
+  severity: "error" | "warning";
+  code: string;
+  message: string;
+  taskId?: string;
+  spec?: string;
+}
+
+export interface FlakerTaskSummary {
+  id: string;
+  node: string;
+  specs: string[];
+  grep?: string;
+  grepInvert?: string;
+  trigger?: string;
+  needs: string[];
+  srcCount: number;
+  command: string[];
+}
+
+export interface FlakerSummary {
+  workflow?: FlakerWorkflow;
+  nodeCount: number;
+  taskCount: number;
+  managedSpecs: string[];
+  unmanagedSpecs: string[];
+  tasks: FlakerTaskSummary[];
+  errors: FlakerIssue[];
+  warnings: FlakerIssue[];
+  generatedAt: string;
+}
+
+interface SummarizeOptions {
+  cwd: string;
+  testsDir?: string;
+  excludedSpecs?: string[];
+}
+
+function usage(): string {
+  return [
+    "Flaker config summary",
+    "",
+    "Usage:",
+    "  npx tsx scripts/flaker-config.ts [options]",
+    "",
+    "Options:",
+    `  --config <file>      flaker.star path (default: ${DEFAULT_CONFIG_PATH})`,
+    `  --tests-dir <dir>    Playwright tests directory (default: ${DEFAULT_TESTS_DIR})`,
+    "  --json <file>        Write JSON summary",
+    "  --markdown <file>    Write Markdown summary",
+    "  --check              Exit non-zero when validation errors exist",
+    "  --list               Print managed task ids and resolved specs",
+    "  --help               Show this help",
+  ].join("\n");
+}
+
+function parseCliArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    configPath: DEFAULT_CONFIG_PATH,
+    testsDir: DEFAULT_TESTS_DIR,
+    check: false,
+    listOnly: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--config") {
+      options.configPath = args[++i] ?? "";
+      continue;
+    }
+    if (arg === "--tests-dir") {
+      options.testsDir = args[++i] ?? "";
+      continue;
+    }
+    if (arg === "--json") {
+      options.jsonOutput = args[++i];
+      continue;
+    }
+    if (arg === "--markdown") {
+      options.markdownOutput = args[++i];
+      continue;
+    }
+    if (arg === "--check") {
+      options.check = true;
+      continue;
+    }
+    if (arg === "--list") {
+      options.listOnly = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.configPath) {
+    throw new Error("--config requires a file path");
+  }
+  if (!options.testsDir) {
+    throw new Error("--tests-dir requires a directory path");
+  }
+
+  return options;
+}
+
+function normalizeRepoPath(root: string, target: string): string {
+  return path.relative(root, path.resolve(root, target)).split(path.sep).join("/");
+}
+
+function escapeMarkdownCell(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+function writeOutput(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function splitTopLevel(source: string, separator: string): string[] {
+  const items: string[] = [];
+  let current = "";
+  let depth = 0;
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i]!;
+    if (quote) {
+      current += ch;
+      if (ch === "\\") {
+        const next = source[i + 1];
+        if (next !== undefined) {
+          current += next;
+          i++;
+        }
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === "#") {
+      while (i < source.length && source[i] !== "\n") {
+        i++;
+      }
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") {
+      depth++;
+      current += ch;
+      continue;
+    }
+    if (ch === ")" || ch === "]" || ch === "}") {
+      depth--;
+      current += ch;
+      continue;
+    }
+    if (depth === 0 && ch === separator) {
+      const trimmed = current.trim();
+      if (trimmed.length > 0) {
+        items.push(trimmed);
+      }
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+
+  const trailing = current.trim();
+  if (trailing.length > 0) {
+    items.push(trailing);
+  }
+
+  return items;
+}
+
+function findTopLevelAssignment(source: string): number {
+  let depth = 0;
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i]!;
+    if (quote) {
+      if (ch === "\\") {
+        i++;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") {
+      depth++;
+      continue;
+    }
+    if (ch === ")" || ch === "]" || ch === "}") {
+      depth--;
+      continue;
+    }
+    if (depth === 0 && ch === "=") {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+function parseString(source: string): string {
+  if (source.length < 2) {
+    throw new Error(`Invalid string literal: ${source}`);
+  }
+  const quote = source[0];
+  const body = source.slice(1, -1);
+  if (quote === '"') {
+    return JSON.parse(source);
+  }
+  return body.replace(/\\'/g, "'").replace(/\\\\/g, "\\");
+}
+
+function parseValue(source: string): FlakerValue {
+  const trimmed = source.trim();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const inner = trimmed.slice(1, -1);
+    if (inner.trim().length === 0) {
+      return [];
+    }
+    return splitTopLevel(inner, ",").map(parseValue);
+  }
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return parseString(trimmed);
+  }
+  if (/^-?\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10);
+  }
+  return trimmed;
+}
+
+function parseKeywordArgs(source: string): Record<string, FlakerValue> {
+  const fields: Record<string, FlakerValue> = {};
+  for (const entry of splitTopLevel(source, ",")) {
+    const eqIndex = findTopLevelAssignment(entry);
+    if (eqIndex < 0) {
+      throw new Error(`Unsupported positional argument: ${entry}`);
+    }
+    const key = entry.slice(0, eqIndex).trim();
+    const value = entry.slice(eqIndex + 1).trim();
+    fields[key] = parseValue(value);
+  }
+  return fields;
+}
+
+function extractCalls(source: string): RawCall[] {
+  const calls: RawCall[] = [];
+
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i]!;
+    if (/\s/.test(ch)) {
+      continue;
+    }
+    if (ch === "#") {
+      while (i < source.length && source[i] !== "\n") {
+        i++;
+      }
+      continue;
+    }
+    if (!/[A-Za-z_]/.test(ch)) {
+      continue;
+    }
+
+    let j = i + 1;
+    while (j < source.length && /[A-Za-z0-9_]/.test(source[j]!)) {
+      j++;
+    }
+    const name = source.slice(i, j);
+    while (j < source.length && /\s/.test(source[j]!)) {
+      j++;
+    }
+    if (source[j] !== "(") {
+      i = j;
+      continue;
+    }
+
+    let depth = 1;
+    let quote: '"' | "'" | null = null;
+    let k = j + 1;
+    while (k < source.length && depth > 0) {
+      const current = source[k]!;
+      if (quote) {
+        if (current === "\\") {
+          k += 2;
+          continue;
+        }
+        if (current === quote) {
+          quote = null;
+        }
+        k++;
+        continue;
+      }
+      if (current === '"' || current === "'") {
+        quote = current;
+        k++;
+        continue;
+      }
+      if (current === "#") {
+        while (k < source.length && source[k] !== "\n") {
+          k++;
+        }
+        continue;
+      }
+      if (current === "(" || current === "[" || current === "{") {
+        depth++;
+      } else if (current === ")" || current === "]" || current === "}") {
+        depth--;
+      }
+      k++;
+    }
+
+    if (depth !== 0) {
+      throw new Error(`Unterminated call: ${name}`);
+    }
+
+    calls.push({
+      name,
+      argsSource: source.slice(j + 1, k - 1),
+    });
+    i = k - 1;
+  }
+
+  return calls;
+}
+
+function asString(value: FlakerValue | undefined, field: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Expected string for ${field}`);
+  }
+  return value;
+}
+
+function asNumber(value: FlakerValue | undefined, field: string, fallback = 0): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Expected number for ${field}`);
+  }
+  return value;
+}
+
+function asStringArray(value: FlakerValue | undefined, field: string): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected list for ${field}`);
+  }
+  return value.map((item) => {
+    if (typeof item !== "string") {
+      throw new Error(`Expected string list for ${field}`);
+    }
+    return item;
+  });
+}
+
+export function parseFlakerStar(source: string): FlakerConfig {
+  const config: FlakerConfig = {
+    nodes: [],
+    tasks: [],
+  };
+
+  for (const call of extractCalls(source)) {
+    const args = parseKeywordArgs(call.argsSource);
+    if (call.name === "workflow") {
+      const workflowArgs = args as unknown as WorkflowArgs;
+      config.workflow = {
+        name: asString(workflowArgs.name as unknown as FlakerValue, "workflow.name"),
+        maxParallel: asNumber(
+          workflowArgs.max_parallel as unknown as FlakerValue,
+          "workflow.max_parallel",
+          1,
+        ),
+      };
+      continue;
+    }
+    if (call.name === "node") {
+      const nodeArgs = args as unknown as NodeArgs;
+      config.nodes.push({
+        id: asString(nodeArgs.id as unknown as FlakerValue, "node.id"),
+        dependsOn: asStringArray(
+          nodeArgs.depends_on as unknown as FlakerValue,
+          "node.depends_on",
+        ),
+      });
+      continue;
+    }
+    if (call.name === "task") {
+      const taskArgs = args as unknown as TaskArgs;
+      config.tasks.push({
+        id: asString(taskArgs.id as unknown as FlakerValue, "task.id"),
+        node: asString(taskArgs.node as unknown as FlakerValue, "task.node"),
+        cmd: asStringArray(taskArgs.cmd as unknown as FlakerValue, "task.cmd"),
+        srcs: asStringArray(taskArgs.srcs as unknown as FlakerValue, "task.srcs"),
+        needs: asStringArray(taskArgs.needs as unknown as FlakerValue, "task.needs"),
+        trigger: typeof taskArgs.trigger === "string" ? taskArgs.trigger : undefined,
+      });
+    }
+  }
+
+  return config;
+}
+
+export function discoverPlaywrightSpecs(
+  rootDir: string,
+  testsDir = DEFAULT_TESTS_DIR,
+  excludedSpecs = DEFAULT_EXCLUDED_SPECS,
+): string[] {
+  const baseDir = path.join(rootDir, testsDir);
+  if (!fs.existsSync(baseDir)) {
+    return [];
+  }
+
+  const excluded = new Set(excludedSpecs);
+  const entries = fs.readdirSync(baseDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".test.ts"))
+    .map((entry) => `${testsDir}/${entry.name}`)
+    .filter((spec) => !excluded.has(spec))
+    .sort();
+}
+
+function findOptionValue(command: string[], optionName: string): string | undefined {
+  const index = command.findIndex((part) => part === optionName);
+  if (index < 0) {
+    return undefined;
+  }
+  return command[index + 1];
+}
+
+function extractSpecs(command: string[]): string[] {
+  return command.filter((part) => part.endsWith(".test.ts"));
+}
+
+function isFilteredTask(task: FlakerTaskSummary): boolean {
+  return Boolean(task.grep || task.grepInvert);
+}
+
+function createIssue(issue: FlakerIssue): FlakerIssue {
+  return issue;
+}
+
+export function summarizeFlakerConfig(
+  config: FlakerConfig,
+  options: SummarizeOptions,
+): FlakerSummary {
+  const cwd = options.cwd;
+  const testsDir = options.testsDir ?? DEFAULT_TESTS_DIR;
+  const excludedSpecs = options.excludedSpecs ?? DEFAULT_EXCLUDED_SPECS;
+
+  const errors: FlakerIssue[] = [];
+  const warnings: FlakerIssue[] = [];
+  const nodeIds = new Set<string>();
+  const taskIds = new Set<string>();
+
+  for (const node of config.nodes) {
+    if (nodeIds.has(node.id)) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "duplicate-node-id",
+        message: `Duplicate node id: ${node.id}`,
+      }));
+    }
+    nodeIds.add(node.id);
+  }
+
+  for (const node of config.nodes) {
+    for (const dependency of node.dependsOn) {
+      if (!nodeIds.has(dependency)) {
+        errors.push(createIssue({
+          severity: "error",
+          code: "unknown-node-dependency",
+          message: `Node ${node.id} depends on missing node ${dependency}`,
+        }));
+      }
+    }
+  }
+
+  const tasks: FlakerTaskSummary[] = config.tasks.map((task) => {
+    if (taskIds.has(task.id)) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "duplicate-task-id",
+        message: `Duplicate task id: ${task.id}`,
+        taskId: task.id,
+      }));
+    }
+    taskIds.add(task.id);
+
+    if (!nodeIds.has(task.node)) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "unknown-task-node",
+        message: `Task ${task.id} references missing node ${task.node}`,
+        taskId: task.id,
+      }));
+    }
+
+    return {
+      id: task.id,
+      node: task.node,
+      specs: extractSpecs(task.cmd).map((spec) => normalizeRepoPath(cwd, spec)).sort(),
+      grep: findOptionValue(task.cmd, "--grep"),
+      grepInvert: findOptionValue(task.cmd, "--grep-invert"),
+      trigger: task.trigger,
+      needs: [...task.needs].sort(),
+      srcCount: task.srcs.length,
+      command: [...task.cmd],
+    };
+  });
+
+  for (const task of config.tasks) {
+    for (const dependency of task.needs) {
+      if (!taskIds.has(dependency)) {
+        errors.push(createIssue({
+          severity: "error",
+          code: "unknown-task-dependency",
+          message: `Task ${task.id} depends on missing task ${dependency}`,
+          taskId: task.id,
+        }));
+      }
+    }
+  }
+
+  for (const task of tasks) {
+    if (task.specs.length === 0) {
+      warnings.push(createIssue({
+        severity: "warning",
+        code: "no-spec-files",
+        message: `Task ${task.id} does not reference a Playwright spec file`,
+        taskId: task.id,
+      }));
+      continue;
+    }
+    for (const spec of task.specs) {
+      if (!fs.existsSync(path.join(cwd, spec))) {
+        errors.push(createIssue({
+          severity: "error",
+          code: "missing-spec-file",
+          message: `Task ${task.id} references missing spec ${spec}`,
+          taskId: task.id,
+          spec,
+        }));
+      }
+    }
+  }
+
+  const specOwners = new Map<string, FlakerTaskSummary[]>();
+  for (const task of tasks) {
+    for (const spec of task.specs) {
+      const owners = specOwners.get(spec) ?? [];
+      owners.push(task);
+      specOwners.set(spec, owners);
+    }
+  }
+
+  for (const [spec, owners] of specOwners.entries()) {
+    if (owners.length < 2) {
+      continue;
+    }
+    const filteredOwners = owners.filter(isFilteredTask);
+    if (filteredOwners.length !== owners.length) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "duplicate-spec-ownership",
+        message: `Spec ${spec} is owned by multiple tasks without explicit grep partition: ${owners.map((owner) => owner.id).join(", ")}`,
+        spec,
+      }));
+      continue;
+    }
+    const selectorKeys = new Set(
+      owners.map((owner) => `${owner.grep ?? ""}::${owner.grepInvert ?? ""}`),
+    );
+    if (selectorKeys.size !== owners.length) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "duplicate-spec-selector",
+        message: `Spec ${spec} has duplicate filtered ownership: ${owners.map((owner) => owner.id).join(", ")}`,
+        spec,
+      }));
+    }
+  }
+
+  const discoveredSpecs = discoverPlaywrightSpecs(cwd, testsDir, excludedSpecs);
+  const managedSpecs = [...specOwners.keys()].sort();
+  const managedSet = new Set(managedSpecs);
+  const unmanagedSpecs = discoveredSpecs.filter((spec) => !managedSet.has(spec));
+
+  for (const spec of unmanagedSpecs) {
+    warnings.push(createIssue({
+      severity: "warning",
+      code: "unmanaged-spec",
+      message: `Playwright spec is not managed by flaker: ${spec}`,
+      spec,
+    }));
+  }
+
+  return {
+    workflow: config.workflow,
+    nodeCount: config.nodes.length,
+    taskCount: config.tasks.length,
+    managedSpecs,
+    unmanagedSpecs,
+    tasks: tasks.sort((a, b) => a.id.localeCompare(b.id)),
+    errors,
+    warnings,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+export function renderMarkdownSummary(summary: FlakerSummary): string {
+  const lines: string[] = [];
+
+  lines.push("# Flaker Config Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Workflow | ${escapeMarkdownCell(summary.workflow?.name ?? "unknown")} |`);
+  lines.push(`| Nodes | ${summary.nodeCount} |`);
+  lines.push(`| Tasks | ${summary.taskCount} |`);
+  lines.push(`| Managed specs | ${summary.managedSpecs.length} |`);
+  lines.push(`| Unmanaged specs | ${summary.unmanagedSpecs.length} |`);
+  lines.push(`| Errors | ${summary.errors.length} |`);
+  lines.push(`| Warnings | ${summary.warnings.length} |`);
+
+  lines.push("");
+  lines.push("## Tasks");
+  lines.push("");
+  lines.push("| Task | Node | Specs | Filter | Needs | Trigger | Srcs |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- |");
+  for (const task of summary.tasks) {
+    lines.push(
+      `| ${escapeMarkdownCell(task.id)} | ${escapeMarkdownCell(task.node)} | ${escapeMarkdownCell(task.specs.join("<br>"))} | ${escapeMarkdownCell(task.grep ?? task.grepInvert ?? "")} | ${escapeMarkdownCell(task.needs.join(", "))} | ${escapeMarkdownCell(task.trigger ?? "")} | ${task.srcCount} |`,
+    );
+  }
+
+  if (summary.errors.length > 0) {
+    lines.push("");
+    lines.push("## Errors");
+    lines.push("");
+    lines.push("| Code | Message |");
+    lines.push("| --- | --- |");
+    for (const issue of summary.errors) {
+      lines.push(`| ${escapeMarkdownCell(issue.code)} | ${escapeMarkdownCell(issue.message)} |`);
+    }
+  }
+
+  if (summary.warnings.length > 0) {
+    lines.push("");
+    lines.push("## Warnings");
+    lines.push("");
+    lines.push("| Code | Message |");
+    lines.push("| --- | --- |");
+    for (const issue of summary.warnings) {
+      lines.push(`| ${escapeMarkdownCell(issue.code)} | ${escapeMarkdownCell(issue.message)} |`);
+    }
+  }
+
+  if (summary.unmanagedSpecs.length > 0) {
+    lines.push("");
+    lines.push("## Unmanaged Specs");
+    lines.push("");
+    for (const spec of summary.unmanagedSpecs) {
+      lines.push(`- ${spec}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function printTaskList(summary: FlakerSummary): void {
+  for (const task of summary.tasks) {
+    const filter = task.grep ?? task.grepInvert;
+    const suffix = filter ? ` [grep=${filter}]` : "";
+    console.log(`${task.id}\t${task.specs.join(", ")}${suffix}`);
+  }
+}
+
+function isMainModule(): boolean {
+  if (!import.meta.url.startsWith("file:")) {
+    return false;
+  }
+  return process.argv[1] === fileURLToPath(import.meta.url);
+}
+
+if (isMainModule()) {
+  try {
+    const options = parseCliArgs(process.argv.slice(2));
+    const configSource = fs.readFileSync(path.resolve(process.cwd(), options.configPath), "utf8");
+    const config = parseFlakerStar(configSource);
+    const summary = summarizeFlakerConfig(config, {
+      cwd: process.cwd(),
+      testsDir: options.testsDir,
+    });
+
+    if (options.listOnly) {
+      printTaskList(summary);
+    } else {
+      const markdown = renderMarkdownSummary(summary);
+      process.stdout.write(markdown);
+      if (options.markdownOutput) {
+        writeOutput(options.markdownOutput, markdown);
+      }
+    }
+
+    if (options.jsonOutput) {
+      writeOutput(options.jsonOutput, `${JSON.stringify(summary, null, 2)}\n`);
+    }
+
+    if (options.check && summary.errors.length > 0) {
+      process.exit(1);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  }
+}

--- a/scripts/vrt-bench.test.ts
+++ b/scripts/vrt-bench.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseBenchRunOutput,
+  renderMarkdownSummary,
+  summarizeBenchRun,
+  type VrtBenchGroup,
+} from "./vrt-bench.ts";
+
+function sampleOutput(): string {
+  return `
+# VRT bench group: api
+0\tbench_vrt_render_paint_tree_dashboard
+1\tbench_vrt_render_paint_tree_json_component
+----- BEGIN MOON TEST RESULT -----
+{"package":"mizchi/crater/benchmarks","filename":"vrt_api_bench.mbt","index":"0","test_name":"bench_vrt_render_paint_tree_dashboard","message":"@BATCH_BENCH { \\"summaries\\": [{\\"name\\":\\"vrt_render_paint_tree_dashboard\\",\\"sum\\":1000,\\"min\\":90,\\"max\\":110,\\"mean\\":100,\\"median\\":98,\\"variance\\":4,\\"std_dev\\":2,\\"std_dev_pct\\":2,\\"median_abs_dev\\":1,\\"median_abs_dev_pct\\":1,\\"quartiles\\":[95,98,104],\\"iqr\\":9,\\"batch_size\\":64,\\"runs\\":10}] }"}
+----- END MOON TEST RESULT -----
+----- BEGIN MOON TEST RESULT -----
+{"package":"mizchi/crater/benchmarks","filename":"vrt_api_bench.mbt","index":"1","test_name":"bench_vrt_render_paint_tree_json_component","message":"@BATCH_BENCH { \\"summaries\\": [{\\"name\\":\\"vrt_render_paint_tree_json_component\\",\\"sum\\":550,\\"min\\":50,\\"max\\":60,\\"mean\\":55,\\"median\\":54,\\"variance\\":2,\\"std_dev\\":1.4,\\"std_dev_pct\\":2.5,\\"median_abs_dev\\":1,\\"median_abs_dev_pct\\":1.8,\\"quartiles\\":[53,54,56],\\"iqr\\":3,\\"batch_size\\":128,\\"runs\\":10}] }"}
+----- END MOON TEST RESULT -----
+`;
+}
+
+describe("parseBenchRunOutput", () => {
+  it("extracts group and rows from moon bench output", () => {
+    const parsed = parseBenchRunOutput(sampleOutput(), "api");
+
+    expect(parsed.group).toBe<VrtBenchGroup>("api");
+    expect(parsed.rows).toHaveLength(2);
+    expect(parsed.rows[0]?.testName).toBe("bench_vrt_render_paint_tree_dashboard");
+    expect(parsed.rows[0]?.summary.name).toBe("vrt_render_paint_tree_dashboard");
+    expect(parsed.rows[1]?.summary.batch_size).toBe(128);
+  });
+});
+
+describe("summarizeBenchRun", () => {
+  it("computes totals and highlights the slowest benchmark", () => {
+    const parsed = parseBenchRunOutput(sampleOutput(), "api");
+    const summary = summarizeBenchRun(parsed);
+
+    expect(summary.totalRows).toBe(2);
+    expect(summary.slowest?.testName).toBe("bench_vrt_render_paint_tree_dashboard");
+    expect(summary.meanTotal).toBe(155);
+  });
+});
+
+describe("renderMarkdownSummary", () => {
+  it("renders markdown table with headline metrics", () => {
+    const parsed = parseBenchRunOutput(sampleOutput(), "api");
+    const summary = summarizeBenchRun(parsed);
+    const markdown = renderMarkdownSummary(summary);
+
+    expect(markdown).toContain("# VRT Bench Summary (api)");
+    expect(markdown).toContain("| Test | Benchmark | Mean | Median | Min | Max | Batch | Runs |");
+    expect(markdown).toContain("| bench_vrt_render_paint_tree_dashboard | vrt_render_paint_tree_dashboard | 100.00 | 98.00 | 90.00 | 110.00 | 64 | 10 |");
+    expect(markdown).toContain("Slowest benchmark");
+  });
+});

--- a/scripts/vrt-bench.ts
+++ b/scripts/vrt-bench.ts
@@ -1,0 +1,439 @@
+#!/usr/bin/env npx tsx
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+type BenchGroup = "api" | "phases" | "all";
+export type VrtBenchGroup = BenchGroup;
+
+interface CliOptions {
+  group: BenchGroup;
+  listOnly: boolean;
+  jsonOutput?: string;
+  markdownOutput?: string;
+}
+
+interface BenchEntry {
+  index: number;
+  testName: string;
+}
+
+interface BenchRange {
+  start: number;
+  end: number;
+}
+
+export interface VrtBenchStatSummary {
+  name: string;
+  sum: number;
+  min: number;
+  max: number;
+  mean: number;
+  median: number;
+  variance: number;
+  std_dev: number;
+  std_dev_pct: number;
+  median_abs_dev: number;
+  median_abs_dev_pct: number;
+  quartiles: number[];
+  iqr: number;
+  batch_size: number;
+  runs: number;
+}
+
+export interface VrtBenchRow {
+  index: number;
+  testName: string;
+  summary: VrtBenchStatSummary;
+}
+
+export interface VrtBenchParsedRun {
+  group: BenchGroup;
+  rows: VrtBenchRow[];
+  rawOutput: string;
+}
+
+export interface VrtBenchRunSummary {
+  group: BenchGroup;
+  rows: VrtBenchRow[];
+  totalRows: number;
+  meanTotal: number;
+  medianTotal: number;
+  slowest?: VrtBenchRow;
+  fastest?: VrtBenchRow;
+  generatedAt: string;
+}
+
+const BENCH_PACKAGE = "benchmarks";
+const BENCH_SOURCE_FILE = "src/benchmarks/vrt_api_bench.mbt";
+const DRIVER_FILE = "_build/js/release/bench/benchmarks/__generated_driver_for_internal_test.mbt";
+const INTERNAL_RUNNER = "_build/js/release/bench/benchmarks/benchmarks.internal_test.js";
+const GENERATED_FILE_KEY = "vrt_api_bench.mbt";
+
+function usage(): string {
+  return [
+    "VRT Bench Runner",
+    "",
+    "Usage:",
+    "  npx tsx scripts/vrt-bench.ts [options]",
+    "",
+    "Options:",
+    "  --group <api|phases|all>   Select VRT bench group (default: api)",
+    "  --list                     List resolved bench indices without executing",
+    "  --json <file>              Write parsed benchmark summary JSON",
+    "  --markdown <file>          Write parsed benchmark summary Markdown",
+    "  --help                     Show this help",
+  ].join("\n");
+}
+
+function parseCliArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    group: "api",
+    listOnly: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--group") {
+      const next = args[++i];
+      if (next !== "api" && next !== "phases" && next !== "all") {
+        throw new Error(`Unsupported group: ${next ?? ""}`);
+      }
+      options.group = next;
+      continue;
+    }
+    if (arg === "--list") {
+      options.listOnly = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.jsonOutput = args[++i];
+      continue;
+    }
+    if (arg === "--markdown") {
+      options.markdownOutput = args[++i];
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function runOrThrow(command: string, args: string[]): void {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function buildBenchArtifacts(): void {
+  runOrThrow("moon", [
+    "bench",
+    "-p",
+    BENCH_PACKAGE,
+    "-f",
+    BENCH_SOURCE_FILE,
+    "--build-only",
+    "--no-render",
+  ]);
+}
+
+function readBenchEntries(): BenchEntry[] {
+  const driverPath = path.join(process.cwd(), DRIVER_FILE);
+  const text = fs.readFileSync(driverPath, "utf8");
+  const lines = text.split("\n");
+  const start = lines.findIndex((line) =>
+    line.includes(`"${GENERATED_FILE_KEY}": {`)
+  );
+  if (start < 0) {
+    throw new Error(`Failed to locate ${GENERATED_FILE_KEY} in ${DRIVER_FILE}`);
+  }
+
+  const entries: BenchEntry[] = [];
+  const entryPattern = /^\s*(\d+): .*?\["([^"]+)"\]\),?$/;
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith("  },") || line.trim() === "}") {
+      break;
+    }
+    const match = line.match(entryPattern);
+    if (!match) {
+      continue;
+    }
+    entries.push({
+      index: Number.parseInt(match[1], 10),
+      testName: match[2],
+    });
+  }
+
+  if (entries.length === 0) {
+    throw new Error(`No VRT bench entries found in ${DRIVER_FILE}`);
+  }
+
+  return entries.sort((a, b) => a.index - b.index);
+}
+
+function belongsToGroup(entry: BenchEntry, group: BenchGroup): boolean {
+  if (!entry.testName.startsWith("bench_vrt_")) {
+    return false;
+  }
+  if (group === "all") {
+    return true;
+  }
+  if (group === "phases") {
+    return entry.testName.startsWith("bench_vrt_phase_");
+  }
+  return !entry.testName.startsWith("bench_vrt_phase_");
+}
+
+function compressRanges(entries: BenchEntry[]): BenchRange[] {
+  const ranges: BenchRange[] = [];
+  for (const entry of entries) {
+    const last = ranges.at(-1);
+    if (last && last.end === entry.index) {
+      last.end = entry.index + 1;
+      continue;
+    }
+    ranges.push({
+      start: entry.index,
+      end: entry.index + 1,
+    });
+  }
+  return ranges;
+}
+
+function listEntries(group: BenchGroup, entries: BenchEntry[]): void {
+  console.log(`# VRT bench group: ${group}`);
+  for (const entry of entries) {
+    console.log(`${entry.index}\t${entry.testName}`);
+  }
+}
+
+function runSelectedEntries(entries: BenchEntry[]): string {
+  const runnerPath = path.join(process.cwd(), INTERNAL_RUNNER);
+  const ranges = compressRanges(entries);
+  const payload = JSON.stringify({
+    file_and_index: [[GENERATED_FILE_KEY, ranges]],
+  });
+  const result = spawnSync("node", [runnerPath, payload], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  if (stdout) {
+    process.stdout.write(stdout);
+  }
+  if (stderr) {
+    process.stderr.write(stderr);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+  return `${stdout}${stderr}`;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function asNumberArray(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item) => typeof item === "number" && Number.isFinite(item));
+}
+
+export function parseBenchRunOutput(
+  output: string,
+  group: BenchGroup,
+): VrtBenchParsedRun {
+  const rows: VrtBenchRow[] = [];
+  const lines = output.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{") || !trimmed.includes("\"test_name\"")) {
+      continue;
+    }
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    const testName =
+      typeof parsed.test_name === "string" ? parsed.test_name : "";
+    const index = Number.parseInt(String(parsed.index ?? "-1"), 10);
+    const message = typeof parsed.message === "string" ? parsed.message : "";
+    if (!testName || !Number.isFinite(index)) {
+      continue;
+    }
+    if (!message.startsWith("@BATCH_BENCH ")) {
+      continue;
+    }
+
+    let benchPayload: Record<string, unknown>;
+    try {
+      benchPayload = JSON.parse(message.slice("@BATCH_BENCH ".length));
+    } catch {
+      continue;
+    }
+    const summaries = Array.isArray(benchPayload.summaries)
+      ? benchPayload.summaries
+      : [];
+    for (const summary of summaries) {
+      if (typeof summary !== "object" || summary === null) {
+        continue;
+      }
+      const row = summary as Record<string, unknown>;
+      rows.push({
+        index,
+        testName,
+        summary: {
+          name: typeof row.name === "string" ? row.name : testName,
+          sum: asNumber(row.sum),
+          min: asNumber(row.min),
+          max: asNumber(row.max),
+          mean: asNumber(row.mean),
+          median: asNumber(row.median),
+          variance: asNumber(row.variance),
+          std_dev: asNumber(row.std_dev),
+          std_dev_pct: asNumber(row.std_dev_pct),
+          median_abs_dev: asNumber(row.median_abs_dev),
+          median_abs_dev_pct: asNumber(row.median_abs_dev_pct),
+          quartiles: asNumberArray(row.quartiles),
+          iqr: asNumber(row.iqr),
+          batch_size: asNumber(row.batch_size),
+          runs: asNumber(row.runs),
+        },
+      });
+    }
+  }
+
+  return {
+    group,
+    rows,
+    rawOutput: output,
+  };
+}
+
+export function summarizeBenchRun(
+  parsed: VrtBenchParsedRun,
+): VrtBenchRunSummary {
+  const rows = [...parsed.rows].sort((a, b) => b.summary.mean - a.summary.mean);
+  const meanTotal = rows.reduce((sum, row) => sum + row.summary.mean, 0);
+  const medianTotal = rows.reduce((sum, row) => sum + row.summary.median, 0);
+  return {
+    group: parsed.group,
+    rows,
+    totalRows: rows.length,
+    meanTotal,
+    medianTotal,
+    slowest: rows[0],
+    fastest: rows.at(-1),
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function fmtNumber(value: number): string {
+  return value.toFixed(2);
+}
+
+export function renderMarkdownSummary(summary: VrtBenchRunSummary): string {
+  const lines: string[] = [];
+  lines.push(`# VRT Bench Summary (${summary.group})`);
+  lines.push("");
+  lines.push(`- Benchmarks: ${summary.totalRows}`);
+  lines.push(`- Mean total: ${fmtNumber(summary.meanTotal)}`);
+  lines.push(`- Median total: ${fmtNumber(summary.medianTotal)}`);
+  if (summary.slowest) {
+    lines.push(
+      `- Slowest benchmark: \`${summary.slowest.testName}\` (${fmtNumber(summary.slowest.summary.mean)})`,
+    );
+  }
+  if (summary.fastest) {
+    lines.push(
+      `- Fastest benchmark: \`${summary.fastest.testName}\` (${fmtNumber(summary.fastest.summary.mean)})`,
+    );
+  }
+  lines.push("");
+  lines.push("| Test | Benchmark | Mean | Median | Min | Max | Batch | Runs |");
+  lines.push("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |");
+  for (const row of summary.rows) {
+    lines.push(
+      `| ${row.testName} | ${row.summary.name} | ${fmtNumber(row.summary.mean)} | ${fmtNumber(row.summary.median)} | ${fmtNumber(row.summary.min)} | ${fmtNumber(row.summary.max)} | ${row.summary.batch_size} | ${row.summary.runs} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function ensureParentDir(filePath: string): void {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeOptionalReports(
+  parsed: VrtBenchParsedRun,
+  options: CliOptions,
+): void {
+  if (!options.jsonOutput && !options.markdownOutput) {
+    return;
+  }
+  const summary = summarizeBenchRun(parsed);
+  if (options.jsonOutput) {
+    ensureParentDir(options.jsonOutput);
+    fs.writeFileSync(options.jsonOutput, JSON.stringify(summary, null, 2));
+  }
+  if (options.markdownOutput) {
+    ensureParentDir(options.markdownOutput);
+    fs.writeFileSync(options.markdownOutput, renderMarkdownSummary(summary));
+  }
+}
+
+function main(): void {
+  const options = parseCliArgs(process.argv.slice(2));
+  buildBenchArtifacts();
+  const selected = readBenchEntries().filter((entry) =>
+    belongsToGroup(entry, options.group)
+  );
+  if (selected.length === 0) {
+    throw new Error(`No benches matched group: ${options.group}`);
+  }
+
+  listEntries(options.group, selected);
+  if (!options.listOnly) {
+    const output = runSelectedEntries(selected);
+    writeOptionalReports(parseBenchRunOutput(output, options.group), options);
+  }
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return path.resolve(entry) === fileURLToPath(import.meta.url);
+}
+
+if (isMainModule()) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  }
+}

--- a/src/aom/pkg.generated.mbti
+++ b/src/aom/pkg.generated.mbti
@@ -233,11 +233,9 @@ pub(all) enum Role {
   HtmlCanvas
   HtmlLabel
   HtmlSummary
-}
+} derive(Eq, Show)
 pub fn Role::from_string(String) -> Self?
 pub fn Role::to_string(Self) -> String
-pub impl Eq for Role
-pub impl Show for Role
 
 pub(all) struct RoleMappingContext {
   parent_tag : String?
@@ -264,10 +262,8 @@ pub(all) enum State {
   Selected
   CheckedMixed
   PressedMixed
-}
+} derive(Eq, Show)
 pub fn State::to_string(Self) -> String
-pub impl Eq for State
-pub impl Show for State
 
 // Type aliases
 

--- a/src/benchmarks/moon.pkg
+++ b/src/benchmarks/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/bench",
+  "mizchi/crater",
   "mizchi/crater/html",
   "mizchi/crater/renderer",
   "mizchi/crater/layout/node",

--- a/src/benchmarks/vrt_api_bench.mbt
+++ b/src/benchmarks/vrt_api_bench.mbt
@@ -1,0 +1,165 @@
+///|
+fn vrt_viewport() -> @types.Size[Double] {
+  @types.Size::new(1280.0, 900.0)
+}
+
+///|
+fn vrt_render_context(
+  viewport : @types.Size[Double],
+) -> @renderer.RenderContext {
+  {
+    ..@renderer.RenderContext::default(),
+    viewport_width: viewport.width,
+    viewport_height: viewport.height,
+  }
+}
+
+///|
+fn build_vrt_paint_tree(
+  node : @node.Node,
+  layout : @types.Layout,
+  viewport : @types.Size[Double],
+) -> @paint.PaintNode {
+  match
+    @paint.from_node_and_layout_with_viewport(
+      node,
+      layout,
+      0.0,
+      viewport.height,
+      0.0,
+    ) {
+    Some(paint_tree) => paint_tree
+    None => @paint.from_node_and_layout(node, layout)
+  }
+}
+
+///|
+fn vrt_component_fixture(
+  padding_px : Int,
+  bg : String,
+  accent : String,
+) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string(
+    "<!DOCTYPE html><html><body style=\"margin:0;background:#f4f6fb;padding:24px\">",
+  )
+  buf.write_string(
+    "<section style=\"width:420px;border:1px solid #d8dee8;border-radius:20px;background:",
+  )
+  buf.write_string(bg)
+  buf.write_string(";padding:")
+  buf.write_string(padding_px.to_string())
+  buf.write_string("px\">")
+  buf.write_string(
+    "<p style=\"margin:0 0 10px;color:#5f6b7a;font-size:12px;text-transform:uppercase\">status</p>",
+  )
+  buf.write_string(
+    "<h2 style=\"margin:0 0 12px;font-size:22px;font-weight:700\">Billing Ready</h2>",
+  )
+  buf.write_string(
+    "<p style=\"margin:0 0 18px;font-size:14px;line-height:1.45;color:#17212b\">Invoice automation is active for the current workspace.</p>",
+  )
+  buf.write_string("<div style=\"display:flex;gap:8px;margin-bottom:18px\">")
+  buf.write_string(
+    "<span style=\"padding:4px 8px;border-radius:999px;background:#eef2f8\">Auto</span>",
+  )
+  buf.write_string(
+    "<span style=\"padding:4px 8px;border-radius:999px;background:#eef2f8\">USD</span>",
+  )
+  buf.write_string("</div>")
+  buf.write_string(
+    "<button style=\"display:block;width:100%;padding:10px 12px;border:0;border-radius:10px;background:",
+  )
+  buf.write_string(accent)
+  buf.write_string(";color:#ffffff\">Open</button>")
+  buf.write_string("</section></body></html>")
+  buf.to_string()
+}
+
+///|
+test "bench_vrt_render_paint_tree_dashboard" (b : @bench.T) {
+  let html = dashboard(16, 24)
+  let viewport = vrt_viewport()
+  b.bench(name="vrt_render_paint_tree_dashboard", fn() {
+    b.keep(@crater.render_html_to_paint_tree(html, viewport))
+  })
+}
+
+///|
+test "bench_vrt_render_paint_tree_json_component" (b : @bench.T) {
+  let html = vrt_component_fixture(20, "#ffffff", "#1463ff")
+  let viewport = vrt_viewport()
+  b.bench(name="vrt_render_paint_tree_json_component", fn() {
+    b.keep(@crater.render_html_to_paint_tree_json(html, viewport))
+  })
+}
+
+///|
+test "bench_vrt_diff_rendered_paint_trees_component" (b : @bench.T) {
+  let viewport = vrt_viewport()
+  let baseline_html = vrt_component_fixture(20, "#ffffff", "#1463ff")
+  let mutated_html = vrt_component_fixture(8, "#eef2f8", "#0f7b3b")
+  b.bench(name="vrt_diff_rendered_paint_trees_component", fn() {
+    b.keep(
+      @crater.diff_rendered_paint_trees(baseline_html, mutated_html, viewport),
+    )
+  })
+}
+
+///|
+test "bench_vrt_phase_parse_dashboard" (b : @bench.T) {
+  let html = dashboard(16, 24)
+  b.bench(name="vrt_phase_parse_dashboard", fn() {
+    b.keep(@html.parse_document(html))
+  })
+}
+
+///|
+test "bench_vrt_phase_node_layout_dashboard" (b : @bench.T) {
+  let html = dashboard(16, 24)
+  let viewport = vrt_viewport()
+  let ctx = vrt_render_context(viewport)
+  let doc = @html.parse_document(html)
+  b.bench(name="vrt_phase_node_layout_dashboard", fn() {
+    b.keep(@renderer.render_to_node_and_layout_with_document(doc, ctx, []))
+  })
+}
+
+///|
+test "bench_vrt_phase_paint_tree_dashboard" (b : @bench.T) {
+  let html = dashboard(16, 24)
+  let viewport = vrt_viewport()
+  let ctx = vrt_render_context(viewport)
+  let (node, layout) = @renderer.render_to_node_and_layout(html, ctx)
+  b.bench(name="vrt_phase_paint_tree_dashboard", fn() {
+    b.keep(build_vrt_paint_tree(node, layout, viewport))
+  })
+}
+
+///|
+test "bench_vrt_phase_paint_tree_json_component" (b : @bench.T) {
+  let viewport = vrt_viewport()
+  let ctx = vrt_render_context(viewport)
+  let html = vrt_component_fixture(20, "#ffffff", "#1463ff")
+  let (node, layout) = @renderer.render_to_node_and_layout(html, ctx)
+  let paint_tree = build_vrt_paint_tree(node, layout, viewport)
+  b.bench(name="vrt_phase_paint_tree_json_component", fn() {
+    b.keep(paint_tree.to_json_string())
+  })
+}
+
+///|
+test "bench_vrt_phase_diff_component" (b : @bench.T) {
+  let viewport = vrt_viewport()
+  let baseline = @crater.render_html_to_paint_tree(
+    vrt_component_fixture(20, "#ffffff", "#1463ff"),
+    viewport,
+  )
+  let mutated = @crater.render_html_to_paint_tree(
+    vrt_component_fixture(8, "#eef2f8", "#0f7b3b"),
+    viewport,
+  )
+  b.bench(name="vrt_phase_diff_component", fn() {
+    b.keep(@paint.diff_trees(baseline, mutated))
+  })
+}

--- a/src/css/computed/compute.mbt
+++ b/src/css/computed/compute.mbt
@@ -215,6 +215,8 @@ priv struct StyleBuilder {
   mut border_bottom_right_radius : Double
   mut border_bottom_left_radius : Double
   mut text_decoration_underline : Bool
+  mut text_decoration_line_through : Bool
+  mut text_decoration_overline : Bool
   mut letter_spacing : Double
   mut word_spacing : Double
 }
@@ -331,6 +333,8 @@ fn StyleBuilder::new() -> StyleBuilder {
     border_bottom_right_radius: 0.0,
     border_bottom_left_radius: 0.0,
     text_decoration_underline: false,
+    text_decoration_line_through: false,
+    text_decoration_overline: false,
     letter_spacing: 0.0,
     word_spacing: 0.0,
   }
@@ -449,6 +453,8 @@ fn StyleBuilder::from_style(style : @style.Style) -> StyleBuilder {
     border_bottom_right_radius: style.border_bottom_right_radius,
     border_bottom_left_radius: style.border_bottom_left_radius,
     text_decoration_underline: style.text_decoration_underline,
+    text_decoration_line_through: style.text_decoration_line_through,
+    text_decoration_overline: style.text_decoration_overline,
     letter_spacing: style.letter_spacing,
     word_spacing: style.word_spacing,
   }
@@ -578,6 +584,8 @@ fn StyleBuilder::build(self : StyleBuilder) -> @style.Style {
     border_bottom_right_radius: self.border_bottom_right_radius,
     border_bottom_left_radius: self.border_bottom_left_radius,
     text_decoration_underline: self.text_decoration_underline,
+    text_decoration_line_through: self.text_decoration_line_through,
+    text_decoration_overline: self.text_decoration_overline,
     letter_spacing: self.letter_spacing,
     word_spacing: self.word_spacing,
   }
@@ -762,7 +770,14 @@ fn get_style_value_as_string(property : String, style : @style.Style) -> String 
         @style.Direction::Rtl => "rtl"
       }
     "font-size" => style.font_size.to_string() + "px"
+    "font-weight" => style.font_weight.to_string()
     "line-height" => style.line_height.to_string() + "px"
+    "text-decoration" | "text-decoration-line" =>
+      text_decoration_to_string(
+        style.text_decoration_underline,
+        style.text_decoration_line_through,
+        style.text_decoration_overline,
+      )
     "text-align" =>
       match style.text_align {
         @style.TextAlign::Start => "start"
@@ -814,6 +829,36 @@ fn dimension_to_string(dim : @types.Dimension) -> String {
     @types.Dimension::MinContent => "min-content"
     @types.Dimension::MaxContent => "max-content"
     @types.Dimension::FitContent(n) => "fit-content(" + n.to_string() + "px)"
+  }
+}
+
+///|
+fn text_decoration_to_string(
+  underline : Bool,
+  line_through : Bool,
+  overline : Bool,
+) -> String {
+  let values : Array[String] = []
+  if underline {
+    values.push("underline")
+  }
+  if line_through {
+    values.push("line-through")
+  }
+  if overline {
+    values.push("overline")
+  }
+  if values.is_empty() {
+    "none"
+  } else {
+    let buf = StringBuilder::new()
+    for i, value in values {
+      if i > 0 {
+        buf.write_string(" ")
+      }
+      buf.write_string(value)
+    }
+    buf.to_string()
   }
 }
 
@@ -2030,6 +2075,8 @@ fn apply_property(
     "text-decoration" | "text-decoration-line" => {
       let v = value.trim().to_lower()
       builder.text_decoration_underline = v.contains("underline")
+      builder.text_decoration_line_through = v.contains("line-through")
+      builder.text_decoration_overline = v.contains("overline")
     }
     "letter-spacing" => {
       let v = value.trim().to_lower()

--- a/src/css/computed/properties.mbt
+++ b/src/css/computed/properties.mbt
@@ -102,7 +102,9 @@ pub fn initial_value(property : String) -> String {
     "direction" => "ltr"
     "writing-mode" => "horizontal-tb"
     "text-align" => "start"
+    "font-weight" => "400"
     "white-space" => "normal"
+    "text-decoration" | "text-decoration-line" => "none"
     // Containment
     "contain" => "none"
     "contain-intrinsic-size"

--- a/src/css/media/pkg.generated.mbti
+++ b/src/css/media/pkg.generated.mbti
@@ -10,9 +10,7 @@ pub fn parse_media_query_list(String) -> MediaQueryList
 pub(all) enum ColorScheme {
   Light
   Dark
-}
-pub impl Eq for ColorScheme
-pub impl Show for ColorScheme
+} derive(Eq, Show)
 
 pub(all) struct MediaEnvironment {
   viewport_width : Double
@@ -52,48 +50,38 @@ pub enum MediaFeature {
   PrefersColorScheme(String)
   PrefersReducedMotion(String)
   Custom(String, MediaValue?)
-}
-pub impl Eq for MediaFeature
-pub impl Show for MediaFeature
+} derive(Eq, Show)
 
 pub struct MediaQuery {
   negated : Bool
   only : Bool
   media_type : MediaType?
   conditions : Array[MediaFeature]
-}
+} derive(Eq, Show)
 pub fn MediaQuery::default() -> Self
 pub fn MediaQuery::evaluate(Self, MediaEnvironment) -> Bool
-pub impl Eq for MediaQuery
-pub impl Show for MediaQuery
 
 pub struct MediaQueryList {
   queries : Array[MediaQuery]
-}
+} derive(Eq, Show)
 pub fn MediaQueryList::evaluate(Self, MediaEnvironment) -> Bool
 pub fn MediaQueryList::is_empty(Self) -> Bool
 pub fn MediaQueryList::length(Self) -> Int
 pub fn MediaQueryList::new() -> Self
-pub impl Eq for MediaQueryList
-pub impl Show for MediaQueryList
 
 pub enum MediaType {
   All
   Screen
   Print
   Speech
-}
-pub impl Eq for MediaType
-pub impl Show for MediaType
+} derive(Eq, Show)
 
 pub enum MediaValue {
   Number(Double)
   Dimension(Double, String)
   Ratio(Int, Int)
   Ident(String)
-}
-pub impl Eq for MediaValue
-pub impl Show for MediaValue
+} derive(Eq, Show)
 
 pub enum RangeOp {
   Eq
@@ -101,9 +89,7 @@ pub enum RangeOp {
   Le
   Gt
   Ge
-}
-pub impl Eq for RangeOp
-pub impl Show for RangeOp
+} derive(Eq, Show)
 
 // Type aliases
 

--- a/src/css/selector/pkg.generated.mbti
+++ b/src/css/selector/pkg.generated.mbti
@@ -173,12 +173,10 @@ pub(all) struct Specificity {
   a : Int
   b : Int
   c : Int
-}
+} derive(Compare, Eq)
 pub fn Specificity::add(Self, Self) -> Self
 pub fn Specificity::compare_to(Self, Self) -> Int
 pub fn Specificity::zero() -> Self
-pub impl Compare for Specificity
-pub impl Eq for Specificity
 pub impl Show for Specificity
 
 // Type aliases

--- a/src/dom/pkg.generated.mbti
+++ b/src/dom/pkg.generated.mbti
@@ -34,8 +34,7 @@ pub fn create_svg_transform_translate(Double, Double) -> SVGTransform
 pub enum CoreError {
   NodeNotFound(node_id~ : NodeId)
   InvalidOperation(message~ : String)
-}
-pub impl Show for CoreError
+} derive(Show)
 
 type DomNode
 
@@ -86,19 +85,16 @@ pub struct FlushResult {
   processed : Int
   nodes_affected : Int
   needs_layout : Bool
-}
-pub impl Show for FlushResult
+} derive(Show)
 
 pub struct GetBBoxOptions {
   fill : Bool
   stroke : Bool
   markers : Bool
   clipped : Bool
-}
+} derive(Eq, Show)
 pub fn GetBBoxOptions::all() -> Self
 pub fn GetBBoxOptions::default() -> Self
-pub impl Eq for GetBBoxOptions
-pub impl Show for GetBBoxOptions
 
 pub struct MutationQueue {
   mut records : Array[MutationRecord]
@@ -125,31 +121,25 @@ pub struct MutationRecord {
   old_value : String?
   new_value : String?
   changed_properties : Array[String]
-}
+} derive(Show)
 pub fn MutationRecord::affects_layout(Self) -> Bool
 pub fn MutationRecord::attribute(NodeId, String, old_value? : String?, new_value? : String?) -> Self
 pub fn MutationRecord::character_data(NodeId, old_value? : String?, new_value? : String?) -> Self
 pub fn MutationRecord::child_list(NodeId, added? : Array[NodeId], removed? : Array[NodeId]) -> Self
 pub fn MutationRecord::style_change(NodeId, Array[String]) -> Self
-pub impl Show for MutationRecord
 
 pub enum MutationType {
   ChildList
   Attributes
   CharacterData
   StyleChange
-}
-pub impl Eq for MutationType
-pub impl Show for MutationType
+} derive(Eq, Show)
 
-pub struct NodeId(Int)
+pub struct NodeId(Int) derive(Eq, Hash, Show)
 pub fn NodeId::from_int(Int) -> Self
 #deprecated
 pub fn NodeId::inner(Self) -> Int
 pub fn NodeId::to_int(Self) -> Int
-pub impl Eq for NodeId
-pub impl Hash for NodeId
-pub impl Show for NodeId
 
 pub struct NodeInfo {
   node_id : NodeId
@@ -157,8 +147,7 @@ pub struct NodeInfo {
   node_name : String
   node_value : String
   child_count : Int
-}
-pub impl Show for NodeInfo
+} derive(Show)
 
 pub enum NodeType {
   Document
@@ -166,39 +155,31 @@ pub enum NodeType {
   Element
   Text
   Comment
-}
+} derive(Eq, Show)
 pub fn NodeType::from_dom_constant(Int) -> Self?
-pub impl Eq for NodeType
-pub impl Show for NodeType
 
 pub struct Point {
   x : Double
   y : Double
-}
-pub impl Eq for Point
-pub impl Show for Point
+} derive(Eq, Show)
 
 pub struct Rect {
   x : Double
   y : Double
   width : Double
   height : Double
-}
+} derive(Eq, Show)
 pub fn Rect::center(Self) -> Point
 pub fn Rect::new(Double, Double, Double, Double) -> Self
-pub impl Eq for Rect
-pub impl Show for Rect
 
 pub struct SVGAngle {
   unit_type : SVGAngleType
   value : Double
   value_in_specified_units : Double
-}
+} derive(Eq, Show)
 pub fn SVGAngle::new(Double) -> Self
 pub fn SVGAngle::to_degrees(Self) -> Double
 pub fn SVGAngle::to_radians(Self) -> Double
-pub impl Eq for SVGAngle
-pub impl Show for SVGAngle
 
 pub enum SVGAngleType {
   Unknown
@@ -207,19 +188,15 @@ pub enum SVGAngleType {
   Rad
   Grad
   Turn
-}
-pub impl Eq for SVGAngleType
-pub impl Show for SVGAngleType
+} derive(Eq, Show)
 
 pub struct SVGLength {
   unit_type : SVGLengthType
   value : Double
   value_in_specified_units : Double
-}
+} derive(Eq, Show)
 pub fn SVGLength::new(Double) -> Self
 pub fn SVGLength::to_user_units(Self, dpi? : Double, font_size? : Double) -> Double
-pub impl Eq for SVGLength
-pub impl Show for SVGLength
 
 pub enum SVGLengthType {
   Unknown
@@ -233,9 +210,7 @@ pub enum SVGLengthType {
   In
   Pt
   Pc
-}
-pub impl Eq for SVGLengthType
-pub impl Show for SVGLengthType
+} derive(Eq, Show)
 
 pub struct SVGMatrix {
   a : Double
@@ -244,7 +219,7 @@ pub struct SVGMatrix {
   d : Double
   e : Double
   f : Double
-}
+} derive(Eq, Show)
 pub fn SVGMatrix::flip_x(Self) -> Self
 pub fn SVGMatrix::flip_y(Self) -> Self
 pub fn SVGMatrix::identity() -> Self
@@ -261,52 +236,42 @@ pub fn SVGMatrix::skew_x(Double) -> Self
 pub fn SVGMatrix::skew_y(Double) -> Self
 pub fn SVGMatrix::translate(Double, Double) -> Self
 pub fn SVGMatrix::translate_self(Self, Double, Double) -> Self
-pub impl Eq for SVGMatrix
-pub impl Show for SVGMatrix
 
 pub struct SVGNumber {
   value : Double
-}
+} derive(Eq, Show)
 pub fn SVGNumber::new(Double) -> Self
-pub impl Eq for SVGNumber
-pub impl Show for SVGNumber
 
 pub struct SVGPoint {
   x : Double
   y : Double
-}
+} derive(Eq, Show)
 pub fn SVGPoint::matrix_transform(Self, SVGMatrix) -> Self
 pub fn SVGPoint::new(Double, Double) -> Self
 pub fn SVGPoint::origin() -> Self
-pub impl Eq for SVGPoint
-pub impl Show for SVGPoint
 
 pub struct SVGRect {
   x : Double
   y : Double
   width : Double
   height : Double
-}
+} derive(Eq, Show)
 pub fn SVGRect::empty() -> Self
 pub fn SVGRect::from_rect(Rect) -> Self
 pub fn SVGRect::new(Double, Double, Double, Double) -> Self
 pub fn SVGRect::to_rect(Self) -> Rect
-pub impl Eq for SVGRect
-pub impl Show for SVGRect
 
 pub struct SVGTransform {
   transform_type : SVGTransformType
   matrix : SVGMatrix
   angle : Double
-}
+} derive(Eq, Show)
 pub fn SVGTransform::from_matrix(SVGMatrix) -> Self
 pub fn SVGTransform::rotate(Double, cx? : Double, cy? : Double) -> Self
 pub fn SVGTransform::scale(Double, Double) -> Self
 pub fn SVGTransform::skew_x(Double) -> Self
 pub fn SVGTransform::skew_y(Double) -> Self
 pub fn SVGTransform::translate(Double, Double) -> Self
-pub impl Eq for SVGTransform
-pub impl Show for SVGTransform
 
 pub enum SVGTransformType {
   Unknown
@@ -316,9 +281,7 @@ pub enum SVGTransformType {
   Rotate
   SkewX
   SkewY
-}
-pub impl Eq for SVGTransformType
-pub impl Show for SVGTransformType
+} derive(Eq, Show)
 
 pub struct ScrollState {
   scroll_left : Double
@@ -327,7 +290,7 @@ pub struct ScrollState {
   scroll_height : Double
   client_width : Double
   client_height : Double
-}
+} derive(Eq, Show)
 pub fn ScrollState::can_scroll_x(Self) -> Bool
 pub fn ScrollState::can_scroll_y(Self) -> Bool
 pub fn ScrollState::default() -> Self
@@ -336,8 +299,6 @@ pub fn ScrollState::max_scroll_top(Self) -> Double
 pub fn ScrollState::new(Double, Double, Double, Double) -> Self
 pub fn ScrollState::scroll_by(Self, Double, Double) -> Self
 pub fn ScrollState::scroll_to(Self, Double, Double) -> Self
-pub impl Eq for ScrollState
-pub impl Show for ScrollState
 
 // Type aliases
 

--- a/src/layout/grid/pkg.generated.mbti
+++ b/src/layout/grid/pkg.generated.mbti
@@ -16,11 +16,9 @@ pub fn compute_layout(@node.Node, Double, Double) -> @types.Layout
 // Errors
 
 // Types and methods
-type BaselineInfo
-pub impl Show for BaselineInfo
+type BaselineInfo derive(Show)
 
-type GridAreaBounds
-pub impl Show for GridAreaBounds
+type GridAreaBounds derive(Show)
 
 // Type aliases
 

--- a/src/layout/trace/pkg.generated.mbti
+++ b/src/layout/trace/pkg.generated.mbti
@@ -22,14 +22,12 @@ pub(all) struct ComputeOutput {
   node_uid : Int
   width : Double
   height : Double
-}
-pub impl Show for ComputeOutput
+} derive(Show)
 
 pub(all) struct Dependency {
   node_uid : Int
   kind : DependencyKind
-}
-pub impl Show for Dependency
+} derive(Show)
 
 pub(all) enum DependencyKind {
   ParentWidth
@@ -38,9 +36,7 @@ pub(all) enum DependencyKind {
   ChildIntrinsicCross(Int)
   SiblingSize(Int)
   OwnStyle
-}
-pub impl Eq for DependencyKind
-pub impl Show for DependencyKind
+} derive(Eq, Show)
 
 pub struct LayoutTracer {
   traces : Map[Int, NodeTrace]

--- a/src/layout/tree/pkg.generated.mbti
+++ b/src/layout/tree/pkg.generated.mbti
@@ -43,10 +43,9 @@ pub struct ConstraintKey {
   available_width : Double
   available_height : Double?
   sizing_mode : @types.SizingMode
-}
+} derive(Eq)
 pub fn ConstraintKey::approx_eq(Self, Self) -> Bool
 pub fn ConstraintKey::new(Double, Double?, @types.SizingMode) -> Self
-pub impl Eq for ConstraintKey
 
 pub struct ConstraintSpace {
   available_width : Double
@@ -68,10 +67,8 @@ pub(all) enum DependencyKind {
   ParentBoth
   Intrinsic
   Viewport
-}
+} derive(Eq, Show)
 pub fn DependencyKind::merge(Self, Self) -> Self
-pub impl Eq for DependencyKind
-pub impl Show for DependencyKind
 
 pub struct Document {
   dom : @dom.DomTree
@@ -239,12 +236,9 @@ pub fn LayoutTree::resize_viewport(Self, Double, Double) -> Unit
 pub fn LayoutTree::resolve_resource(Self, ResourceId, Double, Double) -> Unit
 pub fn LayoutTree::update_node_style(Self, String, @cascade.CascadedValues) -> Bool
 
-pub(all) struct ResourceId(Int)
+pub(all) struct ResourceId(Int) derive(Eq, Hash, Show)
 #deprecated
 pub fn ResourceId::inner(Self) -> Int
-pub impl Eq for ResourceId
-pub impl Hash for ResourceId
-pub impl Show for ResourceId
 
 pub struct ResourceRegistry {
   mut next_id : Int

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -8,6 +8,8 @@ import {
   "mizchi/crater/layout/table",
   "mizchi/crater/x/webvitals",
   "mizchi/crater/layout/dispatch",
+  "mizchi/crater/paint",
+  "mizchi/crater/renderer",
 }
 
 import {

--- a/src/paint/diff.mbt
+++ b/src/paint/diff.mbt
@@ -1,0 +1,491 @@
+///|
+pub(all) struct PaintPropertyChange {
+  node_path : String
+  node_id : String
+  property : String
+  before : String?
+  after : String?
+}
+
+///|
+pub(all) struct PaintLayoutShift {
+  node_path : String
+  node_id : String
+  dx : Double
+  dy : Double
+  dw : Double
+  dh : Double
+}
+
+///|
+pub(all) struct PaintTreeDiff {
+  changes : Array[PaintPropertyChange]
+  layout_shifts : Array[PaintLayoutShift]
+}
+
+///|
+priv struct FlatPaintNode {
+  path : String
+  node : PaintNode
+}
+
+///|
+pub fn diff_trees(before : PaintNode, after : PaintNode) -> PaintTreeDiff {
+  let before_nodes : Array[FlatPaintNode] = []
+  let after_nodes : Array[FlatPaintNode] = []
+  let before_by_path : Map[String, FlatPaintNode] = {}
+  let after_by_path : Map[String, FlatPaintNode] = {}
+  collect_flat_nodes(before, before.tag + "[0]", before_nodes, before_by_path)
+  collect_flat_nodes(after, after.tag + "[0]", after_nodes, after_by_path)
+
+  let changes : Array[PaintPropertyChange] = []
+  let layout_shifts : Array[PaintLayoutShift] = []
+
+  for flat in before_nodes {
+    match after_by_path.get(flat.path) {
+      Some(other) => compare_nodes(flat, other, changes, layout_shifts)
+      None =>
+        changes.push({
+          node_path: flat.path,
+          node_id: flat.node.id,
+          property: "node_presence",
+          before: Some("present"),
+          after: None,
+        })
+    }
+  }
+
+  for flat in after_nodes {
+    if before_by_path.get(flat.path) is None {
+      changes.push({
+        node_path: flat.path,
+        node_id: flat.node.id,
+        property: "node_presence",
+        before: None,
+        after: Some("present"),
+      })
+    }
+  }
+
+  { changes, layout_shifts }
+}
+
+///|
+fn collect_flat_nodes(
+  node : PaintNode,
+  path : String,
+  flat_nodes : Array[FlatPaintNode],
+  by_path : Map[String, FlatPaintNode],
+) -> Unit {
+  let flat = { path, node }
+  flat_nodes.push(flat)
+  by_path.set(path, flat)
+  for i, child in node.children {
+    collect_flat_nodes(
+      child,
+      path + "/" + child.tag + "[" + i.to_string() + "]",
+      flat_nodes,
+      by_path,
+    )
+  }
+}
+
+///|
+fn compare_nodes(
+  before : FlatPaintNode,
+  after : FlatPaintNode,
+  changes : Array[PaintPropertyChange],
+  layout_shifts : Array[PaintLayoutShift],
+) -> Unit {
+  let before_node = before.node
+  let after_node = after.node
+
+  if before_node.x != after_node.x ||
+    before_node.y != after_node.y ||
+    before_node.width != after_node.width ||
+    before_node.height != after_node.height {
+    layout_shifts.push({
+      node_path: before.path,
+      node_id: after_node.id,
+      dx: after_node.x - before_node.x,
+      dy: after_node.y - before_node.y,
+      dw: after_node.width - before_node.width,
+      dh: after_node.height - before_node.height,
+    })
+  }
+
+  compare_string_property(
+    before.path,
+    before_node.id,
+    "id",
+    before_node.id,
+    after_node.id,
+    changes,
+  )
+  compare_string_property(
+    before.path,
+    before_node.id,
+    "tag",
+    before_node.tag,
+    after_node.tag,
+    changes,
+  )
+  compare_optional_string_property(
+    before.path,
+    before_node.id,
+    "text",
+    before_node.text,
+    after_node.text,
+    changes,
+  )
+  compare_optional_string_property(
+    before.path,
+    before_node.id,
+    "src",
+    before_node.src,
+    after_node.src,
+    changes,
+  )
+  compare_double_property(
+    before.path,
+    before_node.id,
+    "scroll_width",
+    before_node.scroll_width,
+    after_node.scroll_width,
+    changes,
+  )
+  compare_double_property(
+    before.path,
+    before_node.id,
+    "scroll_height",
+    before_node.scroll_height,
+    after_node.scroll_height,
+    changes,
+  )
+  compare_string_property(
+    before.path,
+    before_node.id,
+    "clip",
+    before_node.clip.to_string(),
+    after_node.clip.to_string(),
+    changes,
+  )
+  compare_string_property(
+    before.path,
+    before_node.id,
+    "overflow_x",
+    overflow_to_string(before_node.overflow_x),
+    overflow_to_string(after_node.overflow_x),
+    changes,
+  )
+  compare_string_property(
+    before.path,
+    before_node.id,
+    "overflow_y",
+    overflow_to_string(before_node.overflow_y),
+    overflow_to_string(after_node.overflow_y),
+    changes,
+  )
+  compare_paint_properties(
+    before.path,
+    before_node.id,
+    before_node.paint,
+    after_node.paint,
+    changes,
+  )
+}
+
+///|
+fn compare_paint_properties(
+  path : String,
+  node_id : String,
+  before : PaintProperties,
+  after : PaintProperties,
+  changes : Array[PaintPropertyChange],
+) -> Unit {
+  compare_string_property(
+    path,
+    node_id,
+    "z_index",
+    before.z_index.to_string(),
+    after.z_index.to_string(),
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "visibility",
+    before.visibility.to_string(),
+    after.visibility.to_string(),
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "pointer_events",
+    before.pointer_events.to_string(),
+    after.pointer_events.to_string(),
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "opacity",
+    before.opacity,
+    after.opacity,
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "color",
+    before.color.to_string(),
+    after.color.to_string(),
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "background_color",
+    before.background_color.to_string(),
+    after.background_color.to_string(),
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "background_image",
+    before.background_image.to_string(),
+    after.background_image.to_string(),
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "font_size",
+    before.font_size,
+    after.font_size,
+    changes,
+  )
+  compare_bool_property(
+    path,
+    node_id,
+    "is_bold",
+    before.is_bold,
+    after.is_bold,
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "font_family",
+    before.font_family,
+    after.font_family,
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "border_top_left_radius",
+    before.border_top_left_radius,
+    after.border_top_left_radius,
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "border_top_right_radius",
+    before.border_top_right_radius,
+    after.border_top_right_radius,
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "border_bottom_right_radius",
+    before.border_bottom_right_radius,
+    after.border_bottom_right_radius,
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "border_bottom_left_radius",
+    before.border_bottom_left_radius,
+    after.border_bottom_left_radius,
+    changes,
+  )
+  compare_bool_property(
+    path,
+    node_id,
+    "text_decoration_underline",
+    before.text_decoration_underline,
+    after.text_decoration_underline,
+    changes,
+  )
+  compare_bool_property(
+    path,
+    node_id,
+    "text_decoration_line_through",
+    before.text_decoration_line_through,
+    after.text_decoration_line_through,
+    changes,
+  )
+  compare_bool_property(
+    path,
+    node_id,
+    "text_decoration_overline",
+    before.text_decoration_overline,
+    after.text_decoration_overline,
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "border_top_width",
+    before.border_top_width,
+    after.border_top_width,
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "border_right_width",
+    before.border_right_width,
+    after.border_right_width,
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "border_bottom_width",
+    before.border_bottom_width,
+    after.border_bottom_width,
+    changes,
+  )
+  compare_double_property(
+    path,
+    node_id,
+    "border_left_width",
+    before.border_left_width,
+    after.border_left_width,
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "border_top_color",
+    before.border_top_color.to_string(),
+    after.border_top_color.to_string(),
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "border_right_color",
+    before.border_right_color.to_string(),
+    after.border_right_color.to_string(),
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "border_bottom_color",
+    before.border_bottom_color.to_string(),
+    after.border_bottom_color.to_string(),
+    changes,
+  )
+  compare_string_property(
+    path,
+    node_id,
+    "border_left_color",
+    before.border_left_color.to_string(),
+    after.border_left_color.to_string(),
+    changes,
+  )
+}
+
+///|
+fn compare_bool_property(
+  path : String,
+  node_id : String,
+  property : String,
+  before : Bool,
+  after : Bool,
+  changes : Array[PaintPropertyChange],
+) -> Unit {
+  if before != after {
+    changes.push({
+      node_path: path,
+      node_id,
+      property,
+      before: Some(before.to_string()),
+      after: Some(after.to_string()),
+    })
+  }
+}
+
+///|
+fn compare_double_property(
+  path : String,
+  node_id : String,
+  property : String,
+  before : Double,
+  after : Double,
+  changes : Array[PaintPropertyChange],
+) -> Unit {
+  if before != after {
+    changes.push({
+      node_path: path,
+      node_id,
+      property,
+      before: Some(before.to_string()),
+      after: Some(after.to_string()),
+    })
+  }
+}
+
+///|
+fn compare_string_property(
+  path : String,
+  node_id : String,
+  property : String,
+  before : String,
+  after : String,
+  changes : Array[PaintPropertyChange],
+) -> Unit {
+  if before != after {
+    changes.push({
+      node_path: path,
+      node_id,
+      property,
+      before: Some(before),
+      after: Some(after),
+    })
+  }
+}
+
+///|
+fn compare_optional_string_property(
+  path : String,
+  node_id : String,
+  property : String,
+  before : String?,
+  after : String?,
+  changes : Array[PaintPropertyChange],
+) -> Unit {
+  if before != after {
+    changes.push({ node_path: path, node_id, property, before, after })
+  }
+}
+
+///|
+fn overflow_to_string(value : @types.Overflow) -> String {
+  match value {
+    @types.Visible => "visible"
+    @types.Hidden => "hidden"
+    @types.Clip => "clip"
+    @types.Scroll => "scroll"
+    @types.Auto => "auto"
+  }
+}

--- a/src/paint/diff_test.mbt
+++ b/src/paint/diff_test.mbt
@@ -1,0 +1,112 @@
+///|
+fn has_property_change(
+  diff : PaintTreeDiff,
+  node_id : String,
+  property : String,
+) -> Bool {
+  for change in diff.changes {
+    if change.node_id == node_id && change.property == property {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn make_text_node(
+  text : String,
+  bold : Bool,
+  underline : Bool,
+  line_through : Bool,
+  overline : Bool,
+) -> PaintNode {
+  PaintNode::new(
+    "#text",
+    "#text",
+    0.0,
+    0.0,
+    64.0,
+    16.0,
+    {
+      ..PaintProperties::default(),
+      is_bold: bold,
+      text_decoration_underline: underline,
+      text_decoration_line_through: line_through,
+      text_decoration_overline: overline,
+    },
+    [],
+    text=Some(text),
+  )
+}
+
+///|
+test "diff_trees reports paint property changes and layout shifts" {
+  let before = PaintNode::new(
+    "body",
+    "body",
+    0.0,
+    0.0,
+    200.0,
+    120.0,
+    PaintProperties::default(),
+    [
+      PaintNode::new(
+        "div.card",
+        "div",
+        10.0,
+        20.0,
+        100.0,
+        50.0,
+        {
+          ..PaintProperties::default(),
+          background_color: @types.Color::rgb(240, 240, 240),
+        },
+        [make_text_node("Hello", false, false, false, false)],
+      ),
+    ],
+  )
+  let after = PaintNode::new(
+    "body",
+    "body",
+    0.0,
+    0.0,
+    200.0,
+    120.0,
+    PaintProperties::default(),
+    [
+      PaintNode::new(
+        "div.card",
+        "div",
+        14.0,
+        20.0,
+        100.0,
+        60.0,
+        {
+          ..PaintProperties::default(),
+          background_color: @types.Color::rgb(255, 0, 0),
+        },
+        [make_text_node("Hello", true, true, true, true)],
+      ),
+    ],
+  )
+
+  let diff = diff_trees(before, after)
+  inspect(diff.layout_shifts.length(), content="1")
+  inspect(
+    has_property_change(diff, "div.card", "background_color"),
+    content="true",
+  )
+  inspect(has_property_change(diff, "#text", "is_bold"), content="true")
+  inspect(
+    has_property_change(diff, "#text", "text_decoration_underline"),
+    content="true",
+  )
+  inspect(
+    has_property_change(diff, "#text", "text_decoration_line_through"),
+    content="true",
+  )
+  inspect(
+    has_property_change(diff, "#text", "text_decoration_overline"),
+    content="true",
+  )
+}

--- a/src/paint/paint.mbt
+++ b/src/paint/paint.mbt
@@ -33,6 +33,8 @@ pub(all) struct PaintProperties {
   overflow_x : @types.Overflow
   overflow_y : @types.Overflow
   text_decoration_underline : Bool
+  text_decoration_line_through : Bool
+  text_decoration_overline : Bool
   border_top_width : Double
   border_right_width : Double
   border_bottom_width : Double
@@ -63,6 +65,8 @@ pub fn PaintProperties::default() -> PaintProperties {
     overflow_x: @types.Visible,
     overflow_y: @types.Visible,
     text_decoration_underline: false,
+    text_decoration_line_through: false,
+    text_decoration_overline: false,
     border_top_width: 0.0,
     border_right_width: 0.0,
     border_bottom_width: 0.0,
@@ -85,7 +89,7 @@ pub fn PaintProperties::from_style(style : @style.Style) -> PaintProperties {
     background_color: style.background_color,
     background_image: style.background_image,
     font_size: style.font_size,
-    is_bold: false, // Will be set from tag name in from_node_and_layout
+    is_bold: is_bold_weight(style.font_weight),
     font_family: style.font_family,
     border_top_left_radius: style.border_top_left_radius,
     border_top_right_radius: style.border_top_right_radius,
@@ -94,6 +98,8 @@ pub fn PaintProperties::from_style(style : @style.Style) -> PaintProperties {
     overflow_x: style.overflow_x,
     overflow_y: style.overflow_y,
     text_decoration_underline: style.text_decoration_underline,
+    text_decoration_line_through: style.text_decoration_line_through,
+    text_decoration_overline: style.text_decoration_overline,
     border_top_width: 0.0, // Resolved from Layout in from_node_and_layout
     border_right_width: 0.0,
     border_bottom_width: 0.0,
@@ -147,6 +153,11 @@ pub fn PaintProperties::z_index_value(self : PaintProperties) -> Int {
     @style.ZIndex::Auto => 0
     @style.ZIndex::Value(v) => v
   }
+}
+
+///|
+fn is_bold_weight(weight : Double) -> Bool {
+  weight >= 600.0
 }
 
 // =============================================================================
@@ -247,7 +258,7 @@ pub impl Show for PaintNode with output(self, logger) {
     logger.write_string(" z:")
     self.stacking_order.output(logger)
   }
-  if not(self.paint.should_render()) {
+  if !self.paint.should_render() {
     logger.write_string(" [hidden]")
   }
   if self.paint.opacity < 1.0 {
@@ -395,7 +406,7 @@ pub fn sort_by_stacking_order(nodes : Array[PaintNode]) -> Array[PaintNode] {
       break
     }
   }
-  if not(needs_sort) {
+  if !needs_sort {
     return nodes
   }
   // Create a copy to sort
@@ -438,7 +449,7 @@ pub fn flatten_for_rendering(node : PaintNode) -> Array[PaintNode] {
   let result : Array[PaintNode] = []
   fn collect(n : PaintNode, arr : Array[PaintNode]) -> Unit {
     // Skip invisible nodes
-    if not(n.paint.should_render()) {
+    if !n.paint.should_render() {
       return
     }
     // Add this node
@@ -464,6 +475,23 @@ fn is_bold_tag(tag : String) -> Bool {
   match tag {
     "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "b" | "strong" | "th" => true
     _ => false
+  }
+}
+
+///|
+fn inherit_text_paint(
+  parent : PaintProperties,
+  child : PaintProperties,
+) -> PaintProperties {
+  {
+    ..child,
+    is_bold: child.is_bold || parent.is_bold,
+    text_decoration_underline: child.text_decoration_underline ||
+    parent.text_decoration_underline,
+    text_decoration_line_through: child.text_decoration_line_through ||
+    parent.text_decoration_line_through,
+    text_decoration_overline: child.text_decoration_overline ||
+    parent.text_decoration_overline,
   }
 }
 
@@ -542,10 +570,7 @@ pub fn from_node_and_layout(
     let child_node = node.children[node_index]
     let child_layout = layout.children[layout_index]
     let mut child = from_node_and_layout(child_node, child_layout)
-    // Propagate bold to text children
-    if paint.is_bold && not(child.paint.is_bold) {
-      child = { ..child, paint: { ..child.paint, is_bold: true } }
-    }
+    child = { ..child, paint: inherit_text_paint(paint, child.paint) }
     // Generate list marker for <li> children of <ul>/<ol>
     let child_tag = extract_tag_from_id(child_node.id)
     if child_tag == "li" {
@@ -735,12 +760,7 @@ fn from_node_and_layout_with_viewport_inner(
         child_node, child_layout, child_extent, viewport_top, viewport_bottom, abs_y,
       ) {
       Some(child) => {
-        // Propagate bold to text children
-        let mut c = if paint.is_bold && not(child.paint.is_bold) {
-          { ..child, paint: { ..child.paint, is_bold: true } }
-        } else {
-          child
-        }
+        let mut c = { ..child, paint: inherit_text_paint(paint, child.paint) }
         // Generate list marker for <li> children of <ul>/<ol>
         let child_tag = extract_tag_from_id(child_node.id)
         if child_tag == "li" {

--- a/src/paint/paint_json.mbt
+++ b/src/paint/paint_json.mbt
@@ -59,6 +59,19 @@ fn write_paint_props_json(buf : StringBuilder, p : PaintProperties) -> Unit {
   if p.is_bold {
     buf.write_string(",\"b\":true")
   }
+  if p.font_family != "" {
+    buf.write_string(",\"ff\":")
+    write_json_string(buf, p.font_family)
+  }
+  if p.text_decoration_underline {
+    buf.write_string(",\"u\":true")
+  }
+  if p.text_decoration_line_through {
+    buf.write_string(",\"lt\":true")
+  }
+  if p.text_decoration_overline {
+    buf.write_string(",\"ov\":true")
+  }
   let vis = match p.visibility {
     @style.Visibility::Visible => "visible"
     @style.Visibility::Hidden => "hidden"
@@ -80,6 +93,34 @@ fn write_paint_props_json(buf : StringBuilder, p : PaintProperties) -> Unit {
     write_json_double(buf, p.border_bottom_right_radius)
     buf.write_char(',')
     write_json_double(buf, p.border_bottom_left_radius)
+    buf.write_char(']')
+  }
+  if p.border_top_width != 0.0 ||
+    p.border_right_width != 0.0 ||
+    p.border_bottom_width != 0.0 ||
+    p.border_left_width != 0.0 {
+    buf.write_string(",\"bw\":[")
+    write_json_double(buf, p.border_top_width)
+    buf.write_char(',')
+    write_json_double(buf, p.border_right_width)
+    buf.write_char(',')
+    write_json_double(buf, p.border_bottom_width)
+    buf.write_char(',')
+    write_json_double(buf, p.border_left_width)
+    buf.write_char(']')
+  }
+  if p.border_top_color != @types.Color::transparent() ||
+    p.border_right_color != @types.Color::transparent() ||
+    p.border_bottom_color != @types.Color::transparent() ||
+    p.border_left_color != @types.Color::transparent() {
+    buf.write_string(",\"bc\":[")
+    write_color_json(buf, p.border_top_color)
+    buf.write_char(',')
+    write_color_json(buf, p.border_right_color)
+    buf.write_char(',')
+    write_color_json(buf, p.border_bottom_color)
+    buf.write_char(',')
+    write_color_json(buf, p.border_left_color)
     buf.write_char(']')
   }
   buf.write_char('}')

--- a/src/paint/paint_json_test.mbt
+++ b/src/paint/paint_json_test.mbt
@@ -33,3 +33,31 @@ test "PaintNode::to_json_string basic" {
   assert_true(json.contains("\"text\":\"Hello\""))
   assert_true(json.contains("\"bg\":[238,238,238,"))
 }
+
+///|
+test "PaintNode::to_json_string includes decoration flags" {
+  let node = PaintNode::new(
+    "#text",
+    "#text",
+    0.0,
+    0.0,
+    80.0,
+    20.0,
+    {
+      ..PaintProperties::default(),
+      is_bold: true,
+      font_family: "ahem",
+      text_decoration_underline: true,
+      text_decoration_line_through: true,
+      text_decoration_overline: true,
+    },
+    [],
+    text=Some("Hello"),
+  )
+  let json = node.to_json_string()
+  assert_true(json.contains("\"b\":true"))
+  assert_true(json.contains("\"ff\":\"ahem\""))
+  assert_true(json.contains("\"u\":true"))
+  assert_true(json.contains("\"lt\":true"))
+  assert_true(json.contains("\"ov\":true"))
+}

--- a/src/paint/pkg.generated.mbti
+++ b/src/paint/pkg.generated.mbti
@@ -10,6 +10,8 @@ import {
 // Values
 pub fn collect_scrollable_elements(PaintNode) -> Array[ScrollableElement]
 
+pub fn diff_trees(PaintNode, PaintNode) -> PaintTreeDiff
+
 pub fn find_scrollable_at(PaintNode, Double, Double, Double, Double) -> ScrollableHitResult?
 
 pub fn flatten_for_rendering(PaintNode) -> Array[PaintNode]
@@ -27,6 +29,15 @@ pub fn sort_tree_by_stacking_order(PaintNode) -> PaintNode
 // Errors
 
 // Types and methods
+pub(all) struct PaintLayoutShift {
+  node_path : String
+  node_id : String
+  dx : Double
+  dy : Double
+  dw : Double
+  dh : Double
+}
+
 pub(all) struct PaintNode {
   id : String
   tag : String
@@ -75,6 +86,8 @@ pub(all) struct PaintProperties {
   overflow_x : @types.Overflow
   overflow_y : @types.Overflow
   text_decoration_underline : Bool
+  text_decoration_line_through : Bool
+  text_decoration_overline : Bool
   border_top_width : Double
   border_right_width : Double
   border_bottom_width : Double
@@ -90,6 +103,19 @@ pub fn PaintProperties::from_style(@style.Style) -> Self
 pub fn PaintProperties::should_render(Self) -> Bool
 pub fn PaintProperties::z_index_value(Self) -> Int
 pub impl Show for PaintProperties
+
+pub(all) struct PaintPropertyChange {
+  node_path : String
+  node_id : String
+  property : String
+  before : String?
+  after : String?
+}
+
+pub(all) struct PaintTreeDiff {
+  changes : Array[PaintPropertyChange]
+  layout_shifts : Array[PaintLayoutShift]
+}
 
 pub(all) struct ScrollableElement {
   id : String

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "mizchi/crater"
 
 import {
   "mizchi/crater/layout/node",
+  "mizchi/crater/paint",
   "mizchi/crater/types",
   "mizchi/crater/x/webvitals",
 }
@@ -21,6 +22,14 @@ pub fn compute_layout(@node.Node, @types.Size[Double]) -> @types.Layout
 pub fn compute_layout_with_warnings(@node.Node, @types.Size[Double]) -> @types.LayoutResult
 
 pub fn compute_total_cls(Array[@types.BoundingRect], Array[@types.BoundingRect], @types.Size[Double]) -> Double
+
+pub fn diff_rendered_paint_trees(String, String, @types.Size[Double]) -> @paint.PaintTreeDiff
+
+pub fn render_html_to_paint_tree(String, @types.Size[Double]) -> @paint.PaintNode
+
+pub fn render_html_to_paint_tree_json(String, @types.Size[Double]) -> String
+
+pub fn render_html_to_paint_tree_with_external_css(String, @types.Size[Double], Array[String]) -> @paint.PaintNode
 
 pub fn validate_core_subset(@node.Node) -> Array[CoreIssue]
 

--- a/src/renderer/renderer.mbt
+++ b/src/renderer/renderer.mbt
@@ -6990,13 +6990,18 @@ fn get_ua_default_style(tag : String) -> @style.Style {
         display: @types.Inline,
         text_decoration_underline: true,
       }
+    "s" | "strike" | "del" =>
+      {
+        ..default_style,
+        display: @types.Inline,
+        text_decoration_line_through: true,
+      }
     // Inline elements - HTML default display: inline
     "span"
     | "em"
     | "strong"
     | "i"
     | "b"
-    | "s"
     | "code"
     | "abbr"
     | "cite"

--- a/src/scheduler/pkg.generated.mbti
+++ b/src/scheduler/pkg.generated.mbti
@@ -94,8 +94,7 @@ pub(all) enum FetchResult {
   Success(response~ : NetworkResponse)
   Redirect(location~ : String, status~ : Int)
   Failure(error~ : String)
-}
-pub impl Show for FetchResult
+} derive(Show)
 
 pub(all) enum HttpMethod {
   GET
@@ -105,11 +104,9 @@ pub(all) enum HttpMethod {
   HEAD
   OPTIONS
   PATCH
-}
+} derive(Eq, Show)
 pub fn HttpMethod::from_string(String) -> Self
 pub fn HttpMethod::to_string(Self) -> String
-pub impl Eq for HttpMethod
-pub impl Show for HttpMethod
 
 pub(all) struct ImageRegistration {
   resource_id : @tree.ResourceId
@@ -126,8 +123,7 @@ pub(all) enum InputEvent {
   Mouse(MouseEvent)
   Keyboard(KeyboardEvent)
   Text(String)
-}
-pub impl Show for InputEvent
+} derive(Show)
 
 pub struct InputManager {
   pending_events : Array[InputEvent]
@@ -144,9 +140,7 @@ pub(all) enum KeyEventType {
   KeyUp
   RawKeyDown
   Char
-}
-pub impl Eq for KeyEventType
-pub impl Show for KeyEventType
+} derive(Eq, Show)
 
 pub(all) struct KeyboardEvent {
   event_type : KeyEventType
@@ -155,12 +149,11 @@ pub(all) struct KeyboardEvent {
   modifiers : Int
   text : String?
   timestamp : Double
-}
+} derive(Show)
 pub fn KeyboardEvent::new(KeyEventType, String) -> Self
 pub fn KeyboardEvent::with_code(Self, String) -> Self
 pub fn KeyboardEvent::with_modifiers(Self, Int) -> Self
 pub fn KeyboardEvent::with_text(Self, String) -> Self
-pub impl Show for KeyboardEvent
 
 pub(all) struct LayoutComputeResult {
   layout : @types.Layout
@@ -209,9 +202,7 @@ pub(all) enum MouseButton {
   Right
   Back
   Forward
-}
-pub impl Eq for MouseButton
-pub impl Show for MouseButton
+} derive(Eq, Show)
 
 pub(all) struct MouseEvent {
   event_type : MouseEventType
@@ -222,29 +213,25 @@ pub(all) struct MouseEvent {
   click_count : Int
   modifiers : Int
   timestamp : Double
-}
+} derive(Show)
 pub fn MouseEvent::new(MouseEventType, Double, Double) -> Self
 pub fn MouseEvent::with_button(Self, MouseButton) -> Self
 pub fn MouseEvent::with_modifiers(Self, Int) -> Self
-pub impl Show for MouseEvent
 
 pub(all) enum MouseEventType {
   MousePressed
   MouseReleased
   MouseMoved
   MouseWheel
-}
-pub impl Eq for MouseEventType
-pub impl Show for MouseEventType
+} derive(Eq, Show)
 
 pub(all) enum NetworkEvent {
   RequestWillBeSent(NetworkRequest)
   ResponseReceived(NetworkResponse)
   LoadingFinished(request_id~ : RequestId, encoded_data_length~ : Int)
   LoadingFailed(request_id~ : RequestId, error~ : String)
-}
+} derive(Show)
 pub fn NetworkEvent::request_id(Self) -> RequestId
-pub impl Show for NetworkEvent
 
 pub struct NetworkManager {
   pending_requests : Map[Int, NetworkRequest]
@@ -272,12 +259,11 @@ pub(all) struct NetworkRequest {
   frame_id : String
   loader_id : String
   timestamp : Double
-}
+} derive(Show)
 pub fn NetworkRequest::new(String, ResourceType, document_url? : String, frame_id? : String, http_method? : HttpMethod) -> Self
 pub fn NetworkRequest::with_headers(Self, Map[String, String]) -> Self
 pub fn NetworkRequest::with_loader_id(Self, String) -> Self
 pub fn NetworkRequest::with_timestamp(Self, Double) -> Self
-pub impl Show for NetworkRequest
 
 pub(all) struct NetworkResponse {
   request_id : RequestId
@@ -290,14 +276,13 @@ pub(all) struct NetworkResponse {
   content_length : Int
   timestamp : Double
   loader_id : String
-}
+} derive(Show)
 pub fn NetworkResponse::new(RequestId, String, Int) -> Self
 pub fn NetworkResponse::with_body(Self, String) -> Self
 pub fn NetworkResponse::with_headers(Self, Map[String, String]) -> Self
 pub fn NetworkResponse::with_loader_id(Self, String) -> Self
 pub fn NetworkResponse::with_mime_type(Self, String) -> Self
 pub fn NetworkResponse::with_timestamp(Self, Double) -> Self
-pub impl Show for NetworkResponse
 
 pub(all) struct ParseCompleteResult {
   root : @html.Element
@@ -316,13 +301,10 @@ pub(all) struct RenderPipelineResult {
   image_decode_tasks : Array[TaskId]
 }
 
-pub(all) struct RequestId(Int)
+pub(all) struct RequestId(Int) derive(Eq, Hash, Show)
 #deprecated
 pub fn RequestId::inner(Self) -> Int
 pub fn RequestId::next() -> Self
-pub impl Eq for RequestId
-pub impl Hash for RequestId
-pub impl Show for RequestId
 
 pub(all) struct ResizeResult {
   resized : Bool
@@ -346,9 +328,7 @@ pub(all) enum ResourceType {
   Image
   Font
   Other
-}
-pub impl Eq for ResourceType
-pub impl Show for ResourceType
+} derive(Eq, Show)
 
 pub struct Scheduler {
   tasks : Map[Int, Task]
@@ -436,26 +416,21 @@ pub(all) enum TaskAction {
   FetchResource(url~ : String, resource_type~ : ResourceType)
   DecodeImage(resource_id~ : Int)
   ExecuteScript(source~ : String)
-}
+} derive(Show)
 pub fn TaskAction::is_internal(Self) -> Bool
 pub fn TaskAction::source(Self) -> TaskSource
-pub impl Show for TaskAction
 
 pub(all) enum TaskConstraint {
   MainThreadOnly
   Parallel
   Blocking(Array[TaskSource])
-}
+} derive(Show)
 pub fn TaskConstraint::blocks(Self, TaskSource) -> Bool
 pub fn TaskConstraint::is_parallel(Self) -> Bool
-pub impl Show for TaskConstraint
 
-pub(all) struct TaskId(Int)
+pub(all) struct TaskId(Int) derive(Eq, Hash, Show)
 #deprecated
 pub fn TaskId::inner(Self) -> Int
-pub impl Eq for TaskId
-pub impl Hash for TaskId
-pub impl Show for TaskId
 
 pub struct TaskQueue {
   tasks : Array[Task]
@@ -477,8 +452,7 @@ pub(all) enum TaskResult {
   Success(new_tasks~ : Array[TaskAction])
   Failure(error~ : String)
   Cancelled
-}
-pub impl Show for TaskResult
+} derive(Show)
 
 pub(all) enum TaskSource {
   DOM
@@ -487,10 +461,7 @@ pub(all) enum TaskSource {
   Networking
   Scripting
   ImageDecode
-}
-pub impl Eq for TaskSource
-pub impl Hash for TaskSource
-pub impl Show for TaskSource
+} derive(Eq, Hash, Show)
 
 pub(all) enum TaskState {
   Pending
@@ -499,10 +470,9 @@ pub(all) enum TaskState {
   Completed
   Cancelled
   Failed(String)
-}
+} derive(Show)
 pub fn TaskState::is_runnable(Self) -> Bool
 pub fn TaskState::is_terminal(Self) -> Bool
-pub impl Show for TaskState
 
 // Type aliases
 

--- a/src/style/pkg.generated.mbti
+++ b/src/style/pkg.generated.mbti
@@ -13,9 +13,7 @@ import {
 pub(all) enum BorderCollapse {
   Separate
   Collapse
-}
-pub impl Eq for BorderCollapse
-pub impl Show for BorderCollapse
+} derive(Eq, Show)
 
 pub(all) enum BorderStyle {
   None
@@ -28,46 +26,34 @@ pub(all) enum BorderStyle {
   Solid
   Double
   Hidden
-}
+} derive(Eq, Show)
 pub fn BorderStyle::priority(Self) -> Int
-pub impl Eq for BorderStyle
-pub impl Show for BorderStyle
 
 pub(all) enum BreakBefore {
   Auto
   Column
   Avoid
-}
-pub impl Eq for BreakBefore
-pub impl Show for BreakBefore
+} derive(Eq, Show)
 
 pub(all) enum BreakInside {
   Auto
   Avoid
-}
-pub impl Eq for BreakInside
-pub impl Show for BreakInside
+} derive(Eq, Show)
 
 pub(all) enum CaptionSide {
   Top
   Bottom
-}
-pub impl Eq for CaptionSide
-pub impl Show for CaptionSide
+} derive(Eq, Show)
 
 pub(all) enum ColumnFill {
   Balance
   Auto
-}
-pub impl Eq for ColumnFill
-pub impl Show for ColumnFill
+} derive(Eq, Show)
 
 pub(all) enum ColumnSpan {
   None
   All
-}
-pub impl Eq for ColumnSpan
-pub impl Show for ColumnSpan
+} derive(Eq, Show)
 
 pub(all) struct Contain {
   size : Bool
@@ -75,21 +61,17 @@ pub(all) struct Contain {
   layout : Bool
   paint : Bool
   style : Bool
-}
+} derive(Eq, Show)
 pub fn Contain::content() -> Self
 pub fn Contain::has_containment(Self) -> Bool
 pub fn Contain::none() -> Self
 pub fn Contain::strict() -> Self
-pub impl Eq for Contain
-pub impl Show for Contain
 
 pub(all) enum Direction {
   Ltr
   Rtl
-}
+} derive(Eq, Show)
 pub fn Direction::is_rtl(Self) -> Bool
-pub impl Eq for Direction
-pub impl Show for Direction
 
 pub(all) enum MarginTrim {
   None
@@ -99,55 +81,43 @@ pub(all) enum MarginTrim {
   InlineStart
   InlineEnd
   Inline
-}
+} derive(Eq, Show)
 pub fn MarginTrim::trim_block_end(Self) -> Bool
 pub fn MarginTrim::trim_block_start(Self) -> Bool
-pub impl Eq for MarginTrim
-pub impl Show for MarginTrim
 
 pub(all) enum PointerEvents {
   Auto
   None
-}
-pub impl Eq for PointerEvents
-pub impl Show for PointerEvents
+} derive(Eq, Show)
 
 pub(all) enum ScrollSnapAlign {
   None
   Start
   End
   Center
-}
-pub impl Eq for ScrollSnapAlign
-pub impl Show for ScrollSnapAlign
+} derive(Eq, Show)
 
 pub(all) enum ScrollSnapAxis {
   None
   X
   Y
   Both
-}
-pub impl Eq for ScrollSnapAxis
-pub impl Show for ScrollSnapAxis
+} derive(Eq, Show)
 
 pub(all) enum ScrollSnapStrictness {
   None
   Mandatory
   Proximity
-}
-pub impl Eq for ScrollSnapStrictness
-pub impl Show for ScrollSnapStrictness
+} derive(Eq, Show)
 
 pub(all) struct ScrollSnapType {
   axis : ScrollSnapAxis
   strictness : ScrollSnapStrictness
-}
+} derive(Eq, Show)
 pub fn ScrollSnapType::is_mandatory(Self) -> Bool
 pub fn ScrollSnapType::none() -> Self
 pub fn ScrollSnapType::snaps_x(Self) -> Bool
 pub fn ScrollSnapType::snaps_y(Self) -> Bool
-pub impl Eq for ScrollSnapType
-pub impl Show for ScrollSnapType
 
 pub(all) struct Style {
   mut display : @types.Display
@@ -241,6 +211,8 @@ pub(all) struct Style {
   mut border_bottom_right_radius : Double
   mut border_bottom_left_radius : Double
   mut text_decoration_underline : Bool
+  mut text_decoration_line_through : Bool
+  mut text_decoration_overline : Bool
   mut letter_spacing : Double
   mut word_spacing : Double
 }
@@ -254,9 +226,7 @@ pub fn Style::suppresses_intrinsic_width(Self) -> Bool
 pub(all) enum TableLayout {
   Auto
   Fixed
-}
-pub impl Eq for TableLayout
-pub impl Show for TableLayout
+} derive(Eq, Show)
 
 pub(all) enum TextAlign {
   Start
@@ -265,30 +235,24 @@ pub(all) enum TextAlign {
   Right
   Center
   Justify
-}
-pub impl Eq for TextAlign
-pub impl Show for TextAlign
+} derive(Eq, Show)
 
 pub(all) struct Transform {
   translate_x : TranslateValue
   translate_y : TranslateValue
   scale_x : Double
   scale_y : Double
-}
+} derive(Eq, Show)
 pub fn Transform::compute_translate_x(Self, Double) -> Double
 pub fn Transform::compute_translate_y(Self, Double) -> Double
 pub fn Transform::has_scale(Self) -> Bool
 pub fn Transform::is_none(Self) -> Bool
 pub fn Transform::none() -> Self
-pub impl Eq for Transform
-pub impl Show for Transform
 
 pub(all) enum TranslateValue {
   Length(Double)
   Percent(Double)
-}
-pub impl Eq for TranslateValue
-pub impl Show for TranslateValue
+} derive(Eq, Show)
 
 pub(all) enum VerticalAlign {
   Baseline
@@ -299,17 +263,13 @@ pub(all) enum VerticalAlign {
   TextBottom
   Sub
   Super
-}
-pub impl Eq for VerticalAlign
-pub impl Show for VerticalAlign
+} derive(Eq, Show)
 
 pub(all) enum Visibility {
   Visible
   Hidden
   Collapse
-}
-pub impl Eq for Visibility
-pub impl Show for Visibility
+} derive(Eq, Show)
 
 pub(all) enum WhiteSpace {
   Normal
@@ -317,26 +277,20 @@ pub(all) enum WhiteSpace {
   Pre
   PreWrap
   PreLine
-}
-pub impl Eq for WhiteSpace
-pub impl Show for WhiteSpace
+} derive(Eq, Show)
 
 pub(all) enum WritingMode {
   HorizontalTb
   VerticalRl
   VerticalLr
-}
+} derive(Eq, Show)
 pub fn WritingMode::is_block_rtl(Self) -> Bool
 pub fn WritingMode::is_vertical(Self) -> Bool
-pub impl Eq for WritingMode
-pub impl Show for WritingMode
 
 pub(all) enum ZIndex {
   Auto
   Value(Int)
-}
-pub impl Eq for ZIndex
-pub impl Show for ZIndex
+} derive(Eq, Show)
 
 // Type aliases
 

--- a/src/style/style.mbt
+++ b/src/style/style.mbt
@@ -560,6 +560,8 @@ pub(all) struct Style {
   mut border_bottom_left_radius : Double
   // Text decoration
   mut text_decoration_underline : Bool
+  mut text_decoration_line_through : Bool
+  mut text_decoration_overline : Bool
   // Letter/word spacing
   mut letter_spacing : Double // in pixels, 0 = normal
   mut word_spacing : Double // in pixels, 0 = normal
@@ -684,6 +686,8 @@ pub fn Style::default() -> Style {
     border_bottom_right_radius: 0.0,
     border_bottom_left_radius: 0.0,
     text_decoration_underline: false,
+    text_decoration_line_through: false,
+    text_decoration_overline: false,
     letter_spacing: 0.0,
     word_spacing: 0.0,
   }

--- a/src/svg/pkg.generated.mbti
+++ b/src/svg/pkg.generated.mbti
@@ -142,9 +142,7 @@ pub(all) enum Align {
   XMinYMax
   XMidYMax
   XMaxYMax
-}
-pub impl Eq for Align
-pub impl Show for Align
+} derive(Eq, Show)
 
 pub(all) enum AnimProperty {
   TranslateX(Double)
@@ -208,9 +206,7 @@ pub(all) enum BlendMode {
   Saturation
   ColorMode
   Luminosity
-}
-pub impl Eq for BlendMode
-pub impl Show for BlendMode
+} derive(Eq, Show)
 
 pub(all) struct BoundingBox {
   min_x : Double
@@ -305,10 +301,8 @@ pub(all) enum Easing {
   EaseInCubic
   EaseOutCubic
   EaseInOutCubic
-}
+} derive(Eq, Show)
 pub fn Easing::apply(Self, Double) -> Double
-pub impl Eq for Easing
-pub impl Show for Easing
 
 pub(all) struct EmitterConfig {
   emit_rate : Double
@@ -361,16 +355,12 @@ pub(all) enum EventType {
   DragStart
   DragMove
   DragEnd
-}
-pub impl Eq for EventType
-pub impl Show for EventType
+} derive(Eq, Show)
 
 pub(all) enum FillRule {
   NonZero
   EvenOdd
-}
-pub impl Eq for FillRule
-pub impl Show for FillRule
+} derive(Eq, Show)
 
 pub(all) enum Filter {
   Blur(Double)
@@ -435,25 +425,19 @@ pub fn Image::sub_image(Self, Int, Int, Int, Int) -> Self
 pub(all) enum Isolation {
   Auto
   Isolate
-}
-pub impl Eq for Isolation
-pub impl Show for Isolation
+} derive(Eq, Show)
 
 pub(all) enum LineCap {
   Butt
   Round
   Square
-}
-pub impl Eq for LineCap
-pub impl Show for LineCap
+} derive(Eq, Show)
 
 pub(all) enum LineJoin {
   Miter
   Round
   Bevel
-}
-pub impl Eq for LineJoin
-pub impl Show for LineJoin
+} derive(Eq, Show)
 
 pub(all) struct LinearGradient {
   x1 : Double
@@ -537,23 +521,17 @@ pub fn MaskRegistry::new() -> Self
 pub(all) enum MaskType {
   Luminance
   Alpha
-}
-pub impl Eq for MaskType
-pub impl Show for MaskType
+} derive(Eq, Show)
 
 pub(all) enum MaskUnits {
   UserSpaceOnUse
   ObjectBoundingBox
-}
-pub impl Eq for MaskUnits
-pub impl Show for MaskUnits
+} derive(Eq, Show)
 
 pub(all) enum MeetOrSlice {
   Meet
   Slice
-}
-pub impl Eq for MeetOrSlice
-pub impl Show for MeetOrSlice
+} derive(Eq, Show)
 
 pub(all) struct ObjectPool[T] {
   available : Array[T]
@@ -577,9 +555,7 @@ pub(all) enum PaintOrder {
   StrokeFirst
   FillOnly
   StrokeOnly
-}
-pub impl Eq for PaintOrder
-pub impl Show for PaintOrder
+} derive(Eq, Show)
 
 pub(all) struct Particle {
   mut x : Double
@@ -626,8 +602,7 @@ pub(all) enum PathCommand {
   QuadraticCurveToRel(Double, Double, Double, Double)
   SmoothQuadraticCurveToRel(Double, Double)
   ArcToRel(Double, Double, Double, Bool, Bool, Double, Double)
-}
-pub impl Show for PathCommand
+} derive(Show)
 
 pub(all) struct PathFollower {
   path : Array[PathCommand]
@@ -780,8 +755,7 @@ pub(all) enum Shape {
   Path(commands~ : Array[PathCommand])
   Text(x~ : Double, y~ : Double, text~ : String, font_size~ : Double)
   Group
-}
-pub impl Show for Shape
+} derive(Show)
 
 pub(all) struct SimpleRNG {
   mut state : Int
@@ -794,9 +768,7 @@ pub(all) enum SpreadMethod {
   Pad
   Repeat
   Reflect
-}
-pub impl Eq for SpreadMethod
-pub impl Show for SpreadMethod
+} derive(Eq, Show)
 
 pub(all) struct Sprite {
   image : Image
@@ -880,9 +852,7 @@ pub(all) enum TextDecoration {
   Underline
   Overline
   LineThrough
-}
-pub impl Eq for TextDecoration
-pub impl Show for TextDecoration
+} derive(Eq, Show)
 
 pub(all) struct TextDecorationFull {
   line : TextDecoration
@@ -898,25 +868,19 @@ pub(all) enum TextDecorationStyle {
   Dotted
   Dashed
   Wavy
-}
-pub impl Eq for TextDecorationStyle
-pub impl Show for TextDecorationStyle
+} derive(Eq, Show)
 
 pub(all) enum TextOrientation {
   Mixed
   Upright
   Sideways
-}
-pub impl Eq for TextOrientation
-pub impl Show for TextOrientation
+} derive(Eq, Show)
 
 pub(all) enum TextOverflow {
   Clip
   Ellipsis
   Custom(String)
-}
-pub impl Eq for TextOverflow
-pub impl Show for TextOverflow
+} derive(Eq, Show)
 
 pub(all) struct TextSpan {
   text : String
@@ -1018,17 +982,13 @@ pub(all) enum WhiteSpace {
   PreWrap
   PreLine
   BreakSpaces
-}
-pub impl Eq for WhiteSpace
-pub impl Show for WhiteSpace
+} derive(Eq, Show)
 
 pub(all) enum WritingMode {
   HorizontalTB
   VerticalRL
   VerticalLR
-}
-pub impl Eq for WritingMode
-pub impl Show for WritingMode
+} derive(Eq, Show)
 
 // Type aliases
 

--- a/src/types/pkg.generated.mbti
+++ b/src/types/pkg.generated.mbti
@@ -28,9 +28,7 @@ pub(all) enum AlignSelf {
   Center
   Stretch
   Baseline
-}
-pub impl Eq for AlignSelf
-pub impl Show for AlignSelf
+} derive(Eq, Show)
 
 pub(all) enum Alignment {
   Start
@@ -45,15 +43,12 @@ pub(all) enum Alignment {
   SpaceEvenly
   Stretch
   Baseline
-}
-pub impl Eq for Alignment
-pub impl Show for Alignment
+} derive(Eq, Show)
 
 pub(all) enum BackgroundImage {
   None
   Gradient(LinearGradient)
-}
-pub impl Show for BackgroundImage
+} derive(Show)
 
 pub(all) struct BoundingRect {
   x : Double
@@ -72,25 +67,20 @@ pub impl Show for BoundingRect
 pub(all) enum BoxSizing {
   ContentBox
   BorderBox
-}
-pub impl Eq for BoxSizing
-pub impl Show for BoxSizing
+} derive(Eq, Show)
 
 pub(all) enum Clear {
   None
   Left
   Right
   Both
-}
-pub impl Eq for Clear
-pub impl Show for Clear
+} derive(Eq, Show)
 
 pub(all) enum ClipRect {
   Auto
   Rect(top~ : Double, right~ : Double, bottom~ : Double, left~ : Double)
-}
+} derive(Eq)
 pub fn ClipRect::default() -> Self
-pub impl Eq for ClipRect
 pub impl Show for ClipRect
 
 pub(all) struct Color {
@@ -118,7 +108,7 @@ pub(all) enum Dimension {
   MinContent
   MaxContent
   FitContent(Double)
-}
+} derive(Eq)
 pub fn Dimension::eq_length(Self, Double) -> Bool
 pub fn Dimension::eq_percent(Self, Double) -> Bool
 pub fn Dimension::is_definite(Self) -> Bool
@@ -126,7 +116,6 @@ pub fn Dimension::is_intrinsic(Self) -> Bool
 pub fn Dimension::resolve(Self, Double) -> Double?
 pub fn Dimension::resolve_or(Self, Double, Double) -> Double
 pub fn Dimension::resolve_or_intrinsic(Self, Double, Double) -> Double
-pub impl Eq for Dimension
 pub impl Show for Dimension
 
 pub(all) enum Display {
@@ -150,65 +139,50 @@ pub(all) enum Display {
   None
   Contents
   FlowRoot
-}
-pub impl Eq for Display
-pub impl Show for Display
+} derive(Eq, Show)
 
 pub(all) enum FlexDirection {
   Row
   RowReverse
   Column
   ColumnReverse
-}
-pub impl Eq for FlexDirection
-pub impl Show for FlexDirection
+} derive(Eq, Show)
 
 pub(all) enum FlexWrap {
   NoWrap
   Wrap
   WrapReverse
-}
-pub impl Eq for FlexWrap
-pub impl Show for FlexWrap
+} derive(Eq, Show)
 
 pub(all) enum Float {
   None
   Left
   Right
-}
-pub impl Eq for Float
-pub impl Show for Float
+} derive(Eq, Show)
 
 pub(all) struct GradientStop {
   color : Color
   position : Double
-}
-pub impl Show for GradientStop
+} derive(Show)
 
 pub(all) enum GridAutoFlow {
   Row
   Column
   RowDense
   ColumnDense
-}
-pub impl Eq for GridAutoFlow
-pub impl Show for GridAutoFlow
+} derive(Eq, Show)
 
 pub(all) struct GridLine {
   start : GridPlacement
   end : GridPlacement
-}
+} derive(Eq, Show)
 pub fn GridLine::auto() -> Self
-pub impl Eq for GridLine
-pub impl Show for GridLine
 
 pub(all) enum GridPlacement {
   Auto
   Line(Int)
   Span(Int)
-}
-pub impl Eq for GridPlacement
-pub impl Show for GridPlacement
+} derive(Eq, Show)
 
 pub(all) struct IntrinsicSize {
   min_width : Double
@@ -255,8 +229,7 @@ pub(all) enum LayoutWarning {
   UnsupportedFloat(String)
   UnsupportedPosition(String)
   UnsupportedDisplay(String)
-}
-pub impl Show for LayoutWarning
+} derive(Show)
 
 pub struct Line[T] {
   start : T
@@ -268,8 +241,7 @@ pub impl[T : Show] Show for Line[T]
 pub(all) struct LinearGradient {
   angle_deg : Double
   stops : Array[GradientStop]
-}
-pub impl Show for LinearGradient
+} derive(Show)
 
 pub(all) enum MaxTrackSizing {
   Length(Double)
@@ -278,9 +250,7 @@ pub(all) enum MaxTrackSizing {
   Auto
   MinContent
   MaxContent
-}
-pub impl Eq for MaxTrackSizing
-pub impl Show for MaxTrackSizing
+} derive(Eq, Show)
 
 pub(all) struct MeasureFunc {
   func : (Double, Double) -> IntrinsicSize
@@ -292,9 +262,7 @@ pub(all) enum MinTrackSizing {
   Auto
   MinContent
   MaxContent
-}
-pub impl Eq for MinTrackSizing
-pub impl Show for MinTrackSizing
+} derive(Eq, Show)
 
 pub(all) enum Overflow {
   Visible
@@ -302,9 +270,7 @@ pub(all) enum Overflow {
   Clip
   Scroll
   Auto
-}
-pub impl Eq for Overflow
-pub impl Show for Overflow
+} derive(Eq, Show)
 
 pub struct Point[T] {
   x : T
@@ -320,9 +286,7 @@ pub(all) enum Position {
   Relative
   Absolute
   Fixed
-}
-pub impl Eq for Position
-pub impl Show for Position
+} derive(Eq, Show)
 
 pub(all) struct Rect[T] {
   left : T
@@ -342,9 +306,7 @@ pub(all) enum RepeatCount {
   Count(Int)
   AutoFill
   AutoFit
-}
-pub impl Eq for RepeatCount
-pub impl Show for RepeatCount
+} derive(Eq, Show)
 
 pub(all) enum SingleTrackSizing {
   Length(Double)
@@ -356,9 +318,7 @@ pub(all) enum SingleTrackSizing {
   MinMax(MinTrackSizing, MaxTrackSizing)
   FitContentLength(Double)
   FitContentPercent(Double)
-}
-pub impl Eq for SingleTrackSizing
-pub impl Show for SingleTrackSizing
+} derive(Eq, Show)
 
 pub struct Size[T] {
   width : T
@@ -372,8 +332,7 @@ pub impl[T : Show] Show for Size[T]
 pub(all) enum SizingMode {
   Definite
   MaxContent
-}
-pub impl Eq for SizingMode
+} derive(Eq)
 
 pub(all) enum TrackSizingFunction {
   Length(Double)
@@ -386,9 +345,7 @@ pub(all) enum TrackSizingFunction {
   Repeat(RepeatCount, Array[SingleTrackSizing])
   FitContentLength(Double)
   FitContentPercent(Double)
-}
-pub impl Eq for TrackSizingFunction
-pub impl Show for TrackSizingFunction
+} derive(Eq, Show)
 
 // Type aliases
 

--- a/src/vrt_api.mbt
+++ b/src/vrt_api.mbt
@@ -1,0 +1,61 @@
+///|
+fn make_render_context(
+  viewport : @types.Size[Double],
+) -> @renderer.RenderContext {
+  {
+    ..@renderer.RenderContext::default(),
+    viewport_width: viewport.width,
+    viewport_height: viewport.height,
+  }
+}
+
+///|
+pub fn render_html_to_paint_tree(
+  html : String,
+  viewport : @types.Size[Double],
+) -> @paint.PaintNode {
+  render_html_to_paint_tree_with_external_css(html, viewport, [])
+}
+
+///|
+pub fn render_html_to_paint_tree_with_external_css(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : Array[String],
+) -> @paint.PaintNode {
+  let (node, layout) = @renderer.render_to_node_and_layout_with_external_css(
+    html,
+    make_render_context(viewport),
+    external_css,
+  )
+  match
+    @paint.from_node_and_layout_with_viewport(
+      node,
+      layout,
+      0.0,
+      viewport.height,
+      0.0,
+    ) {
+    Some(paint_tree) => paint_tree
+    None => @paint.from_node_and_layout(node, layout)
+  }
+}
+
+///|
+pub fn render_html_to_paint_tree_json(
+  html : String,
+  viewport : @types.Size[Double],
+) -> String {
+  render_html_to_paint_tree(html, viewport).to_json_string()
+}
+
+///|
+pub fn diff_rendered_paint_trees(
+  baseline_html : String,
+  current_html : String,
+  viewport : @types.Size[Double],
+) -> @paint.PaintTreeDiff {
+  let baseline = render_html_to_paint_tree(baseline_html, viewport)
+  let current = render_html_to_paint_tree(current_html, viewport)
+  @paint.diff_trees(baseline, current)
+}

--- a/src/vrt_api_test.mbt
+++ b/src/vrt_api_test.mbt
@@ -1,0 +1,81 @@
+///|
+fn find_text_node(node : @paint.PaintNode, text : String) -> @paint.PaintNode? {
+  match node.text {
+    Some(content) => if content == text { return Some(node) }
+    None => ()
+  }
+  for child in node.children {
+    match find_text_node(child, text) {
+      Some(found) => return Some(found)
+      None => ()
+    }
+  }
+  None
+}
+
+///|
+fn has_change(
+  diff : @paint.PaintTreeDiff,
+  node_id : String,
+  property : String,
+) -> Bool {
+  for change in diff.changes {
+    if change.node_id == node_id && change.property == property {
+      return true
+    }
+  }
+  false
+}
+
+///|
+test "render_html_to_paint_tree propagates font weight and text decoration" {
+  let html =
+    #|<!DOCTYPE html>
+    #|<style>
+    #|body { margin: 0; }
+    #|.card {
+    #|  color: #123456;
+    #|  font-weight: 700;
+    #|  text-decoration: underline line-through overline;
+    #|}
+    #|</style>
+    #|<p class="card">Hello paint</p>
+  let paint_tree = render_html_to_paint_tree(
+    html,
+    @types.Size::new(240.0, 120.0),
+  )
+  match find_text_node(paint_tree, "Hello paint") {
+    Some(text_node) => {
+      inspect(text_node.paint.is_bold, content="true")
+      inspect(text_node.paint.text_decoration_underline, content="true")
+      inspect(text_node.paint.text_decoration_line_through, content="true")
+      inspect(text_node.paint.text_decoration_overline, content="true")
+    }
+    None => fail("text node not found")
+  }
+}
+
+///|
+test "diff_rendered_paint_trees reports layout and paint changes" {
+  let baseline =
+    #|<!DOCTYPE html>
+    #|<style>
+    #|body { margin: 0; }
+    #|.card { padding: 20px; background: #eeeeee; }
+    #|</style>
+    #|<div class="card"><span>Callout</span></div>
+  let current =
+    #|<!DOCTYPE html>
+    #|<style>
+    #|body { margin: 0; }
+    #|.card { padding: 0; background: #cccccc; }
+    #|</style>
+    #|<div class="card"><span>Callout</span></div>
+  let diff = diff_rendered_paint_trees(
+    baseline,
+    current,
+    @types.Size::new(240.0, 120.0),
+  )
+  inspect(has_change(diff, "div.card", "background_color"), content="true")
+  inspect(diff.layout_shifts.length() > 0, content="true")
+}

--- a/src/x/image/sixel.mbt
+++ b/src/x/image/sixel.mbt
@@ -1096,7 +1096,7 @@ fn DynamicPalette::get_or_add(self : DynamicPalette, c : Color) -> Int {
 /// Collect all colors from PaintNode tree
 fn collect_colors(palette : DynamicPalette, node : @paint.PaintNode) -> Unit {
   // Add background color if not transparent
-  if not(node.paint.background_color.is_transparent()) {
+  if !node.paint.background_color.is_transparent() {
     let _ = palette.get_or_add(
       types_color_to_sixel(node.paint.background_color),
     )
@@ -1140,6 +1140,27 @@ fn pixel_in_clip(clip : ClipRect?, px : Int, py : Int) -> Bool {
   match clip {
     None => true
     Some(c) => px >= c.x && px < c.x + c.w && py >= c.y && py < c.y + c.h
+  }
+}
+
+///|
+fn draw_text_decoration_line(
+  fb : Framebuffer,
+  palette : DynamicPalette,
+  x : Int,
+  y : Int,
+  w : Int,
+  color : @types.Color,
+  clip : ClipRect?,
+) -> Unit {
+  if y < 0 || y >= fb.height {
+    return
+  }
+  let line_color = palette.get_or_add(types_color_to_sixel(color))
+  for px = x; px < x + w && px < fb.width; px = px + 1 {
+    if px >= 0 && pixel_in_clip(clip, px, y) {
+      fb.set_pixel(px, y, line_color)
+    }
   }
 }
 
@@ -1495,7 +1516,7 @@ fn render_paint_node_clipped(
   clip : ClipRect?,
 ) -> Unit {
   // Skip invisible nodes
-  if not(node.paint.should_render()) {
+  if !node.paint.should_render() {
     return
   }
   let abs_x = parent_x + node.x
@@ -1577,7 +1598,7 @@ fn render_paint_node_clipped(
         bl_r,
       )
     @types.None =>
-      if not(node.paint.background_color.is_transparent()) {
+      if !node.paint.background_color.is_transparent() {
         if has_radius {
           fill_rounded_rect_clipped(
             fb,
@@ -1616,7 +1637,7 @@ fn render_paint_node_clipped(
   let bb = node.paint.border_bottom_width.to_int()
   let bl = node.paint.border_left_width.to_int()
   let opacity = node.paint.opacity
-  if bt > 0 && not(node.paint.border_top_color.is_transparent()) {
+  if bt > 0 && !node.paint.border_top_color.is_transparent() {
     fill_rect_clipped(
       fb,
       palette,
@@ -1629,7 +1650,7 @@ fn render_paint_node_clipped(
       clip,
     )
   }
-  if bb > 0 && not(node.paint.border_bottom_color.is_transparent()) {
+  if bb > 0 && !node.paint.border_bottom_color.is_transparent() {
     fill_rect_clipped(
       fb,
       palette,
@@ -1642,7 +1663,7 @@ fn render_paint_node_clipped(
       clip,
     )
   }
-  if bl > 0 && not(node.paint.border_left_color.is_transparent()) {
+  if bl > 0 && !node.paint.border_left_color.is_transparent() {
     fill_rect_clipped(
       fb,
       palette,
@@ -1655,7 +1676,7 @@ fn render_paint_node_clipped(
       clip,
     )
   }
-  if br > 0 && not(node.paint.border_right_color.is_transparent()) {
+  if br > 0 && !node.paint.border_right_color.is_transparent() {
     fill_rect_clipped(
       fb,
       palette,
@@ -1721,23 +1742,44 @@ fn render_paint_node_clipped(
       }
     None => ()
   }
-  // Draw underline decoration if set
+  // Draw text decorations
   match node.text {
-    Some(_) =>
-      if node.paint.text_decoration_underline {
-        let font_size = node.paint.font_size
-        let underline_y = y + (font_size * 1.1).to_int()
-        let underline_color = palette.get_or_add(
-          types_color_to_sixel(node.paint.color),
+    Some(_) => {
+      let font_size = node.paint.font_size
+      if node.paint.text_decoration_overline {
+        draw_text_decoration_line(
+          fb,
+          palette,
+          x,
+          y + (font_size * 0.15).to_int(),
+          w,
+          node.paint.color,
+          clip,
         )
-        if underline_y >= 0 && underline_y < fb.height {
-          for px = x; px < x + w && px < fb.width; px = px + 1 {
-            if px >= 0 && pixel_in_clip(clip, px, underline_y) {
-              fb.set_pixel(px, underline_y, underline_color)
-            }
-          }
-        }
       }
+      if node.paint.text_decoration_line_through {
+        draw_text_decoration_line(
+          fb,
+          palette,
+          x,
+          y + (font_size * 0.6).to_int(),
+          w,
+          node.paint.color,
+          clip,
+        )
+      }
+      if node.paint.text_decoration_underline {
+        draw_text_decoration_line(
+          fb,
+          palette,
+          x,
+          y + (font_size * 1.1).to_int(),
+          w,
+          node.paint.color,
+          clip,
+        )
+      }
+    }
     None => ()
   }
 
@@ -1880,7 +1922,7 @@ fn render_svg_into_region(
       if dst_x < 0 || dst_x >= fb.width {
         continue
       }
-      if not(pixel_in_clip(clip, dst_x, dst_y)) {
+      if !pixel_in_clip(clip, dst_x, dst_y) {
         continue
       }
       let tmp_idx = tmp_fb.pixels[py * w + px]
@@ -1940,7 +1982,7 @@ pub fn to_sixel_dynamic(fb : Framebuffer, palette : DynamicPalette) -> String {
       }
     }
     for color_idx = 0; color_idx < palette_len; color_idx = color_idx + 1 {
-      if not(active_colors[color_idx]) {
+      if !active_colors[color_idx] {
         continue
       }
       buf.write_string("#")
@@ -2027,14 +2069,13 @@ pub fn render_paint_node_to_framebuffer_scrolled(
   let mut canvas_bg = sorted_node.paint.background_color
   if canvas_bg.is_transparent() {
     for child in sorted_node.children {
-      if child.tag == "body" &&
-        not(child.paint.background_color.is_transparent()) {
+      if child.tag == "body" && !child.paint.background_color.is_transparent() {
         canvas_bg = child.paint.background_color
         break
       }
     }
   }
-  if not(canvas_bg.is_transparent()) {
+  if !canvas_bg.is_transparent() {
     let bg_sixel = { r: canvas_bg.r, g: canvas_bg.g, b: canvas_bg.b }
     let bg_idx = palette.get_or_add(bg_sixel)
     fb.fill_rect(0, 0, fb.width, fb.height, bg_idx)
@@ -2073,14 +2114,13 @@ pub fn render_paint_node_to_framebuffer(
   if canvas_bg.is_transparent() {
     // Look for body element among root's children
     for child in sorted_node.children {
-      if child.tag == "body" &&
-        not(child.paint.background_color.is_transparent()) {
+      if child.tag == "body" && !child.paint.background_color.is_transparent() {
         canvas_bg = child.paint.background_color
         break
       }
     }
   }
-  if not(canvas_bg.is_transparent()) {
+  if !canvas_bg.is_transparent() {
     let bg_sixel = { r: canvas_bg.r, g: canvas_bg.g, b: canvas_bg.b }
     let bg_idx = palette.get_or_add(bg_sixel)
     fb.fill_rect(0, 0, fb.width, fb.height, bg_idx)

--- a/src/x/webvitals/pkg.generated.mbti
+++ b/src/x/webvitals/pkg.generated.mbti
@@ -50,9 +50,7 @@ pub(all) enum LCPElementType {
   BackgroundImage(url~ : String)
   Video(poster~ : String?)
   TextBlock
-}
-pub impl Eq for LCPElementType
-pub impl Show for LCPElementType
+} derive(Eq, Show)
 
 pub(all) struct LCPTracker {
   candidates : Array[LCPCandidate]


### PR DESCRIPTION
## Summary
- add public VRT API entry points, paint-tree diffing, and VRT-focused MoonBit benchmarks
- extend paint/style compatibility for font weight and text decorations, and expose VRT bench summaries in CI
- replace the old `metrici` naming with `flaker`, add repo-side flaker config validation/reporting, and wire a dedicated CI job for it

## Validation
- `moon info`
- `moon fmt`
- `moon test src/vrt_api_test.mbt src/paint/diff_test.mbt src/paint/paint_json_test.mbt --no-render`
- `pnpm exec vitest run scripts/flaker-config.test.ts scripts/vrt-bench.test.ts`
- `just flaker-check`
- `just flaker-report /tmp/crater-flaker-report`
