### PR TITLE
Add prepared external CSS render path

### DIFF
--- a/benchmarks/BASELINE.md
+++ b/benchmarks/BASELINE.md
@@ -220,6 +220,34 @@ Notes:
 - `css-flexbox` WPT 全件はこの変更後も `289 / 289 passed`
 - synthetic bench では indexed path が non-indexed にかなり近づき、1000-rule ではほぼ同等まで縮んだ
 
+## GitHub Real URL VRT Phase Benchmarks (2026-05-09)
+
+Commands:
+```bash
+moon bench --manifest-path benchmarks/moon.mod.json -p mizchi/crater-benchmarks -f vrt_api_bench.mbt --target js --release -i 13-21
+pnpm exec tsx scripts/vrt-bench.ts --group all --json /tmp/crater-vrt-bench-prepared-css-all.json --markdown /tmp/crater-vrt-bench-prepared-css-all.md
+```
+
+Context:
+- GitHub profile snapshot fixture (`benchmarks/fixtures/github_mizchi.html`) and the checked-in GitHub CSS bundle are used as a real URL proxy.
+- The hot-path benchmarks warm `renderer`'s external CSS bundle cache before the measured loop.
+- Prepared CSS handle benchmarks pass the parsed/indexed CSS bundle directly, avoiding per-render cache key construction.
+
+| Benchmark | mean | note |
+|-----------|------|------|
+| `vrt_phase_parse_github_real_url_fixture` | 7.42 ms | 211 KB HTML parse |
+| `vrt_phase_parse_github_external_css_bundle` | 36.37 ms | 831 KB CSS cold parse/index input |
+| `vrt_phase_prepare_github_external_css_hot` | 1.99 ms | cached external CSS bundle, still builds array cache key |
+| `vrt_phase_prepare_github_prepared_css_handle` | 191.71 µs | prepared CSS handle, pre-parsed HTML |
+| `vrt_phase_node_layout_github_external_css_hot` | 2.37 ms | cached CSS + node/layout, array API |
+| `vrt_phase_node_layout_github_prepared_css_handle` | 524.65 µs | prepared CSS handle + node/layout |
+| `vrt_render_paint_tree_github_external_css_hot` | 3.90 ms | cached CSS + node/layout + paint tree, high variance |
+| `vrt_render_paint_tree_github_prepared_css_handle` | 437.03 µs | prepared CSS handle + node/layout + paint tree |
+
+Notes:
+- The expensive part is still the first CSS parse/index build.
+- Repeated component/URL VRT should prepare the CSS bundle once with `prepare_external_css()` and reuse the returned handle. In this fixture, that cuts repeated prepare from ~2 ms to ~0.2 ms and node/layout from ~2.4 ms to ~0.5 ms.
+
 ---
 
 # Optimization Results (2025-01-12)

--- a/benchmarks/vrt_api_bench.mbt
+++ b/benchmarks/vrt_api_bench.mbt
@@ -306,3 +306,170 @@ test "bench_capture_screenshot_phase_visual_sanity_dashboard" (b : @bench.T) {
     b.keep(@tui_paint_output.framebuffer_visual_stats(fb, palette))
   })
 }
