### PR TITLE
chore: bump mizchi/x to 0.2.0

### DIFF
--- a/browser/moon.mod.json
+++ b/browser/moon.mod.json
@@ -6,7 +6,7 @@
       "path": ".."
     },
     "mizchi/v8": "0.2.0",
-    "mizchi/x": "0.1.6",
+    "mizchi/x": "0.2.0",
     "moonbitlang/async": "0.16.6",
     "moonbitlang/x": "0.4.40",
     "mizchi/sqlite": "0.2.3"

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -4,7 +4,7 @@
   "description": "CSS Layout Engine that implements Box/Flex/Grid",
   "deps": {
     "mizchi/layout": "0.2.0",
-    "mizchi/x": "0.1.6",
+    "mizchi/x": "0.2.0",
     "mizchi/font": "0.7.0",
     "mizchi/svg": "0.2.0",
     "moonbitlang/async": "0.16.7"


### PR DESCRIPTION
## Summary
- Bump \`mizchi/x\` from 0.1.6 to 0.2.0 in both \`crater\` and \`browser\`

Note: main CI has 186 pre-existing layout test failures unrelated to this bump
(same failures reproduce with clean main, no mizchi/x changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)