### PR TITLE
Add Playwright report summaries for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,22 @@ jobs:
           path: playwright-report.json
           if-no-files-found: warn
 
+      - name: Build Playwright report summary
+        if: always()
+        run: just playwright-report-summary playwright-report.json playwright-bidi playwright-summary
+
+      - name: Publish Playwright report summary
+        if: always()
+        run: cat playwright-summary/playwright-bidi.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Playwright report summary
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-summary
+          path: playwright-summary/*
+          if-no-files-found: warn
+
   flaker-config:
     runs-on: ubuntu-latest
 
@@ -501,8 +517,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Validate flaker config tests
-        run: pnpm exec vitest run scripts/flaker-config.test.ts
+      - name: Validate flaker/report tool tests
+        run: pnpm exec vitest run scripts/flaker-config.test.ts scripts/playwright-report-summary.test.ts
 
       - name: Build flaker config summary
         run: just flaker-report flaker-report
@@ -630,6 +646,22 @@ jobs:
         with:
           name: paint-vrt-report
           path: paint-vrt-report.json
+          if-no-files-found: warn
+
+      - name: Build paint VRT report summary
+        if: always()
+        run: just playwright-report-summary paint-vrt-report.json paint-vrt paint-vrt-summary
+
+      - name: Publish paint VRT report summary
+        if: always()
+        run: cat paint-vrt-summary/paint-vrt.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload paint VRT report summary
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: paint-vrt-summary
+          path: paint-vrt-summary/*
           if-no-files-found: warn
 
       - name: Upload paint VRT artifacts

--- a/justfile
+++ b/justfile
@@ -289,6 +289,11 @@ flaker-report output_dir=".flaker/report":
     mkdir -p {{output_dir}}
     npx tsx scripts/flaker-config.ts --check --json {{output_dir}}/summary.json --markdown {{output_dir}}/summary.md | tee {{output_dir}}/summary.log
 
+# Normalize a Playwright JSON report into JSON/Markdown summary
+playwright-report-summary input label output_dir=".playwright-report":
+    mkdir -p {{output_dir}}
+    npx tsx scripts/playwright-report-summary.ts --input {{input}} --label {{label}} --json {{output_dir}}/{{label}}.json --markdown {{output_dir}}/{{label}}.md | tee {{output_dir}}/{{label}}.log
+
 # Capture a live site into real-world/ (gitignored)
 capture-realworld *args:
     pnpm capture:realworld -- {{args}}

--- a/scripts/playwright-report-summary.test.ts
+++ b/scripts/playwright-report-summary.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPlaywrightSummary,
+  renderPlaywrightMarkdown,
+  type PlaywrightJsonReport,
+} from "./playwright-report-summary.ts";
+
+function makeReport(): PlaywrightJsonReport {
+  return {
+    config: {},
+    suites: [
+      {
+        title: "tests/playwright-adapter.test.ts",
+        file: "tests/playwright-adapter.test.ts",
+        suites: [
+          {
+            title: "Playwright Adapter Tests",
+            file: "tests/playwright-adapter.test.ts",
+            specs: [
+              {
+                title: "goto and evaluate work together",
+                ok: true,
+                tags: [],
+                tests: [
+                  {
+                    projectName: "chromium",
+                    expectedStatus: "passed",
+                    status: "expected",
+                    results: [
+                      {
+                        retry: 0,
+                        workerIndex: 0,
+                        status: "passed",
+                        duration: 18,
+                        errors: [],
+                        startTime: "2026-04-01T00:00:00.000Z",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                title: "locator count",
+                ok: true,
+                tags: [],
+                tests: [
+                  {
+                    projectName: "chromium",
+                    expectedStatus: "passed",
+                    status: "flaky",
+                    results: [
+                      {
+                        retry: 0,
+                        workerIndex: 0,
+                        status: "failed",
+                        duration: 120,
+                        errors: [{ message: "first failure" }],
+                        startTime: "2026-04-01T00:00:01.000Z",
+                      },
+                      {
+                        retry: 1,
+                        workerIndex: 1,
+                        status: "passed",
+                        duration: 33,
+                        errors: [],
+                        startTime: "2026-04-01T00:00:02.000Z",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        title: "tests/paint-vrt.test.ts",
+        file: "tests/paint-vrt.test.ts",
+        specs: [
+          {
+            title: "fixture: cards and controls stay within relaxed visual diff budget",
+            ok: false,
+            tags: [],
+            tests: [
+              {
+                projectName: "chromium",
+                expectedStatus: "passed",
+                status: "unexpected",
+                results: [
+                  {
+                    retry: 0,
+                    workerIndex: 0,
+                    status: "failed",
+                    duration: 210,
+                    errors: [{ message: "visual diff exceeded" }],
+                    startTime: "2026-04-01T00:00:05.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            title: "fixture: footer with multi-column links",
+            ok: true,
+            tags: [],
+            tests: [
+              {
+                projectName: "chromium",
+                expectedStatus: "skipped",
+                status: "skipped",
+                annotations: [{ type: "skip", description: "temporarily disabled" }],
+                results: [
+                  {
+                    retry: 0,
+                    workerIndex: 0,
+                    status: "skipped",
+                    duration: 0,
+                    errors: [],
+                    startTime: "2026-04-01T00:00:06.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    errors: [],
+    stats: {
+      startTime: "2026-04-01T00:00:00.000Z",
+      duration: 381,
+      expected: 2,
+      skipped: 1,
+      unexpected: 1,
+      flaky: 1,
+    },
+  };
+}
+
+describe("buildPlaywrightSummary", () => {
+  it("normalizes rows, counts flaky tests, and groups by file", () => {
+    const summary = buildPlaywrightSummary(makeReport(), "playwright-bidi");
+
+    expect(summary.totals.total).toBe(4);
+    expect(summary.totals.passed).toBe(1);
+    expect(summary.totals.failed).toBe(1);
+    expect(summary.totals.flaky).toBe(1);
+    expect(summary.totals.skipped).toBe(1);
+    expect(summary.totals.retries).toBe(1);
+    expect(summary.files).toHaveLength(2);
+    expect(summary.files[0]?.file).toBe("tests/paint-vrt.test.ts");
+    expect(summary.files[0]?.failed).toBe(1);
+
+    const flakyRow = summary.tests.find((row) => row.title === "locator count");
+    expect(flakyRow?.outcome).toBe("flaky");
+    expect(flakyRow?.attempts).toEqual(["failed", "passed"]);
+    expect(flakyRow?.retryCount).toBe(1);
+  });
+});
+
+describe("renderPlaywrightMarkdown", () => {
+  it("renders totals, file table, and flaky section", () => {
+    const markdown = renderPlaywrightMarkdown(
+      buildPlaywrightSummary(makeReport(), "paint-vrt"),
+    );
+
+    expect(markdown).toContain("# Playwright Report Summary");
+    expect(markdown).toContain("| Label | paint-vrt |");
+    expect(markdown).toContain("| tests/paint-vrt.test.ts | 2 | 0 | 1 | 0 | 1 |");
+    expect(markdown).toContain("## Flaky / Retried Tests");
+    expect(markdown).toContain("locator count");
+    expect(markdown).toContain("failed -> passed");
+  });
+});

--- a/scripts/playwright-report-summary.ts
+++ b/scripts/playwright-report-summary.ts
@@ -1,0 +1,482 @@
+#!/usr/bin/env npx tsx
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface PlaywrightJsonResultError {
+  message?: string;
+  value?: string;
+}
+
+export interface PlaywrightJsonResult {
+  retry?: number;
+  workerIndex?: number;
+  status?: string;
+  duration?: number;
+  startTime?: string;
+  errors?: PlaywrightJsonResultError[];
+}
+
+export interface PlaywrightJsonTest {
+  projectName?: string;
+  projectId?: string;
+  expectedStatus?: string;
+  status?: string;
+  annotations?: Array<{ type?: string; description?: string }>;
+  results?: PlaywrightJsonResult[];
+}
+
+export interface PlaywrightJsonSpec {
+  title?: string;
+  ok?: boolean;
+  file?: string;
+  line?: number;
+  column?: number;
+  tags?: string[];
+  tests?: PlaywrightJsonTest[];
+}
+
+export interface PlaywrightJsonSuite {
+  title?: string;
+  file?: string;
+  line?: number;
+  column?: number;
+  specs?: PlaywrightJsonSpec[];
+  suites?: PlaywrightJsonSuite[];
+}
+
+export interface PlaywrightJsonReport {
+  config?: unknown;
+  suites?: PlaywrightJsonSuite[];
+  errors?: PlaywrightJsonResultError[];
+  stats?: {
+    startTime?: string;
+    duration?: number;
+    expected?: number;
+    skipped?: number;
+    unexpected?: number;
+    flaky?: number;
+  };
+}
+
+export type PlaywrightOutcome =
+  | "passed"
+  | "failed"
+  | "flaky"
+  | "skipped"
+  | "timedout"
+  | "interrupted"
+  | "unknown";
+
+export interface PlaywrightTestRow {
+  id: string;
+  file: string;
+  title: string;
+  titlePath: string[];
+  projectName: string;
+  expectedStatus: string;
+  rawStatus: string;
+  outcome: PlaywrightOutcome;
+  attempts: string[];
+  retryCount: number;
+  durationMs: number;
+  errorMessages: string[];
+}
+
+export interface PlaywrightFileSummary {
+  file: string;
+  total: number;
+  passed: number;
+  failed: number;
+  flaky: number;
+  skipped: number;
+  retries: number;
+  durationMs: number;
+}
+
+export interface PlaywrightSummaryTotals {
+  total: number;
+  passed: number;
+  failed: number;
+  flaky: number;
+  skipped: number;
+  timedout: number;
+  interrupted: number;
+  unknown: number;
+  retries: number;
+  durationMs: number;
+}
+
+export interface PlaywrightSummary {
+  schemaVersion: 1;
+  generatedAt: string;
+  label: string;
+  sourceFile?: string;
+  totals: PlaywrightSummaryTotals;
+  files: PlaywrightFileSummary[];
+  tests: PlaywrightTestRow[];
+}
+
+interface CliOptions {
+  input: string;
+  label?: string;
+  jsonOutput?: string;
+  markdownOutput?: string;
+}
+
+const DEFAULT_INPUT = "playwright-report.json";
+
+function usage(): string {
+  return [
+    "Playwright Report Summary",
+    "",
+    "Usage:",
+    "  npx tsx scripts/playwright-report-summary.ts [options]",
+    "",
+    "Options:",
+    `  --input <file>      Playwright JSON report (default: ${DEFAULT_INPUT})`,
+    "  --label <name>      Summary label shown in markdown/json",
+    "  --json <file>       Write normalized summary JSON",
+    "  --markdown <file>   Write markdown summary",
+    "  --help              Show this help",
+  ].join("\n");
+}
+
+function parseCliArgs(args: string[]): CliOptions {
+  const options: CliOptions = { input: DEFAULT_INPUT };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    if (arg === "--input") {
+      options.input = args[++i] ?? "";
+      continue;
+    }
+    if (arg === "--label") {
+      options.label = args[++i];
+      continue;
+    }
+    if (arg === "--json") {
+      options.jsonOutput = args[++i];
+      continue;
+    }
+    if (arg === "--markdown") {
+      options.markdownOutput = args[++i];
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.input) {
+    throw new Error("--input is required");
+  }
+
+  return options;
+}
+
+function writeOutput(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function asArray<T>(value: T[] | undefined | null): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function pickFile(
+  candidates: Array<string | undefined>,
+  fallback: string,
+): string {
+  for (const candidate of candidates) {
+    if (candidate && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+  return fallback;
+}
+
+function basenameWithoutExt(filePath: string): string {
+  const base = path.basename(filePath);
+  return base.replace(/\.[^.]+$/, "");
+}
+
+function normalizeAttemptStatus(status: string | undefined): string {
+  const normalized = (status ?? "").trim().toLowerCase();
+  if (!normalized) return "unknown";
+  return normalized;
+}
+
+function normalizeOutcome(
+  rawStatus: string,
+  attemptStatuses: string[],
+): PlaywrightOutcome {
+  if (rawStatus === "skipped") return "skipped";
+  if (rawStatus === "flaky") return "flaky";
+
+  if (attemptStatuses.includes("timedout")) return "timedout";
+  if (attemptStatuses.includes("interrupted")) return "interrupted";
+
+  const finalAttempt = attemptStatuses.at(-1) ?? "unknown";
+  if (finalAttempt === "skipped") return "skipped";
+  if (finalAttempt === "passed") {
+    const unique = new Set(attemptStatuses);
+    return unique.size > 1 ? "flaky" : "passed";
+  }
+  if (finalAttempt === "failed") return "failed";
+  if (finalAttempt === "timedout") return "timedout";
+  if (finalAttempt === "interrupted") return "interrupted";
+  return "unknown";
+}
+
+function pushCount(totals: PlaywrightSummaryTotals, outcome: PlaywrightOutcome): void {
+  totals.total += 1;
+  if (outcome === "passed") totals.passed += 1;
+  else if (outcome === "failed") totals.failed += 1;
+  else if (outcome === "flaky") totals.flaky += 1;
+  else if (outcome === "skipped") totals.skipped += 1;
+  else if (outcome === "timedout") totals.timedout += 1;
+  else if (outcome === "interrupted") totals.interrupted += 1;
+  else totals.unknown += 1;
+}
+
+function createEmptyTotals(): PlaywrightSummaryTotals {
+  return {
+    total: 0,
+    passed: 0,
+    failed: 0,
+    flaky: 0,
+    skipped: 0,
+    timedout: 0,
+    interrupted: 0,
+    unknown: 0,
+    retries: 0,
+    durationMs: 0,
+  };
+}
+
+function rowId(file: string, titlePath: string[], projectName: string): string {
+  const base = `${file}::${titlePath.join(" > ")}`;
+  return projectName ? `${base} [${projectName}]` : base;
+}
+
+function collectRowsFromSuite(
+  suite: PlaywrightJsonSuite,
+  parentTitles: string[],
+  inheritedFile: string | undefined,
+  rows: PlaywrightTestRow[],
+): void {
+  const suiteTitle = suite.title?.trim() ?? "";
+  const nextTitles = suiteTitle ? [...parentTitles, suiteTitle] : [...parentTitles];
+  const suiteFile = suite.file ?? inheritedFile;
+
+  for (const spec of asArray(suite.specs)) {
+    const specTitle = spec.title?.trim() ?? "unnamed";
+    const specFile = pickFile(
+      [spec.file, suite.file, inheritedFile],
+      "unknown",
+    );
+    const specTitlePath = [...nextTitles, specTitle];
+
+    for (const test of asArray(spec.tests)) {
+      const attemptStatuses = asArray(test.results).map((result) =>
+        normalizeAttemptStatus(result.status),
+      );
+      const rawStatus = normalizeAttemptStatus(test.status);
+      const outcome = normalizeOutcome(rawStatus, attemptStatuses);
+      const retryCount = Math.max(
+        0,
+        ...asArray(test.results).map((result) =>
+          typeof result.retry === "number" ? result.retry : 0,
+        ),
+      );
+      const durationMs = asArray(test.results).reduce(
+        (sum, result) => sum + (typeof result.duration === "number" ? result.duration : 0),
+        0,
+      );
+      const errorMessages = asArray(test.results).flatMap((result) =>
+        asArray(result.errors)
+          .map((error) => error.message ?? error.value ?? "")
+          .filter((message) => message.length > 0),
+      );
+      const projectName = test.projectName ?? test.projectId ?? "";
+
+      rows.push({
+        id: rowId(specFile, specTitlePath, projectName),
+        file: specFile,
+        title: specTitle,
+        titlePath: specTitlePath,
+        projectName,
+        expectedStatus: test.expectedStatus ?? "passed",
+        rawStatus,
+        outcome,
+        attempts: attemptStatuses,
+        retryCount,
+        durationMs,
+        errorMessages,
+      });
+    }
+  }
+
+  for (const childSuite of asArray(suite.suites)) {
+    collectRowsFromSuite(childSuite, nextTitles, suiteFile, rows);
+  }
+}
+
+export function buildPlaywrightSummary(
+  report: PlaywrightJsonReport,
+  label: string,
+  sourceFile?: string,
+): PlaywrightSummary {
+  const rows: PlaywrightTestRow[] = [];
+  for (const suite of asArray(report.suites)) {
+    collectRowsFromSuite(suite, [], suite.file, rows);
+  }
+
+  rows.sort((a, b) => {
+    if (b.durationMs !== a.durationMs) return b.durationMs - a.durationMs;
+    return a.id.localeCompare(b.id);
+  });
+
+  const totals = createEmptyTotals();
+  const byFile = new Map<string, PlaywrightFileSummary>();
+
+  for (const row of rows) {
+    pushCount(totals, row.outcome);
+    totals.retries += row.retryCount;
+    totals.durationMs += row.durationMs;
+
+    const fileSummary = byFile.get(row.file) ?? {
+      file: row.file,
+      total: 0,
+      passed: 0,
+      failed: 0,
+      flaky: 0,
+      skipped: 0,
+      retries: 0,
+      durationMs: 0,
+    };
+
+    fileSummary.total += 1;
+    if (row.outcome === "passed") fileSummary.passed += 1;
+    else if (row.outcome === "failed") fileSummary.failed += 1;
+    else if (row.outcome === "flaky") fileSummary.flaky += 1;
+    else if (row.outcome === "skipped") fileSummary.skipped += 1;
+    fileSummary.retries += row.retryCount;
+    fileSummary.durationMs += row.durationMs;
+
+    byFile.set(row.file, fileSummary);
+  }
+
+  const files = [...byFile.values()].sort((a, b) => {
+    if (b.failed !== a.failed) return b.failed - a.failed;
+    if (b.flaky !== a.flaky) return b.flaky - a.flaky;
+    if (b.durationMs !== a.durationMs) return b.durationMs - a.durationMs;
+    return a.file.localeCompare(b.file);
+  });
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    label,
+    sourceFile,
+    totals,
+    files,
+    tests: rows,
+  };
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+function fmtMs(value: number): string {
+  return `${value}`;
+}
+
+export function renderPlaywrightMarkdown(summary: PlaywrightSummary): string {
+  const lines: string[] = [];
+  lines.push("# Playwright Report Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Label | ${escapeCell(summary.label)} |`);
+  if (summary.sourceFile) {
+    lines.push(`| Source | ${escapeCell(summary.sourceFile)} |`);
+  }
+  lines.push(`| Total | ${summary.totals.total} |`);
+  lines.push(`| Passed | ${summary.totals.passed} |`);
+  lines.push(`| Failed | ${summary.totals.failed} |`);
+  lines.push(`| Flaky | ${summary.totals.flaky} |`);
+  lines.push(`| Skipped | ${summary.totals.skipped} |`);
+  lines.push(`| Timed out | ${summary.totals.timedout} |`);
+  lines.push(`| Interrupted | ${summary.totals.interrupted} |`);
+  lines.push(`| Retries | ${summary.totals.retries} |`);
+  lines.push(`| Duration (ms) | ${summary.totals.durationMs} |`);
+
+  lines.push("");
+  lines.push("## Files");
+  lines.push("");
+  lines.push("| File | Total | Passed | Failed | Flaky | Skipped | Retries | Duration (ms) |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- | --- |");
+  for (const file of summary.files) {
+    lines.push(
+      `| ${escapeCell(file.file)} | ${file.total} | ${file.passed} | ${file.failed} | ${file.flaky} | ${file.skipped} | ${file.retries} | ${fmtMs(file.durationMs)} |`,
+    );
+  }
+
+  const unstableTests = summary.tests.filter((row) =>
+    row.outcome === "failed" || row.outcome === "flaky" || row.retryCount > 0,
+  );
+  if (unstableTests.length > 0) {
+    lines.push("");
+    lines.push("## Flaky / Retried Tests");
+    lines.push("");
+    lines.push("| Test | Outcome | Attempts | Retries | Duration (ms) |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const row of unstableTests) {
+      lines.push(
+        `| ${escapeCell(row.id)} | ${row.outcome} | ${escapeCell(row.attempts.join(" -> "))} | ${row.retryCount} | ${fmtMs(row.durationMs)} |`,
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function isMainModule(): boolean {
+  if (!import.meta.url.startsWith("file:")) {
+    return false;
+  }
+  return process.argv[1] === fileURLToPath(import.meta.url);
+}
+
+if (isMainModule()) {
+  try {
+    const options = parseCliArgs(process.argv.slice(2));
+    const inputPath = path.resolve(process.cwd(), options.input);
+    const report = JSON.parse(fs.readFileSync(inputPath, "utf8")) as PlaywrightJsonReport;
+    const label = options.label ?? basenameWithoutExt(inputPath);
+    const summary = buildPlaywrightSummary(
+      report,
+      label,
+      path.relative(process.cwd(), inputPath),
+    );
+    const markdown = renderPlaywrightMarkdown(summary);
+    process.stdout.write(markdown);
+
+    if (options.jsonOutput) {
+      writeOutput(options.jsonOutput, `${JSON.stringify(summary, null, 2)}\n`);
+    }
+    if (options.markdownOutput) {
+      writeOutput(options.markdownOutput, markdown);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a Playwright JSON report normalizer for CI/flaker-style summaries
- add a just recipe to emit json/markdown/log outputs from Playwright reports
- publish Playwright and paint VRT summaries in GitHub Actions artifacts and step summaries

## Verification
- pnpm exec vitest run scripts/flaker-config.test.ts scripts/playwright-report-summary.test.ts scripts/vrt-bench.test.ts
- just playwright-report-summary <sample-report> paint-vrt <tmpdir>