+
+///|
+extern "js" fn js_load_benchmark_fixture(name : String) -> String =
+  #| (name) => {
+  #|   const fs = require("node:fs");
+  #|   const path = require("node:path");
+  #|   const candidates = [
+  #|     path.join(process.cwd(), "benchmarks", "fixtures"),
+  #|     path.join(process.cwd(), "..", "benchmarks", "fixtures"),
+  #|     path.join(process.cwd(), "src", "benchmarks", "fixtures"),
+  #|     path.join(process.cwd(), "..", "src", "benchmarks", "fixtures"),
+  #|   ];
+  #|   const dir = candidates.find((candidate) =>
+  #|     fs.existsSync(path.join(candidate, name))
+  #|   );
+  #|   if (!dir) {
+  #|     throw new Error(
+  #|       `benchmark fixture not found: ${name}; searched ${candidates.join(", ")}`,
+  #|     );
+  #|   }
+  #|   return fs.readFileSync(path.join(dir, name), "utf8");
+  #| }
+
+///|
+fn github_fixture_html() -> String {
+  js_load_benchmark_fixture("github_mizchi.html")
+}
+
+///|
+fn github_fixture_external_css() -> Array[String] {
+  [
+    js_load_benchmark_fixture("github_primer.css"),
+    js_load_benchmark_fixture("github_global.css"),
+    js_load_benchmark_fixture("github_main.css"),
+    js_load_benchmark_fixture("github_profile.css"),
+  ]
+}
+
+///|
+fn github_fixture_viewport() -> @types.Size[Double] {
+  @types.Size::new(1280.0, 900.0)
+}
+
+///|
+fn github_fixture_render_context() -> @renderer.RenderContext {
+  vrt_render_context(github_fixture_viewport())
+}
+
+///|
+fn warm_github_external_css_bundle(
+  doc : @html.Document,
+  ctx : @renderer.RenderContext,
+  external_css : Array[String],
+) -> Unit {
+  let _ = @renderer.prepare_render_document(doc, ctx, external_css)
+}
+
+///|
+test "bench_vrt_phase_parse_github_real_url_fixture" (b : @bench.T) {
+  let html = github_fixture_html()
+  b.bench(name="vrt_phase_parse_github_real_url_fixture", fn() {
+    b.keep(@html.parse_document(html))
+  })
+}
+
+///|
+test "bench_vrt_phase_parse_github_external_css_bundle" (b : @bench.T) {
+  let external_css = github_fixture_external_css()
+  b.bench(name="vrt_phase_parse_github_external_css_bundle", fn() {
+    for css in external_css {
+      b.keep(@css.parse_stylesheet(css))
+    }
+  })
+}
+
+///|
+test "bench_vrt_phase_prepare_github_external_css_hot" (b : @bench.T) {
+  let html = github_fixture_html()
+  let doc = @html.parse_document(html)
+  let ctx = github_fixture_render_context()
+  let external_css = github_fixture_external_css()
+  warm_github_external_css_bundle(doc, ctx, external_css)
+  b.bench(name="vrt_phase_prepare_github_external_css_hot", fn() {
+    b.keep(@renderer.prepare_render_document(doc, ctx, external_css))
+  })
+}
+
+///|
+test "bench_vrt_phase_prepare_github_prepared_css_handle" (b : @bench.T) {
+  let html = github_fixture_html()
+  let doc = @html.parse_document(html)
+  let ctx = github_fixture_render_context()
+  let external_css = @renderer.prepare_external_css(
+    github_fixture_external_css(),
+  )
+  b.bench(name="vrt_phase_prepare_github_prepared_css_handle", fn() {
+    b.keep(
+      @renderer.prepare_render_document_with_prepared_external_css(
+        doc, ctx, external_css,
+      ),
+    )
+  })
+}
+
+///|
+test "bench_vrt_phase_node_layout_github_external_css_hot" (b : @bench.T) {
+  let html = github_fixture_html()
+  let doc = @html.parse_document(html)
+  let ctx = github_fixture_render_context()
+  let external_css = github_fixture_external_css()
+  warm_github_external_css_bundle(doc, ctx, external_css)
+  b.bench(name="vrt_phase_node_layout_github_external_css_hot", fn() {
+    b.keep(
+      @renderer.render_to_node_and_layout_with_document(doc, ctx, external_css),
+    )
+  })
+}
+
+///|
+test "bench_vrt_phase_node_layout_github_prepared_css_handle" (b : @bench.T) {
+  let html = github_fixture_html()
+  let doc = @html.parse_document(html)
+  let ctx = github_fixture_render_context()
+  let external_css = @renderer.prepare_external_css(
+    github_fixture_external_css(),
+  )
+  b.bench(name="vrt_phase_node_layout_github_prepared_css_handle", fn() {
+    b.keep(
+      @renderer.render_to_node_and_layout_with_prepared_external_css(
+        doc, ctx, external_css,
+      ),
+    )
+  })
+}
+
+///|
+test "bench_vrt_render_paint_tree_github_external_css_hot" (b : @bench.T) {
+  let html = github_fixture_html()
+  let doc = @html.parse_document(html)
+  let viewport = github_fixture_viewport()
+  let ctx = github_fixture_render_context()
+  let external_css = github_fixture_external_css()
+  warm_github_external_css_bundle(doc, ctx, external_css)
+  b.bench(name="vrt_render_paint_tree_github_external_css_hot", fn() {
+    let (node, layout) = @renderer.render_to_node_and_layout_with_document(
+      doc, ctx, external_css,
+    )
+    b.keep(build_vrt_paint_tree(node, layout, viewport))
+  })
+}
+
+///|
+test "bench_vrt_render_paint_tree_github_prepared_css_handle" (b : @bench.T) {
+  let html = github_fixture_html()
+  let doc = @html.parse_document(html)
+  let viewport = github_fixture_viewport()
+  let ctx = github_fixture_render_context()
+  let external_css = @renderer.prepare_external_css(
+    github_fixture_external_css(),
+  )
+  b.bench(name="vrt_render_paint_tree_github_prepared_css_handle", fn() {
+    let (node, layout) = @renderer.render_to_node_and_layout_with_prepared_external_css(
+      doc, ctx, external_css,
+    )
+    b.keep(build_vrt_paint_tree(node, layout, viewport))
+  })
+}

--- a/renderer/moon.pkg
+++ b/renderer/moon.pkg
@@ -2,5 +2,6 @@ import {
   "mizchi/crater-layout/types",
   "mizchi/crater-painter/paint/diff" @paint_diff,
   "mizchi/crater-painter/paint/model" @paint_model,
+  "mizchi/crater-renderer/renderer" @renderer_core,
   "mizchi/crater-renderer/vrt",
 }

--- a/renderer/pkg.generated.mbti
+++ b/renderer/pkg.generated.mbti
@@ -5,11 +5,14 @@ import {
   "mizchi/crater-layout/types",
   "mizchi/crater-painter/paint/diff",
   "mizchi/crater-painter/paint/model",
+  "mizchi/crater-renderer/renderer",
   "mizchi/crater-renderer/vrt",
 }
 
 // Values
 pub fn diff_rendered_paint_trees(String, String, @types.Size[Double]) -> @diff.PaintTreeDiff
+
+pub fn prepare_external_css(Array[String]) -> @renderer.PreparedExternalCss
 
 pub fn render_html_batch_variants(String, @types.Size[Double], Array[@vrt.RenderVariant]) -> Array[@vrt.RenderVariantResult]
 
@@ -19,6 +22,8 @@ pub fn render_html_to_paint_tree_json(String, @types.Size[Double]) -> String
 
 pub fn render_html_to_paint_tree_with_external_css(String, @types.Size[Double], Array[String]) -> @model.PaintNode
 
+pub fn render_html_to_paint_tree_with_prepared_external_css(String, @types.Size[Double], @renderer.PreparedExternalCss) -> @model.PaintNode
+
 // Errors
 
 // Types and methods
@@ -27,6 +32,8 @@ pub fn render_html_to_paint_tree_with_external_css(String, @types.Size[Double], 
 pub using @vrt {type CssMutation}
 
 pub using @vrt {type CssMutationAction}
+
+pub using @renderer {type PreparedExternalCss}
 
 pub using @vrt {type RenderVariant}
 

--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -50,7 +50,11 @@ pub let perf_pseudo_us : @ref.Ref[Int64]
 
 pub let perf_selector_build_us : @ref.Ref[Int64]
 
+pub fn prepare_external_css(Array[String]) -> PreparedExternalCss
+
 pub fn prepare_render_document(@html.Document, RenderContext, Array[String]) -> PreparedRenderDocument
+
+pub fn prepare_render_document_with_prepared_external_css(@html.Document, RenderContext, PreparedExternalCss) -> PreparedRenderDocument
 
 pub fn print_layout_tree(@types.Layout, Int) -> Unit
 
@@ -59,6 +63,8 @@ pub fn print_layout_tree_with_options(@types.Layout, Int, Bool) -> Unit
 pub fn render(String, RenderContext) -> @types.Layout
 
 pub fn render_document_with_external_css(@html.Document, RenderContext, Array[String]) -> @types.Layout
+
+pub fn render_document_with_prepared_external_css(@html.Document, RenderContext, PreparedExternalCss) -> @types.Layout
 
 pub fn render_to_kitty_with_css(String, Int, Int, Int, Array[String]) -> String
 
@@ -72,9 +78,13 @@ pub fn render_to_node_and_layout_with_document(@html.Document, RenderContext, Ar
 
 pub fn render_to_node_and_layout_with_external_css(String, RenderContext, Array[String]) -> (@node.Node, @types.Layout)
 
+pub fn render_to_node_and_layout_with_prepared_external_css(@html.Document, RenderContext, PreparedExternalCss) -> (@node.Node, @types.Layout)
+
 pub fn render_to_node_with_document(@html.Document, RenderContext, Array[String]) -> @node.Node
 
 pub fn render_to_node_with_external_css(String, RenderContext, Array[String]) -> @node.Node
+
+pub fn render_to_node_with_prepared_external_css(@html.Document, RenderContext, PreparedExternalCss) -> @node.Node
 
 pub fn render_to_sixel(String, Int, Int) -> String
 
@@ -103,6 +113,16 @@ pub struct ImageIntrinsicSizeProvider {
   func : (String) -> (Double, Double)?
 }
 pub fn ImageIntrinsicSizeProvider::new((String) -> (Double, Double)?) -> Self
+
+pub struct PreparedExternalCss {
+  stylesheets : Array[@cascade.Stylesheet]
+  indexed_stylesheets : Array[@cascade.IndexedStylesheet]
+  before_rules : Array[PseudoRule]
+  after_rules : Array[PseudoRule]
+  before_index : PseudoRuleIndex
+  after_index : PseudoRuleIndex
+  total_rules : Int
+}
 
 pub struct PreparedRenderDocument {
   stylesheets : Array[@cascade.Stylesheet]

--- a/renderer/renderer/renderer.mbt
+++ b/renderer/renderer/renderer.mbt
@@ -3513,7 +3513,7 @@ let active_after_index : Ref[PseudoRuleIndex] = {
 }
 
 ///|
-priv struct ExternalCssBundle {
+pub struct PreparedExternalCss {
   stylesheets : Array[@css.Stylesheet]
   indexed_stylesheets : Array[@css.IndexedStylesheet]
   before_rules : Array[PseudoRule]
@@ -3524,7 +3524,7 @@ priv struct ExternalCssBundle {
 }
 
 ///|
-let external_css_bundle_cache : Ref[Map[String, ExternalCssBundle]] = {
+let external_css_bundle_cache : Ref[Map[String, PreparedExternalCss]] = {
   val: {},
 }
 
@@ -3583,29 +3583,36 @@ fn collect_pseudo_rules_from_stylesheet(
 }
 
 ///|
-fn get_external_css_bundle(external_css : Array[String]) -> ExternalCssBundle {
+fn empty_prepared_external_css() -> PreparedExternalCss {
+  {
+    stylesheets: [],
+    indexed_stylesheets: [],
+    before_rules: [],
+    after_rules: [],
+    before_index: {
+      rules: [],
+      by_id: {},
+      by_class: {},
+      by_tag: {},
+      universal: [],
+    },
+    after_index: {
+      rules: [],
+      by_id: {},
+      by_class: {},
+      by_tag: {},
+      universal: [],
+    },
+    total_rules: 0,
+  }
+}
+
+///|
+pub fn prepare_external_css(
+  external_css : Array[String],
+) -> PreparedExternalCss {
   if external_css.is_empty() {
-    return {
-      stylesheets: [],
-      indexed_stylesheets: [],
-      before_rules: [],
-      after_rules: [],
-      before_index: {
-        rules: [],
-        by_id: {},
-        by_class: {},
-        by_tag: {},
-        universal: [],
-      },
-      after_index: {
-        rules: [],
-        by_id: {},
-        by_class: {},
-        by_tag: {},
-        universal: [],
-      },
-      total_rules: 0,
-    }
+    return empty_prepared_external_css()
   }
   let key = external_css_cache_key(external_css)
   match external_css_bundle_cache.val.get(key) {
@@ -3625,7 +3632,7 @@ fn get_external_css_bundle(external_css : Array[String]) -> ExternalCssBundle {
         stylesheets.push(stylesheet)
         indexed_stylesheets.push(@css.IndexedStylesheet::new(stylesheet))
       }
-      let bundle : ExternalCssBundle = {
+      let bundle : PreparedExternalCss = {
         stylesheets,
         indexed_stylesheets,
         before_rules,
@@ -3661,7 +3668,29 @@ pub fn prepare_render_document(
   external_css : Array[String],
 ) -> PreparedRenderDocument {
   let _t0 = perf_clock_us()
-  let external_bundle = get_external_css_bundle(external_css)
+  let external_bundle = prepare_external_css(external_css)
+  prepare_render_document_with_external_css_bundle(
+    doc, ctx, external_bundle, _t0,
+  )
+}
+
+///|
+pub fn prepare_render_document_with_prepared_external_css(
+  doc : @html.Document,
+  ctx : RenderContext,
+  external_css : PreparedExternalCss,
+) -> PreparedRenderDocument {
+  let _t0 = perf_clock_us()
+  prepare_render_document_with_external_css_bundle(doc, ctx, external_css, _t0)
+}
+
+///|
+fn prepare_render_document_with_external_css_bundle(
+  doc : @html.Document,
+  ctx : RenderContext,
+  external_bundle : PreparedExternalCss,
+  t0 : Int64,
+) -> PreparedRenderDocument {
   let stylesheets : Array[@css.Stylesheet] = []
   for stylesheet in external_bundle.stylesheets {
     stylesheets.push(stylesheet)
@@ -3722,7 +3751,7 @@ pub fn prepare_render_document(
   }
   maybe_log_perf(
     "[perf] css_parse=" +
-    ((_t1 - _t0) / 1000L).to_string() +
+    ((_t1 - t0) / 1000L).to_string() +
     "ms index=" +
     ((_t2 - _t1) / 1000L).to_string() +
     "ms rules=" +
@@ -3962,6 +3991,20 @@ pub fn render_document_with_external_css(
   external_css : Array[String],
 ) -> @types.Layout {
   let prepared = prepare_render_document(doc, ctx, external_css)
+  let root = build_render_root_node(doc, ctx, prepared)
+  compute_layout_from_render_root(root, prepared, ctx)
+}
+
+///|
+/// Render a parsed HTML Document to Layout with a prepared external CSS handle.
+pub fn render_document_with_prepared_external_css(
+  doc : @html.Document,
+  ctx : RenderContext,
+  external_css : PreparedExternalCss,
+) -> @types.Layout {
+  let prepared = prepare_render_document_with_prepared_external_css(
+    doc, ctx, external_css,
+  )
   let root = build_render_root_node(doc, ctx, prepared)
   compute_layout_from_render_root(root, prepared, ctx)
 }
@@ -5264,6 +5307,19 @@ pub fn render_to_node_with_document(
 }
 
 ///|
+/// Render a parsed HTML Document to Node tree with a prepared external CSS handle.
+pub fn render_to_node_with_prepared_external_css(
+  doc : @html.Document,
+  ctx : RenderContext,
+  external_css : PreparedExternalCss,
+) -> @node.Node {
+  let prepared = prepare_render_document_with_prepared_external_css(
+    doc, ctx, external_css,
+  )
+  build_render_root_node(doc, ctx, prepared)
+}
+
+///|
 /// Render a parsed HTML Document to Node tree and Layout with external CSS
 /// while sharing HTML/CSS preparation and node construction.
 pub fn render_to_node_and_layout_with_document(
@@ -5272,6 +5328,21 @@ pub fn render_to_node_and_layout_with_document(
   external_css : Array[String],
 ) -> (@node.Node, @types.Layout) {
   let prepared = prepare_render_document(doc, ctx, external_css)
+  let root = build_render_root_node(doc, ctx, prepared)
+  let layout = compute_layout_from_render_root(root, prepared, ctx)
+  (root, layout)
+}
+
+///|
+/// Render a parsed HTML Document to Node tree and Layout with a prepared external CSS handle.
+pub fn render_to_node_and_layout_with_prepared_external_css(
+  doc : @html.Document,
+  ctx : RenderContext,
+  external_css : PreparedExternalCss,
+) -> (@node.Node, @types.Layout) {
+  let prepared = prepare_render_document_with_prepared_external_css(
+    doc, ctx, external_css,
+  )
   let root = build_render_root_node(doc, ctx, prepared)
   let layout = compute_layout_from_render_root(root, prepared, ctx)
   (root, layout)

--- a/renderer/renderer/renderer_test.mbt
+++ b/renderer/renderer/renderer_test.mbt
@@ -135,6 +135,31 @@ test "render_to_node_and_layout_with_external_css is stable across repeated call
 }
 
 ///|
+test "prepared external css renders same layout as css array path" {
+  let html =
+    #|<!doctype html>
+    #|<html><head><style>.local { height: 18px; }</style></head>
+    #|<body><div id="target" class="card local"><span>hello</span></div></body></html>
+  let ctx = @renderer.RenderContext::default()
+  let external_css = [
+    ".card { display: flex; gap: 8px; padding: 12px; border: 1px solid black; }",
+    "#target span { display: inline-block; width: 40px; height: 20px; }",
+  ]
+  let doc = @html.parse_document(html)
+  let prepared_external_css = @renderer.prepare_external_css(external_css)
+  let (_, expected) = @renderer.render_to_node_and_layout_with_document(
+    doc, ctx, external_css,
+  )
+  let (_, actual) = @renderer.render_to_node_and_layout_with_prepared_external_css(
+    doc, ctx, prepared_external_css,
+  )
+  assert_eq(
+    @renderer.layout_to_json(actual),
+    @renderer.layout_to_json(expected),
+  )
+}
+
+///|
 test "debug node style from stylesheet" {
   let html =
     #|<!doctype html>

--- a/renderer/top.mbt
+++ b/renderer/top.mbt
@@ -7,6 +7,16 @@ pub using @vrt {
 }
 
 ///|
+pub using @renderer_core {type PreparedExternalCss}
+
+///|
+pub fn prepare_external_css(
+  external_css : Array[String],
+) -> PreparedExternalCss {
+  @renderer_core.prepare_external_css(external_css)
+}
+
+///|
 pub fn render_html_to_paint_tree(
   html : String,
   viewport : @types.Size[Double],
@@ -21,6 +31,17 @@ pub fn render_html_to_paint_tree_with_external_css(
   external_css : Array[String],
 ) -> @paint_model.PaintNode {
   @vrt.render_html_to_paint_tree_with_external_css(html, viewport, external_css)
+}
+
+///|
+pub fn render_html_to_paint_tree_with_prepared_external_css(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : PreparedExternalCss,
+) -> @paint_model.PaintNode {
+  @vrt.render_html_to_paint_tree_with_prepared_external_css(
+    html, viewport, external_css,
+  )
 }
 
 ///|

--- a/renderer/vrt/pkg.generated.mbti
+++ b/renderer/vrt/pkg.generated.mbti
@@ -5,6 +5,7 @@ import {
   "mizchi/crater-layout/types",
   "mizchi/crater-painter/paint/diff",
   "mizchi/crater-painter/paint/model",
+  "mizchi/crater-renderer/renderer",
   "moonbitlang/core/debug",
 }
 
@@ -18,6 +19,8 @@ pub fn render_html_to_paint_tree(String, @types.Size[Double]) -> @model.PaintNod
 pub fn render_html_to_paint_tree_json(String, @types.Size[Double]) -> String
 
 pub fn render_html_to_paint_tree_with_external_css(String, @types.Size[Double], Array[String]) -> @model.PaintNode
+
+pub fn render_html_to_paint_tree_with_prepared_external_css(String, @types.Size[Double], @renderer.PreparedExternalCss) -> @model.PaintNode
 
 // Errors
 

--- a/renderer/vrt/top.mbt
+++ b/renderer/vrt/top.mbt
@@ -45,6 +45,34 @@ pub fn render_html_to_paint_tree_with_external_css(
 }
 
 ///|
+pub fn render_html_to_paint_tree_with_prepared_external_css(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : @renderer.PreparedExternalCss,
+) -> @paint_model.PaintNode {
+  let doc = @html.parse_document(html)
+  let (node, layout) = @renderer.render_to_node_and_layout_with_prepared_external_css(
+    doc,
+    make_render_context(viewport),
+    external_css,
+  )
+  match
+    @paint_render.from_node_and_layout_with_viewport_rect(
+      node,
+      layout,
+      0.0,
+      0.0,
+      viewport.width,
+      viewport.height,
+      0.0,
+      0.0,
+    ) {
+    Some(paint_tree) => paint_tree
+    None => @paint_render.from_node_and_layout(node, layout)
+  }
+}
+
+///|
 pub fn render_html_to_paint_tree_json(
   html : String,
   viewport : @types.Size[Double],

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -7,6 +7,7 @@ import {
   "mizchi/crater-layout/types",
   "mizchi/crater-painter/paint/diff",
   "mizchi/crater-painter/paint/model",
+  "mizchi/crater-renderer/renderer",
   "mizchi/crater-renderer/vrt",
   "mizchi/crater-webvitals",
 }
@@ -28,6 +29,8 @@ pub fn compute_total_cls(Array[@types.BoundingRect], Array[@types.BoundingRect],
 
 pub fn diff_rendered_paint_trees(String, String, @types.Size[Double]) -> @diff.PaintTreeDiff
 
+pub fn prepare_external_css(Array[String]) -> @renderer.PreparedExternalCss
+
 pub fn render_html_batch_variants(String, @types.Size[Double], Array[@vrt.RenderVariant]) -> Array[@vrt.RenderVariantResult]
 
 pub fn render_html_to_paint_tree(String, @types.Size[Double]) -> @model.PaintNode
@@ -35,6 +38,8 @@ pub fn render_html_to_paint_tree(String, @types.Size[Double]) -> @model.PaintNod
 pub fn render_html_to_paint_tree_json(String, @types.Size[Double]) -> String
 
 pub fn render_html_to_paint_tree_with_external_css(String, @types.Size[Double], Array[String]) -> @model.PaintNode
+
+pub fn render_html_to_paint_tree_with_prepared_external_css(String, @types.Size[Double], @renderer.PreparedExternalCss) -> @model.PaintNode
 
 pub fn validate_core_subset(@node.Node) -> Array[@core_subset.CoreIssue]
 
@@ -50,6 +55,8 @@ pub using @core_subset {type CoreIssue}
 pub using @vrt {type CssMutation}
 
 pub using @vrt {type CssMutationAction}
+
+pub using @renderer {type PreparedExternalCss}
 
 pub using @vrt {type RenderVariant}
 

--- a/src/top.mbt
+++ b/src/top.mbt
@@ -2,6 +2,7 @@
 pub using @renderer_api {
   type CssMutation,
   type CssMutationAction,
+  type PreparedExternalCss,
   type RenderVariant,
   type RenderVariantResult,
 }
@@ -93,6 +94,24 @@ pub fn render_html_to_paint_tree_with_external_css(
   external_css : Array[String],
 ) -> @paint.PaintNode {
   @renderer_api.render_html_to_paint_tree_with_external_css(
+    html, viewport, external_css,
+  )
+}
+
+///|
+pub fn prepare_external_css(
+  external_css : Array[String],
+) -> PreparedExternalCss {
+  @renderer_api.prepare_external_css(external_css)
+}
+
+///|
+pub fn render_html_to_paint_tree_with_prepared_external_css(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : PreparedExternalCss,
+) -> @paint.PaintNode {
+  @renderer_api.render_html_to_paint_tree_with_prepared_external_css(
     html, viewport, external_css,
   )
 }


### PR DESCRIPTION
## Summary
- add PreparedExternalCss handle for reusable parsed/indexed external CSS
- expose prepared CSS render path through renderer and root facades
- add GitHub real URL VRT phase benchmarks comparing array hot path vs prepared handle

## Bench
- prepare: ~1.99ms -> ~0.19ms
- node+layout: ~2.37ms -> ~0.52ms
- paint tree: ~3.90ms high variance -> ~0.44ms

## Tests
- moon test --target js renderer/renderer -j 1
- moon test --target js renderer/vrt renderer src -j 1
- moon test --manifest-path benchmarks/moon.mod.json -p mizchi/crater-benchmarks --target js -j 1
- moon bench --manifest-path benchmarks/moon.mod.json -p mizchi/crater-benchmarks -f vrt_api_bench.mbt --target js --release -i 13-21
- pnpm exec tsx scripts/vrt-bench.ts --group all --json /tmp/crater-vrt-bench-prepared-css-all.json --markdown /tmp/crater-vrt-bench-prepared-css-all.md
- pnpm exec vitest run --config vitest.config.ts scripts/vrt-bench.test.ts
- moon check --target js -j 1
- git diff --check