### PR TITLE
Cache browser graphics render state

### DIFF
--- a/benchmarks/browser_shell/browser_shell_bench_wbtest.mbt
+++ b/benchmarks/browser_shell/browser_shell_bench_wbtest.mbt
@@ -39,11 +39,33 @@ test "bench_browser_sixel_github_mizchi_snapshot" (b : @bench.T) {
 }
 
 ///|
+test "bench_browser_sixel_github_mizchi_hot_snapshot" (b : @bench.T) {
+  let browser = @shell.Browser::new(1440, 960)
+  let html = builtin_github_snapshot_fixture()
+  load_fixture(browser, html)
+  ignore(browser.render_output(@shell.OutputMode::Sixel))
+  b.bench(name="browser_sixel_github_mizchi_hot", fn() {
+    b.keep(browser.render_output(@shell.OutputMode::Sixel))
+  })
+}
+
+///|
 test "bench_browser_kitty_github_mizchi_snapshot" (b : @bench.T) {
   let browser = @shell.Browser::new(1440, 960)
   let html = builtin_github_snapshot_fixture()
   b.bench(name="browser_kitty_github_mizchi", fn() {
     load_fixture(browser, html)
+    b.keep(browser.render_output(@shell.OutputMode::Kitty))
+  })
+}
+
+///|
+test "bench_browser_kitty_github_mizchi_hot_snapshot" (b : @bench.T) {
+  let browser = @shell.Browser::new(1440, 960)
+  let html = builtin_github_snapshot_fixture()
+  load_fixture(browser, html)
+  ignore(browser.render_output(@shell.OutputMode::Kitty))
+  b.bench(name="browser_kitty_github_mizchi_hot", fn() {
     b.keep(browser.render_output(@shell.OutputMode::Kitty))
   })
 }
@@ -55,6 +77,48 @@ test "bench_browser_kitty_article_fixed" (b : @bench.T) {
   b.bench(name="browser_kitty_article", fn() {
     load_fixture(browser, html)
     b.keep(browser.render_output(@shell.OutputMode::Kitty))
+  })
+}
+
+///|
+test "bench_browser_github_mizchi_parse_document" (b : @bench.T) {
+  let html = builtin_github_snapshot_fixture()
+  b.bench(name="browser_github_mizchi_parse_document", fn() {
+    b.keep(@html.assign_synthetic_ids(@html.parse_document(html)))
+  })
+}
+
+///|
+test "bench_browser_github_mizchi_set_html_content" (b : @bench.T) {
+  let browser = @shell.Browser::new(1440, 960)
+  let html = builtin_github_snapshot_fixture()
+  b.bench(name="browser_github_mizchi_set_html_content", fn() {
+    load_fixture(browser, html)
+    b.keep(browser.get_link_count())
+  })
+}
+
+///|
+test "bench_browser_github_mizchi_prepare_document" (b : @bench.T) {
+  let html = builtin_github_snapshot_fixture()
+  let ctx = github_snapshot_render_ctx()
+  let doc = @html.assign_synthetic_ids(@html.parse_document(html))
+  b.bench(name="browser_github_mizchi_prepare_document", fn() {
+    b.keep(@renderer.prepare_render_document(doc, ctx, []))
+  })
+}
+
+///|
+test "bench_browser_github_mizchi_node_layout_prepared_document" (b : @bench.T) {
+  let html = builtin_github_snapshot_fixture()
+  let ctx = github_snapshot_render_ctx()
+  let doc = @html.assign_synthetic_ids(@html.parse_document(html))
+  let prepared = @renderer.prepare_render_document(doc, ctx, [])
+  b.bench(name="browser_github_mizchi_node_layout_prepared_document", fn() {
+    let node = @renderer.build_render_root_node(doc, ctx, prepared)
+    let layout = @renderer.compute_layout_from_render_root(node, prepared, ctx)
+    b.keep(node)
+    b.keep(layout)
   })
 }
 

--- a/benchmarks/browser_shell/moon.pkg
+++ b/benchmarks/browser_shell/moon.pkg
@@ -4,6 +4,7 @@ import {
   "mizchi/crater-browser/tui/paint/plain" @tui_paint_plain,
   "mizchi/crater-benchmarks" @fixtures,
   "mizchi/crater/css",
+  "mizchi/crater-dom/html",
   "mizchi/crater-painter/x/image",
   "mizchi/crater-painter/x/kitty",
   "mizchi/crater-renderer/renderer",

--- a/benchmarks/component_vrt/component_vrt_bench_wbtest.mbt
+++ b/benchmarks/component_vrt/component_vrt_bench_wbtest.mbt
@@ -803,6 +803,17 @@ fn render_fixture_node_and_layout(
 }
 
 ///|
+fn render_prepared_fixture_node_and_layout(
+  doc : @html.Document,
+  ctx : @renderer.RenderContext,
+  prepared : @renderer.PreparedRenderDocument,
+) -> (@layout.Node, @types.Layout) {
+  let node = @renderer.build_render_root_node(doc, ctx, prepared)
+  let layout = @renderer.compute_layout_from_render_root(node, prepared, ctx)
+  (node, layout)
+}
+
+///|
 fn render_component_subtree(
   fixture : ComponentFixture,
 ) -> (@layout.Node, @types.Layout) {
@@ -994,6 +1005,35 @@ test "bench_component_phase_node_layout_m" (b : @bench.T) {
         css,
       ),
     )
+  })
+}
+
+///|
+test "bench_component_phase_node_layout_m_prepared_css" (b : @bench.T) {
+  let fixture = component_fixture_m()
+  let doc = @html.parse_document(fixture.html)
+  let ctx = fixture.render_ctx()
+  let css = @renderer.prepare_external_css(fixture.external_css())
+  b.bench(name="component_phase_node_layout_m_prepared_css", fn() {
+    b.keep(
+      @renderer.render_to_node_and_layout_with_prepared_external_css(
+        doc, ctx, css,
+      ),
+    )
+  })
+}
+
+///|
+test "bench_component_phase_node_layout_m_prepared_document" (b : @bench.T) {
+  let fixture = component_fixture_m()
+  let doc = @html.parse_document(fixture.html)
+  let ctx = fixture.render_ctx()
+  let css = @renderer.prepare_external_css(fixture.external_css())
+  let prepared = @renderer.prepare_render_document_with_prepared_external_css(
+    doc, ctx, css,
+  )
+  b.bench(name="component_phase_node_layout_m_prepared_document", fn() {
+    b.keep(render_prepared_fixture_node_and_layout(doc, ctx, prepared))
   })
 }
 

--- a/benchmarks/moon.pkg
+++ b/benchmarks/moon.pkg
@@ -3,6 +3,7 @@ import {
   "mizchi/crater/css",
   "mizchi/crater-dom/html",
   "mizchi/crater-renderer/renderer",
+  "mizchi/crater-renderer/vrt",
   "mizchi/crater-layout" @tree,
   "mizchi/crater-layout/style",
   "mizchi/crater-layout/types",

--- a/benchmarks/vrt_api_bench.mbt
+++ b/benchmarks/vrt_api_bench.mbt
@@ -473,3 +473,30 @@ test "bench_vrt_render_paint_tree_github_prepared_css_handle" (b : @bench.T) {
     b.keep(build_vrt_paint_tree(node, layout, viewport))
   })
 }
+
+///|
+test "bench_vrt_phase_prepare_github_prepared_page" (b : @bench.T) {
+  let html = github_fixture_html()
+  let viewport = github_fixture_viewport()
+  let external_css = @vrt.prepare_external_css(github_fixture_external_css())
+  b.bench(name="vrt_phase_prepare_github_prepared_page", fn() {
+    b.keep(
+      @vrt.prepare_vrt_page_with_prepared_external_css(
+        html, viewport, external_css,
+      ),
+    )
+  })
+}
+
+///|
+test "bench_vrt_render_paint_tree_github_prepared_page" (b : @bench.T) {
+  let html = github_fixture_html()
+  let viewport = github_fixture_viewport()
+  let external_css = @vrt.prepare_external_css(github_fixture_external_css())
+  let page = @vrt.prepare_vrt_page_with_prepared_external_css(
+    html, viewport, external_css,
+  )
+  b.bench(name="vrt_render_paint_tree_github_prepared_page", fn() {
+    b.keep(@vrt.render_prepared_vrt_page_to_paint_tree(page))
+  })
+}

--- a/browser/shell/browser.mbt
+++ b/browser/shell/browser.mbt
@@ -99,8 +99,22 @@ struct Browser {
   mut dom_snapshot_html : String
   /// Parsed document (cached to avoid re-parsing)
   mut parsed_doc : @html.Document?
+  /// Whether current render HTML may contain declarative shadow DOM templates
+  mut html_has_declarative_shadow_dom : Bool
   /// External CSS content
   mut external_css : Array[String]
+  /// Prepared external CSS content
+  mut prepared_external_css : @renderer.PreparedExternalCss?
+  /// Prepared document/style state for the current HTML/CSS/render context
+  mut prepared_render_document : @renderer.PreparedRenderDocument?
+  /// Color-scheme flag used by prepared_render_document
+  mut prepared_render_document_dark : Bool
+  /// Cached render node for graphics output modes
+  mut graphics_render_node : @layout.Node?
+  /// Cached layout for graphics output modes
+  mut graphics_layout : @types.Layout?
+  /// Color-scheme flag used by graphics render cache
+  mut graphics_render_dark : Bool
   /// Links found in current page
   mut links : Array[Link]
   /// Currently focused link index (legacy, kept for compatibility)
@@ -213,7 +227,14 @@ pub fn Browser::new(
     source_html: "",
     dom_snapshot_html: "",
     parsed_doc: None,
+    html_has_declarative_shadow_dom: false,
     external_css: [],
+    prepared_external_css: None,
+    prepared_render_document: None,
+    prepared_render_document_dark: false,
+    graphics_render_node: None,
+    graphics_layout: None,
+    graphics_render_dark: false,
     links: [],
     focused_link: 0,
     scroll_y: 0,
@@ -288,6 +309,121 @@ pub fn Browser::set_image_cache_max_bytes(
 }
 
 ///|
+fn Browser::set_external_css(
+  self : Browser,
+  external_css : Array[String],
+) -> Unit {
+  self.external_css = external_css
+  self.prepared_external_css = Some(
+    @renderer.prepare_external_css(external_css),
+  )
+  self.prepared_render_document = None
+}
+
+///|
+fn Browser::external_css_handle(
+  self : Browser,
+) -> @renderer.PreparedExternalCss {
+  match self.prepared_external_css {
+    Some(prepared) => prepared
+    None => {
+      let prepared = @renderer.prepare_external_css(self.external_css)
+      self.prepared_external_css = Some(prepared)
+      prepared
+    }
+  }
+}
+
+///|
+fn Browser::clear_render_cache(self : Browser) -> Unit {
+  self.render_node = None
+  self.layout_tree = None
+  self.graphics_render_node = None
+  self.graphics_layout = None
+  self.prev_buffer = None
+  self.last_render_key = ""
+  self.prepared_render_document = None
+}
+
+///|
+fn Browser::prepare_render_document_for_context(
+  self : Browser,
+  doc : @html.Document,
+  ctx : @renderer.RenderContext,
+  dark : Bool,
+) -> @renderer.PreparedRenderDocument {
+  match self.prepared_render_document {
+    Some(prepared) if self.prepared_render_document_dark == dark => prepared
+    _ => {
+      let prepared = @renderer.prepare_render_document_with_prepared_external_css(
+        doc,
+        ctx,
+        self.external_css_handle(),
+      )
+      self.prepared_render_document = Some(prepared)
+      self.prepared_render_document_dark = dark
+      prepared
+    }
+  }
+}
+
+///|
+fn Browser::render_node_from_document(
+  self : Browser,
+  doc : @html.Document,
+  ctx : @renderer.RenderContext,
+  dark : Bool,
+) -> @layout.Node {
+  let prepared = self.prepare_render_document_for_context(doc, ctx, dark)
+  @renderer.build_render_root_node(doc, ctx, prepared)
+}
+
+///|
+fn Browser::render_node_and_layout_from_document(
+  self : Browser,
+  doc : @html.Document,
+  ctx : @renderer.RenderContext,
+  dark : Bool,
+) -> (@layout.Node, @types.Layout) {
+  let prepared = self.prepare_render_document_for_context(doc, ctx, dark)
+  let node = @renderer.build_render_root_node(doc, ctx, prepared)
+  let layout = @renderer.compute_layout_from_render_root(node, prepared, ctx)
+  (node, layout)
+}
+
+///|
+fn Browser::render_graphics_node_and_layout(
+  self : Browser,
+  ctx : @renderer.RenderContext,
+  dark : Bool,
+) -> (@layout.Node, @types.Layout) {
+  match (self.graphics_render_node, self.graphics_layout) {
+    (Some(node), Some(layout)) if self.graphics_render_dark == dark =>
+      (node, layout)
+    _ => {
+      let (node, layout) = match self.parsed_doc {
+        Some(doc) => self.render_node_and_layout_from_document(doc, ctx, dark)
+        None =>
+          @renderer.render_to_node_and_layout_with_external_css(
+            self.html_content,
+            ctx,
+            self.external_css,
+          )
+      }
+      self.graphics_render_node = Some(node)
+      self.graphics_layout = Some(layout)
+      self.graphics_render_dark = dark
+      (node, layout)
+    }
+  }
+}
+
+///|
+fn Browser::refresh_links_from_render_source(self : Browser) -> Unit {
+  self.links = extract_links(self.html_content)
+}
+
+///|
 /// Set a custom JS runtime for script execution (e.g. V8 for native).
 /// Must be called before any script execution (before navigate/load_html).
 pub fn Browser::set_js_runtime(
@@ -317,26 +453,31 @@ pub fn Browser::get_dom_tree(self : Browser) -> @dom.DomTree? {
 /// Set HTML content directly (for testing or headless rendering).
 pub fn Browser::set_html_content(self : Browser, html : String) -> Unit {
   self.source_html = html
-  match normalize_declarative_shadow_source_html(html) {
+  let has_declarative_shadow_dom = html_source_has_declarative_shadow_dom(html)
+  match
+    normalize_declarative_shadow_source_html_with_hint(
+      html, has_declarative_shadow_dom,
+    ) {
     Some(normalized) => {
       self.html_content = normalized.render_html
       self.dom_snapshot_html = normalized.snapshot_html
       self.parsed_doc = Some(normalized.parsed_doc)
+      self.html_has_declarative_shadow_dom = false
     }
     None => {
       self.html_content = html
       self.dom_snapshot_html = html
-      self.parsed_doc = None
+      self.parsed_doc = Some(
+        @html.assign_synthetic_ids(@html.parse_document(self.html_content)),
+      )
+      self.html_has_declarative_shadow_dom = has_declarative_shadow_dom
     }
   }
-  self.links = extract_links(self.html_content)
+  self.refresh_links_from_render_source()
   self.focused_link = 0
   self.scroll_y = 0
   self.clear_element_scroll_states()
-  self.render_node = None
-  self.layout_tree = None
-  self.prev_buffer = None
-  self.last_render_key = ""
+  self.clear_render_cache()
   self.content_height = 0
   self.a11y_tree = None
   self.focus_manager = None
@@ -568,7 +709,7 @@ fn Browser::load_sync_navigable_html_request(
       self.current_url = request.url
       self.last_navigation_request = Some(request)
       self.set_html_content(html)
-      self.external_css = []
+      self.set_external_css([])
       let script_count = self.execute_scripts()
       if script_count > 0 {
         println(
@@ -748,31 +889,40 @@ async fn Browser::load_url_request(
     None => ()
   }
   self.source_html = response.body
-  match normalize_declarative_shadow_source_html(response.body) {
+  let has_declarative_shadow_dom = html_source_has_declarative_shadow_dom(
+    response.body,
+  )
+  match
+    normalize_declarative_shadow_source_html_with_hint(
+      response.body,
+      has_declarative_shadow_dom,
+    ) {
     Some(normalized) => {
       self.html_content = normalized.render_html
       self.dom_snapshot_html = normalized.snapshot_html
       self.parsed_doc = Some(normalized.parsed_doc)
+      self.html_has_declarative_shadow_dom = false
     }
     None => {
       self.html_content = response.body
       self.dom_snapshot_html = response.body
       self.parsed_doc = None
+      self.html_has_declarative_shadow_dom = has_declarative_shadow_dom
     }
   }
   let t1 = perf_now()
   // Fetch external CSS using lightweight extraction (no full parsing)
-  self.external_css = fetch_external_css(
-    self.html_content,
-    url,
-    self.request_sandbox,
-    self.http_cache,
-  ) catch {
-    _ => [] // Fallback to no external CSS on error
-  }
+  self.set_external_css(
+    fetch_external_css(
+      self.html_content,
+      url,
+      self.request_sandbox,
+      self.http_cache,
+    ) catch {
+      _ => [] // Fallback to no external CSS on error
+    },
+  )
   let t2 = perf_now()
-  // Extract links from HTML (lightweight, no full parsing)
-  self.links = extract_links(self.html_content)
   self.focused_link = 0
   self.scroll_y = 0
   // Clear element scroll states on navigation
@@ -787,10 +937,8 @@ async fn Browser::load_url_request(
       self.parsed_doc = Some(doc)
     }
   }
-  self.render_node = None
-  self.layout_tree = None
-  self.prev_buffer = None
-  self.last_render_key = ""
+  self.refresh_links_from_render_source()
+  self.clear_render_cache()
   let t3 = perf_now()
   // Execute scripts including external (JS execution)
   let script_count = self.execute_scripts_async() catch { _ => 0 }
@@ -837,20 +985,29 @@ async fn Browser::load_url_lightweight(
   }
   let response = @http.fetch(url, options=page_options)
   self.source_html = response.body
-  match normalize_declarative_shadow_source_html(response.body) {
+  let has_declarative_shadow_dom = html_source_has_declarative_shadow_dom(
+    response.body,
+  )
+  match
+    normalize_declarative_shadow_source_html_with_hint(
+      response.body,
+      has_declarative_shadow_dom,
+    ) {
     Some(normalized) => {
       self.html_content = normalized.render_html
       self.dom_snapshot_html = normalized.snapshot_html
       self.parsed_doc = Some(normalized.parsed_doc)
+      self.html_has_declarative_shadow_dom = false
     }
     None => {
       self.html_content = response.body
       self.dom_snapshot_html = response.body
       self.parsed_doc = None
+      self.html_has_declarative_shadow_dom = has_declarative_shadow_dom
     }
   }
   // Skip external CSS fetching in lightweight mode
-  self.external_css = []
+  self.set_external_css([])
   // Skip link extraction (not needed for JSON/AOM output)
   self.links = []
   self.focused_link = 0
@@ -867,10 +1024,7 @@ async fn Browser::load_url_lightweight(
       self.parsed_doc = Some(doc)
     }
   }
-  self.render_node = None
-  self.layout_tree = None
-  self.prev_buffer = None
-  self.last_render_key = ""
+  self.clear_render_cache()
   // Skip content height calculation in lightweight mode
   self.content_height = 0
   // Build lightweight accessibility tree (no CSS cascade, no layout)
@@ -959,12 +1113,18 @@ fn Browser::render(self : Browser) -> String {
     return ""
   }
   let installed_provider = self.install_sixel_image_provider()
-  let output = @renderer.render_to_sixel_with_css(
-    self.html_content,
+  let ctx = @browser_contract.create_render_context(
+    self.viewport_width,
+    self.viewport_height,
+    false,
+  )
+  let (node, layout) = self.render_graphics_node_and_layout(ctx, false)
+  let output = @image.render_with_styles_scrolled(
+    node,
+    layout,
     self.viewport_width,
     self.viewport_height,
     self.scroll_y,
-    self.external_css,
   )
   if installed_provider {
     @image.clear_image_provider()
@@ -978,14 +1138,20 @@ fn Browser::render_kitty(self : Browser) -> String {
   if self.html_content.length() == 0 {
     return ""
   }
-  let base = @renderer.render_to_kitty_with_css(
-    self.html_content,
+  let ctx = @browser_contract.create_render_context(
+    self.viewport_width,
+    self.viewport_height,
+    false,
+  )
+  let (node, layout) = self.render_graphics_node_and_layout(ctx, false)
+  let paint_node = @tui_paint_plain.from_node_and_layout(node, layout)
+  let base = @kitty.render_paint_node_to_kitty_scrolled(
+    paint_node,
     self.viewport_width,
     self.viewport_height,
     self.scroll_y,
-    self.external_css,
   )
-  self.collect_graphics_image_regions()
+  self.collect_graphics_image_regions_from_node_layout(node, layout)
   let overlay = self.build_kitty_image_overlay()
   if overlay.length() > 0 {
     base + overlay
@@ -1002,15 +1168,21 @@ async fn[T : @io.Writer] Browser::write_kitty_output(
   if self.html_content.length() == 0 {
     return
   }
-  @renderer.write_kitty_with_css(
+  let ctx = @browser_contract.create_render_context(
+    self.viewport_width,
+    self.viewport_height,
+    false,
+  )
+  let (node, layout) = self.render_graphics_node_and_layout(ctx, false)
+  let paint_node = @tui_paint_plain.from_node_and_layout(node, layout)
+  @kitty.write_paint_node_to_kitty_scrolled(
     writer,
-    self.html_content,
+    paint_node,
     self.viewport_width,
     self.viewport_height,
     self.scroll_y,
-    self.external_css,
   )
-  self.collect_graphics_image_regions()
+  self.collect_graphics_image_regions_from_node_layout(node, layout)
   let overlay = self.build_kitty_image_overlay()
   if overlay.length() > 0 {
     writer.write(overlay) catch {
@@ -1032,10 +1204,7 @@ fn Browser::render_text(self : Browser) -> String {
     self.dark_mode,
   )
   if self.last_color_scheme_dark != self.dark_mode {
-    self.render_node = None
-    self.layout_tree = None
-    self.prev_buffer = None
-    self.last_render_key = ""
+    self.clear_render_cache()
   }
   let mut force_full = false
   // Build or reuse cached render node + layout tree
@@ -1045,8 +1214,7 @@ fn Browser::render_text(self : Browser) -> String {
       force_full = true
       let rn0 = perf_now()
       let n = match self.parsed_doc {
-        Some(doc) =>
-          @renderer.render_to_node_with_document(doc, ctx, self.external_css)
+        Some(doc) => self.render_node_from_document(doc, ctx, self.dark_mode)
         None =>
           @renderer.render_to_node_with_external_css(
             self.html_content,
@@ -1237,58 +1405,11 @@ fn Browser::render_text(self : Browser) -> String {
 }
 
 ///|
-fn Browser::collect_graphics_image_regions(self : Browser) -> Unit {
-  if self.html_content.length() == 0 {
-    self.image_regions = []
-    return
-  }
-  let ctx = @browser_contract.create_render_context(
-    self.viewport_width,
-    self.viewport_height,
-    self.dark_mode,
-  )
-  let render_node = match (self.render_node, self.layout_tree) {
-    (Some(node), Some(_tree)) => node
-    _ => {
-      let n = match self.parsed_doc {
-        Some(doc) =>
-          @renderer.render_to_node_with_document(doc, ctx, self.external_css)
-        None =>
-          @renderer.render_to_node_with_external_css(
-            self.html_content,
-            ctx,
-            self.external_css,
-          )
-      }
-      let tree = @layout.LayoutTree::from_node(
-        n,
-        self.viewport_width.to_double(),
-        self.viewport_height.to_double(),
-      )
-      self.render_node = Some(n)
-      self.layout_tree = Some(tree)
-      n
-    }
-  }
-  let layout = match self.layout_tree {
-    Some(tree) => {
-      let l = tree.compute_incremental()
-      tree.mark_all_layouts_seen()
-      self.layout_tree = Some(tree)
-      l
-    }
-    None => {
-      let tree = @layout.LayoutTree::from_node(
-        render_node,
-        self.viewport_width.to_double(),
-        self.viewport_height.to_double(),
-      )
-      let l = tree.compute_incremental()
-      tree.mark_all_layouts_seen()
-      self.layout_tree = Some(tree)
-      l
-    }
-  }
+fn Browser::collect_graphics_image_regions_from_node_layout(
+  self : Browser,
+  render_node : @layout.Node,
+  layout : @types.Layout,
+) -> Unit {
   let char_width = self.viewport_width / 8
   let char_height = self.viewport_height / 16
   let char_scroll_y = self.scroll_y / 16
@@ -1343,17 +1464,13 @@ pub fn Browser::render_text_full_page(self : Browser) -> String {
     self.dark_mode,
   )
   if self.last_color_scheme_dark != self.dark_mode {
-    self.render_node = None
-    self.layout_tree = None
-    self.prev_buffer = None
-    self.last_render_key = ""
+    self.clear_render_cache()
   }
   let render_node = match (self.render_node, self.layout_tree) {
     (Some(node), Some(_tree)) => node
     _ => {
       let n = match self.parsed_doc {
-        Some(doc) =>
-          @renderer.render_to_node_with_document(doc, ctx, self.external_css)
+        Some(doc) => self.render_node_from_document(doc, ctx, self.dark_mode)
         None =>
           @renderer.render_to_node_with_external_css(
             self.html_content,
@@ -2874,7 +2991,7 @@ fn Browser::ensure_declarative_shadow_dom_normalized(self : Browser) -> Unit {
     Some(_) => return
     None => ()
   }
-  if !html_source_has_declarative_shadow_dom(self.html_content) {
+  if !self.html_has_declarative_shadow_dom {
     return
   }
   match build_dom_tree_from_source_html(self.html_content) {
@@ -2923,11 +3040,7 @@ fn Browser::build_accessibility_tree(self : Browser) -> Unit {
   )
   // Render with CSS to get proper layout bounds
   // Use the document with synthetic IDs for consistent ID matching
-  let layout = @renderer.render_document_with_external_css(
-    doc,
-    ctx,
-    self.external_css,
-  )
+  let (_, layout) = self.render_node_and_layout_from_document(doc, ctx, false)
   // Build accessibility tree with renderer's layout bounds
   let tree = @aom.build_accessibility_tree_with_node_layout(doc, layout)
   self.a11y_tree = Some(tree)
@@ -4748,11 +4861,15 @@ pub fn Browser::debug_layout(self : Browser) -> Unit {
     self.viewport_height,
     false,
   )
-  let layout = @renderer.render_with_external_css(
-    self.html_content,
-    ctx,
-    self.external_css,
-  )
+  let layout = match self.parsed_doc {
+    Some(doc) => self.render_node_and_layout_from_document(doc, ctx, false).1
+    None =>
+      @renderer.render_with_external_css(
+        self.html_content,
+        ctx,
+        self.external_css,
+      )
+  }
   println("=== Layout Tree ===")
   @renderer.print_layout_tree_with_options(layout, 0, true)
   println("===================")
@@ -4830,8 +4947,9 @@ fn char_at(s : String, i : Int) -> Char {
 }
 
 ///|
-/// Extract links from HTML content (memory-efficient version)
-fn extract_links(html : String) -> Array[Link] {
+/// Extract links from HTML content (portable fallback version)
+#cfg(not(target="js"))
+fn extract_links_fallback(html : String) -> Array[Link] {
   let links : Array[Link] = []
   let len = html.length()
   let mut i = 0
@@ -4903,6 +5021,46 @@ fn extract_links(html : String) -> Array[Link] {
     i = i + 1
   }
   links
+}
+
+///|
+#cfg(target="js")
+extern "js" fn extract_links_js(html : String) -> Array[Link] =
+  #| (html) => {
+  #|   const links = [];
+  #|   const anchorRe = /<a\b([^>]*)>([\s\S]*?)<\/a\s*>/gi;
+  #|   const readAttr = (attrs, name) => {
+  #|     const re = new RegExp(
+  #|       "\\b" + name + "\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)'|([^\\s\"'>]+))",
+  #|       "i",
+  #|     );
+  #|     const match = re.exec(attrs);
+  #|     return match ? String(match[1] ?? match[2] ?? match[3] ?? "") : "";
+  #|   };
+  #|   let match;
+  #|   while ((match = anchorRe.exec(html)) !== null) {
+  #|     const attrs = String(match[1] ?? "");
+  #|     const href = readAttr(attrs, "href");
+  #|     if (!href) continue;
+  #|     links.push({
+  #|       href,
+  #|       text: String(match[2] ?? "").trim(),
+  #|       source_id: readAttr(attrs, "id"),
+  #|     });
+  #|   }
+  #|   return links;
+  #| }
+
+///|
+#cfg(target="js")
+fn extract_links(html : String) -> Array[Link] {
+  extract_links_js(html)
+}
+
+///|
+#cfg(not(target="js"))
+fn extract_links(html : String) -> Array[Link] {
+  extract_links_fallback(html)
 }
 
 ///|
@@ -5408,20 +5566,20 @@ fn Browser::sync_render_state_from_dom_tree(self : Browser) -> Bool {
         return false
       }
       self.html_content = next_html
-      self.links = extract_links(self.html_content)
+      self.html_has_declarative_shadow_dom = html_source_has_declarative_shadow_dom(
+        self.html_content,
+      )
+      let next_doc = @html.assign_synthetic_ids(
+        @html.parse_document(self.html_content),
+      )
+      self.parsed_doc = Some(next_doc)
+      self.refresh_links_from_render_source()
       if self.links.length() == 0 {
         self.focused_link = 0
       } else if self.focused_link >= self.links.length() {
         self.focused_link = self.links.length() - 1
       }
-      let next_doc = @html.assign_synthetic_ids(
-        @html.parse_document(self.html_content),
-      )
-      self.parsed_doc = Some(next_doc)
-      self.render_node = None
-      self.layout_tree = None
-      self.prev_buffer = None
-      self.last_render_key = ""
+      self.clear_render_cache()
       self.content_height = @renderer.get_content_height_with_document(
         next_doc,
         self.viewport_width,
@@ -5595,10 +5753,11 @@ fn create_empty_html_dom_tree() -> @dom.DomTree {
 }
 
 ///|
-fn normalize_declarative_shadow_source_html(
+fn normalize_declarative_shadow_source_html_with_hint(
   html : String,
+  has_declarative_shadow_dom : Bool,
 ) -> NormalizedShadowSourceHtml? {
-  if !html_source_has_declarative_shadow_dom(html) {
+  if !has_declarative_shadow_dom {
     return None
   }
   match build_dom_tree_from_source_html(html) {

--- a/browser/shell/browser_js_wbtest.mbt
+++ b/browser/shell/browser_js_wbtest.mbt
@@ -5248,6 +5248,53 @@ test "Browser set_html_content eagerly normalizes declarative shadow DOM source"
 }
 
 ///|
+test "Browser caches prepared render document for repeated graphics renders" {
+  let browser = Browser::new(160, 120, terminal_cols=20)
+  let html =
+    #|<html>
+    #|<head>
+    #|  <style>
+    #|    body { margin: 0; background: #fff; }
+    #|    .card { width: 80px; height: 40px; background: #1463ff; }
+    #|  </style>
+    #|</head>
+    #|<body><div class="card">cached</div></body>
+    #|</html>
+  browser.set_html_content(html)
+  inspect(browser.prepared_render_document is None, content="true")
+  let first = browser.render_output(Sixel)
+  assert_true(first.length() > 0)
+  inspect(browser.prepared_render_document is Some(_), content="true")
+  let second = browser.render_output(Sixel)
+  assert_eq(second, first)
+  inspect(browser.prepared_render_document is Some(_), content="true")
+  browser.set_html_content("<html><body><p>next</p></body></html>")
+  inspect(browser.prepared_render_document is None, content="true")
+}
+
+///|
+test "Browser caches graphics node and layout for repeated graphics renders" {
+  let browser = Browser::new(160, 120, terminal_cols=20)
+  let html =
+    #|<html>
+    #|<head><style>body { margin: 0; } .card { width: 80px; height: 40px; background: #1463ff; }</style></head>
+    #|<body><div class="card">cached</div></body>
+    #|</html>
+  browser.set_html_content(html)
+  inspect(browser.graphics_render_node is None, content="true")
+  inspect(browser.graphics_layout is None, content="true")
+  ignore(browser.render_output(Sixel))
+  inspect(browser.graphics_render_node is Some(_), content="true")
+  inspect(browser.graphics_layout is Some(_), content="true")
+  ignore(browser.render_output(Kitty))
+  inspect(browser.graphics_render_node is Some(_), content="true")
+  inspect(browser.graphics_layout is Some(_), content="true")
+  browser.set_html_content("<html><body><p>next</p></body></html>")
+  inspect(browser.graphics_render_node is None, content="true")
+  inspect(browser.graphics_layout is None, content="true")
+}
+
+///|
 test "Browser set_html_content rebuilds link cache from normalized shadow content" {
   let browser = Browser::new(800, 600)
   let html =

--- a/browser/shell/moon.pkg
+++ b/browser/shell/moon.pkg
@@ -6,6 +6,7 @@ import {
   "mizchi/crater-browser-contract" @browser_contract,
   "mizchi/crater-dom/aom",
   "mizchi/crater-layout" @layout,
+  "mizchi/crater-layout/types",
   "mizchi/crater-dom/dom",
   "mizchi/crater-dom/scheduler",
   "mizchi/crater-browser-http" @http,
@@ -31,6 +32,7 @@ supported_targets = "js+native"
 
 options(
   targets: {
+    "browser_fixture_support_wbtest.mbt": [ "js" ],
     "browser_js_wbtest.mbt": [ "js" ],
     "perf_js.mbt": [ "js" ],
     "perf_js_wbtest.mbt": [ "js" ],

--- a/dom/dom/query.mbt
+++ b/dom/dom/query.mbt
@@ -53,7 +53,7 @@ fn DomTree::query_recursive(
   let node = self.nodes.get(node_id)
   guard node is Some(node) else { return }
   // Check if this node matches
-  if self.matches_selector(node, selector) {
+  if matches_selector(node, selector) {
     results.push(NodeId(node_id))
   }
   // Recurse into children
@@ -64,13 +64,7 @@ fn DomTree::query_recursive(
 
 ///|
 /// Check if node matches selector (simplified)
-fn DomTree::matches_selector(
-  self : DomTree,
-  node : DomNode,
-  selector : String,
-) -> Bool {
-  // Suppress unused warning
-  let _ = self
+fn matches_selector(node : DomNode, selector : String) -> Bool {
   // Only match elements
   guard node.node_type == Element else { return false }
   // Simple selector matching

--- a/layout/flex/flex.mbt
+++ b/layout/flex/flex.mbt
@@ -4137,12 +4137,6 @@ fn compute_internal(
   // - flex-direction: column flows horizontally (like row in horizontal-tb)
   let is_vertical_writing = style.writing_mode.is_vertical()
   let is_block_rtl = style.writing_mode.is_block_rtl()
-  // Check if width is a fixed length (used for intrinsic sizing decisions)
-  let width_is_length = match style.width {
-    @types.Length(_) => true
-    _ => false
-  }
-  let _ = width_is_length // silence unused warning for now
   let effective_direction = style.flex_direction
   let is_rtl = style.direction.is_rtl()
   let axis = @alignment.resolve_flex_axis(

--- a/layout/grid/grid.mbt
+++ b/layout/grid/grid.mbt
@@ -6298,11 +6298,11 @@ fn apply_alignment(
   let remaining_height = available_height - item_height
 
   // Calculate auto margins
-  let (final_margin_left, final_margin_right) = @core.resolve_auto_margin_pair(
+  let (final_margin_left, _) = @core.resolve_auto_margin_pair(
     margin_left_is_auto, margin_right_is_auto, fixed_margin_left, fixed_margin_right,
     remaining_width,
   )
-  let (final_margin_top, final_margin_bottom) = @core.resolve_auto_margin_pair(
+  let (final_margin_top, _) = @core.resolve_auto_margin_pair(
     margin_top_is_auto, margin_bottom_is_auto, fixed_margin_top, fixed_margin_bottom,
     remaining_height,
   )
@@ -6314,10 +6314,6 @@ fn apply_alignment(
   let y_offset = @core.compute_grid_self_alignment_offset(
     align, available_height, item_height, margin_top_is_auto, margin_bottom_is_auto,
   )
-
-  // Suppress unused variable warnings
-  let _ = final_margin_right
-  let _ = final_margin_bottom
 
   // Apply inset only for position:relative.
   let (inset_x, inset_y) = if child_style.position == @types.Relative {

--- a/painter/paint/viewport_bridge/viewport.mbt
+++ b/painter/paint/viewport_bridge/viewport.mbt
@@ -359,6 +359,7 @@ fn node_can_be_pruned_when_covered(node : @model.PaintNode) -> Bool {
 ///|
 fn prune_fully_covered_children(
   children : Array[@model.PaintNode],
+  child_has_transform : Array[Bool],
 ) -> Array[@model.PaintNode] {
   if children.length() <= 1 {
     return children
@@ -367,11 +368,22 @@ fn prune_fully_covered_children(
   for i = 0; i < children.length(); i = i + 1 {
     let child = children[i]
     let mut covered = false
-    if node_can_be_pruned_when_covered(child) {
+    let child_uses_transform = if i < child_has_transform.length() {
+      child_has_transform[i]
+    } else {
+      true
+    }
+    if !child_uses_transform && node_can_be_pruned_when_covered(child) {
       let child_rect = paint_node_rect(child)
       for j = i + 1; j < children.length(); j = j + 1 {
         let cover = children[j]
-        if cover.stacking_order >= child.stacking_order &&
+        let cover_uses_transform = if j < child_has_transform.length() {
+          child_has_transform[j]
+        } else {
+          true
+        }
+        if !cover_uses_transform &&
+          cover.stacking_order >= child.stacking_order &&
           node_paints_opaque_rect(cover) &&
           cull_rect_covers(paint_node_rect(cover), child_rect) {
           covered = true
@@ -457,6 +469,7 @@ fn from_node_and_layout_with_viewport_inner(
   }
   let tag = extract_tag_from_id(node.id)
   let children : Array[@model.PaintNode] = []
+  let child_has_transform : Array[Bool] = []
   let child_clip = match node_clip_rect(abs_x, abs_y, layout, node.style.clip) {
     Some(node_clip) => cull_rect_intersection(clip_rect, node_clip)
     None => Some(clip_rect)
@@ -534,6 +547,7 @@ fn from_node_and_layout_with_viewport_inner(
               )
             }
             children.push(current)
+            child_has_transform.push(!child_node.style.transform.is_none())
           }
           None => ()
         }
@@ -576,9 +590,11 @@ fn from_node_and_layout_with_viewport_inner(
     layout.y,
     layout.width,
     layout.height,
-    residual_visual_transform(node.style.transform),
+    node.style.transform,
   )
-  let paint_children = prune_fully_covered_children(children)
+  let paint_children = prune_fully_covered_children(
+    children, child_has_transform,
+  )
   Some(
     @model.PaintNode::new(
       node.id,
@@ -600,17 +616,6 @@ fn from_node_and_layout_with_viewport_inner(
 }
 
 ///|
-fn residual_visual_transform(transform : @style.Transform) -> @style.Transform {
-  {
-    ..transform,
-    translate_x: @style.TranslateValue::Length(0.0),
-    translate_y: @style.TranslateValue::Length(0.0),
-    scale_x: 1.0,
-    scale_y: 1.0,
-  }
-}
-
-///|
 fn visual_transform_bounds(
   x : Double,
   y : Double,
@@ -621,14 +626,25 @@ fn visual_transform_bounds(
   if transform.has_skew() || transform.has_affine_matrix() {
     visual_affine_transform_bounds(x, y, width, height, transform)
   } else {
+    let translate_x = transform.compute_translate_x(width)
+    let translate_y = transform.compute_translate_y(height)
+    let scaled_width = width * transform.scale_x.abs()
+    let scaled_height = height * transform.scale_y.abs()
     match transform.quarter_turns() {
-      0 | 2 => (x, y, width, height, [])
+      0 | 2 =>
+        (
+          x + translate_x + (width - scaled_width) / 2.0,
+          y + translate_y + (height - scaled_height) / 2.0,
+          scaled_width,
+          scaled_height,
+          [],
+        )
       1 | 3 =>
         (
-          x + (width - height) / 2.0,
-          y + (height - width) / 2.0,
-          height,
-          width,
+          x + translate_x + (width - scaled_height) / 2.0,
+          y + translate_y + (height - scaled_width) / 2.0,
+          scaled_height,
+          scaled_width,
           [],
         )
       _ => visual_affine_transform_bounds(x, y, width, height, transform)
@@ -664,60 +680,40 @@ fn visual_affine_transform_bounds(
   let matrix_f = if transform.has_matrix { transform.matrix_f } else { 0.0 }
   let center_x = x + width / 2.0
   let center_y = y + height / 2.0
-  let points : Array[(Double, Double)] = [
-    transform_point(
-      x, y, center_x, center_y, cos_a, sin_a, skew_x, skew_y, matrix_a, matrix_b,
-      matrix_c, matrix_d, matrix_e, matrix_f,
-    ),
-    transform_point(
-      x + width,
-      y,
-      center_x,
-      center_y,
-      cos_a,
-      sin_a,
-      skew_x,
-      skew_y,
-      matrix_a,
-      matrix_b,
-      matrix_c,
-      matrix_d,
-      matrix_e,
-      matrix_f,
-    ),
-    transform_point(
-      x + width,
-      y + height,
-      center_x,
-      center_y,
-      cos_a,
-      sin_a,
-      skew_x,
-      skew_y,
-      matrix_a,
-      matrix_b,
-      matrix_c,
-      matrix_d,
-      matrix_e,
-      matrix_f,
-    ),
-    transform_point(
-      x,
-      y + height,
-      center_x,
-      center_y,
-      cos_a,
-      sin_a,
-      skew_x,
-      skew_y,
-      matrix_a,
-      matrix_b,
-      matrix_c,
-      matrix_d,
-      matrix_e,
-      matrix_f,
-    ),
+  let translate_x = transform.compute_translate_x(width)
+  let translate_y = transform.compute_translate_y(height)
+  let corners : Array[(Double, Double)] = [
+    (x, y),
+    (x + width, y),
+    (x + width, y + height),
+    (x, y + height),
   ]
+  let points : Array[(Double, Double)] = []
+  for corner in corners {
+    let (corner_x, corner_y) = corner
+    points.push(
+      transform_point(
+        corner_x,
+        corner_y,
+        center_x,
+        center_y,
+        cos_a,
+        sin_a,
+        skew_x,
+        skew_y,
+        matrix_a,
+        matrix_b,
+        matrix_c,
+        matrix_d,
+        matrix_e,
+        matrix_f,
+        transform.scale_x,
+        transform.scale_y,
+        translate_x,
+        translate_y,
+      ),
+    )
+  }
   let (min_x, min_y, bbox_width, bbox_height) = polygon_bounds(points)
   let local_points : Array[(Double, Double)] = []
   for point in points {
@@ -751,16 +747,26 @@ fn transform_point(
   matrix_d : Double,
   matrix_e : Double,
   matrix_f : Double,
+  scale_x : Double,
+  scale_y : Double,
+  translate_x : Double,
+  translate_y : Double,
 ) -> (Double, Double) {
   let dx = x - center_x
   let dy = y - center_y
-  let matrix_x = matrix_a * dx + matrix_c * dy + matrix_e
-  let matrix_y = matrix_b * dx + matrix_d * dy + matrix_f
+  let scaled_x = dx * scale_x
+  let scaled_y = dy * scale_y
+  let matrix_x = matrix_a * scaled_x + matrix_c * scaled_y + matrix_e
+  let matrix_y = matrix_b * scaled_x + matrix_d * scaled_y + matrix_f
   let skewed_x = matrix_x + skew_x * matrix_y
   let skewed_y = skew_y * matrix_x + matrix_y
   (
-    snap_near_integer(center_x + skewed_x * cos_a - skewed_y * sin_a),
-    snap_near_integer(center_y + skewed_x * sin_a + skewed_y * cos_a),
+    snap_near_integer(
+      center_x + translate_x + skewed_x * cos_a - skewed_y * sin_a,
+    ),
+    snap_near_integer(
+      center_y + translate_y + skewed_x * sin_a + skewed_y * cos_a,
+    ),
   )
 }
 

--- a/painter/x/kitty/kitty.mbt
+++ b/painter/x/kitty/kitty.mbt
@@ -64,6 +64,30 @@ fn write_kitty_pixel_triplet(
 }
 
 ///|
+fn kitty_pixel_triplet(triplets : Array[String], color_idx : Int) -> String {
+  if color_idx >= 0 && color_idx < triplets.length() {
+    triplets[color_idx]
+  } else {
+    kitty_white_triplet
+  }
+}
+
+///|
+fn framebuffer_uniform_color_index(fb : @image.Framebuffer) -> Int? {
+  let pixel_count = fb.width * fb.height
+  if pixel_count == 0 {
+    return None
+  }
+  let color_idx = fb.pixels[0]
+  for i in 1..<pixel_count {
+    if fb.pixels[i] != color_idx {
+      return None
+    }
+  }
+  Some(color_idx)
+}
+
+///|
 fn write_kitty_chunk_header(
   buf : StringBuilder,
   width : Int,
@@ -122,15 +146,105 @@ async fn[T : @io.Writer] write_kitty_chunk_header_to(
 }
 
 ///|
+fn write_repeated_kitty_triplet(
+  buf : StringBuilder,
+  triplet : String,
+  count : Int,
+) -> Unit {
+  if count > 0 {
+    buf.write_string(triplet.repeat(count))
+  }
+}
+
+///|
+fn to_kitty_uniform(
+  width : Int,
+  height : Int,
+  pixel_count : Int,
+  triplet : String,
+) -> String {
+  let buf = StringBuilder::new(size_hint=pixel_count * 4)
+  let full_chunk_payload = triplet.repeat(kitty_pixels_per_chunk)
+  let mut first_chunk = true
+  let mut pixel_index = 0
+  while pixel_index < pixel_count {
+    let remaining = pixel_count - pixel_index
+    let chunk_pixels = if remaining > kitty_pixels_per_chunk {
+      kitty_pixels_per_chunk
+    } else {
+      remaining
+    }
+    let has_more = pixel_index + chunk_pixels < pixel_count
+    write_kitty_chunk_header(buf, width, height, first_chunk, has_more)
+    if chunk_pixels == kitty_pixels_per_chunk {
+      buf.write_string(full_chunk_payload)
+    } else {
+      write_repeated_kitty_triplet(buf, triplet, chunk_pixels)
+    }
+    buf.write_string("\u001b\\")
+    first_chunk = false
+    pixel_index += chunk_pixels
+  }
+  buf.to_string()
+}
+
+///|
+async fn[T : @io.Writer] write_kitty_uniform(
+  writer : T,
+  width : Int,
+  height : Int,
+  pixel_count : Int,
+  triplet : String,
+) -> Unit {
+  let full_chunk_payload = triplet.repeat(kitty_pixels_per_chunk)
+  let mut first_chunk = true
+  let mut pixel_index = 0
+  while pixel_index < pixel_count {
+    let remaining = pixel_count - pixel_index
+    let chunk_pixels = if remaining > kitty_pixels_per_chunk {
+      kitty_pixels_per_chunk
+    } else {
+      remaining
+    }
+    let has_more = pixel_index + chunk_pixels < pixel_count
+    write_kitty_chunk_header_to(writer, width, height, first_chunk, has_more)
+    if chunk_pixels == kitty_pixels_per_chunk {
+      writer.write(full_chunk_payload) catch {
+        _ => return
+      }
+    } else if chunk_pixels > 0 {
+      writer.write(triplet.repeat(chunk_pixels)) catch {
+        _ => return
+      }
+    }
+    writer.write("\u001b\\") catch {
+      _ => return
+    }
+    first_chunk = false
+    pixel_index += chunk_pixels
+  }
+}
+
+///|
 /// Convert Framebuffer to Kitty Graphics Protocol string
 pub fn to_kitty(
   fb : @image.Framebuffer,
   palette : @image.DynamicPalette,
 ) -> String {
-  let buf = StringBuilder::new()
   let triplets = build_kitty_palette_triplets(palette)
-  let mut first_chunk = true
   let pixel_count = fb.width * fb.height
+  match framebuffer_uniform_color_index(fb) {
+    Some(color_idx) =>
+      return to_kitty_uniform(
+        fb.width,
+        fb.height,
+        pixel_count,
+        kitty_pixel_triplet(triplets, color_idx),
+      )
+    None => ()
+  }
+  let buf = StringBuilder::new(size_hint=pixel_count * 4)
+  let mut first_chunk = true
   let mut pixel_index = 0
   while pixel_index < pixel_count {
     let remaining = pixel_count - pixel_index
@@ -162,10 +276,23 @@ pub async fn[T : @io.Writer] write_kitty(
   palette : @image.DynamicPalette,
 ) -> Unit {
   let triplets = build_kitty_palette_triplets(palette)
+  let pixel_count = fb.width * fb.height
+  match framebuffer_uniform_color_index(fb) {
+    Some(color_idx) => {
+      write_kitty_uniform(
+        writer,
+        fb.width,
+        fb.height,
+        pixel_count,
+        kitty_pixel_triplet(triplets, color_idx),
+      )
+      return
+    }
+    None => ()
+  }
   let mut chunk = StringBuilder::new()
   let mut chunk_len = 0
   let mut first_chunk = true
-  let pixel_count = fb.width * fb.height
   for pixel_index in 0..<pixel_count {
     if chunk_len + 4 > kitty_chunk_size {
       write_kitty_chunk_header_to(

--- a/renderer/pkg.generated.mbti
+++ b/renderer/pkg.generated.mbti
@@ -14,6 +14,10 @@ pub fn diff_rendered_paint_trees(String, String, @types.Size[Double]) -> @diff.P
 
 pub fn prepare_external_css(Array[String]) -> @renderer.PreparedExternalCss
 
+pub fn prepare_vrt_page(String, @types.Size[Double], Array[String]) -> @vrt.PreparedVrtPage
+
+pub fn prepare_vrt_page_with_prepared_external_css(String, @types.Size[Double], @renderer.PreparedExternalCss) -> @vrt.PreparedVrtPage
+
 pub fn render_html_batch_variants(String, @types.Size[Double], Array[@vrt.RenderVariant]) -> Array[@vrt.RenderVariantResult]
 
 pub fn render_html_to_paint_tree(String, @types.Size[Double]) -> @model.PaintNode
@@ -23,6 +27,10 @@ pub fn render_html_to_paint_tree_json(String, @types.Size[Double]) -> String
 pub fn render_html_to_paint_tree_with_external_css(String, @types.Size[Double], Array[String]) -> @model.PaintNode
 
 pub fn render_html_to_paint_tree_with_prepared_external_css(String, @types.Size[Double], @renderer.PreparedExternalCss) -> @model.PaintNode
+
+pub fn render_prepared_vrt_page_to_paint_tree(@vrt.PreparedVrtPage) -> @model.PaintNode
+
+pub fn render_prepared_vrt_page_to_paint_tree_json(@vrt.PreparedVrtPage) -> String
 
 // Errors
 
@@ -34,6 +42,8 @@ pub using @vrt {type CssMutation}
 pub using @vrt {type CssMutationAction}
 
 pub using @renderer {type PreparedExternalCss}
+
+pub using @vrt {type PreparedVrtPage}
 
 pub using @vrt {type RenderVariant}
 

--- a/renderer/top.mbt
+++ b/renderer/top.mbt
@@ -1,6 +1,7 @@
 ///|
 pub using @vrt {
   type CssMutation,
+  type PreparedVrtPage,
   type CssMutationAction,
   type RenderVariant,
   type RenderVariantResult,
@@ -14,6 +15,38 @@ pub fn prepare_external_css(
   external_css : Array[String],
 ) -> PreparedExternalCss {
   @renderer_core.prepare_external_css(external_css)
+}
+
+///|
+pub fn prepare_vrt_page(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : Array[String],
+) -> PreparedVrtPage {
+  @vrt.prepare_vrt_page(html, viewport, external_css)
+}
+
+///|
+pub fn prepare_vrt_page_with_prepared_external_css(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : PreparedExternalCss,
+) -> PreparedVrtPage {
+  @vrt.prepare_vrt_page_with_prepared_external_css(html, viewport, external_css)
+}
+
+///|
+pub fn render_prepared_vrt_page_to_paint_tree(
+  page : PreparedVrtPage,
+) -> @paint_model.PaintNode {
+  @vrt.render_prepared_vrt_page_to_paint_tree(page)
+}
+
+///|
+pub fn render_prepared_vrt_page_to_paint_tree_json(
+  page : PreparedVrtPage,
+) -> String {
+  @vrt.render_prepared_vrt_page_to_paint_tree_json(page)
 }
 
 ///|

--- a/renderer/vrt/moon.pkg
+++ b/renderer/vrt/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "mizchi/crater-layout" @layout,
   "mizchi/crater-layout/types",
   "mizchi/crater-dom/html",
   "mizchi/crater-painter/paint/model" @paint_model,

--- a/renderer/vrt/pkg.generated.mbti
+++ b/renderer/vrt/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "mizchi/crater-renderer/vrt"
 
 import {
+  "mizchi/crater-dom/html",
   "mizchi/crater-layout/types",
   "mizchi/crater-painter/paint/diff",
   "mizchi/crater-painter/paint/model",
@@ -12,6 +13,12 @@ import {
 // Values
 pub fn diff_rendered_paint_trees(String, String, @types.Size[Double]) -> @diff.PaintTreeDiff
 
+pub fn prepare_external_css(Array[String]) -> @renderer.PreparedExternalCss
+
+pub fn prepare_vrt_page(String, @types.Size[Double], Array[String]) -> PreparedVrtPage
+
+pub fn prepare_vrt_page_with_prepared_external_css(String, @types.Size[Double], @renderer.PreparedExternalCss) -> PreparedVrtPage
+
 pub fn render_html_batch_variants(String, @types.Size[Double], Array[RenderVariant]) -> Array[RenderVariantResult]
 
 pub fn render_html_to_paint_tree(String, @types.Size[Double]) -> @model.PaintNode
@@ -21,6 +28,10 @@ pub fn render_html_to_paint_tree_json(String, @types.Size[Double]) -> String
 pub fn render_html_to_paint_tree_with_external_css(String, @types.Size[Double], Array[String]) -> @model.PaintNode
 
 pub fn render_html_to_paint_tree_with_prepared_external_css(String, @types.Size[Double], @renderer.PreparedExternalCss) -> @model.PaintNode
+
+pub fn render_prepared_vrt_page_to_paint_tree(PreparedVrtPage) -> @model.PaintNode
+
+pub fn render_prepared_vrt_page_to_paint_tree_json(PreparedVrtPage) -> String
 
 // Errors
 
@@ -37,6 +48,13 @@ pub(all) enum CssMutationAction {
   Override(String)
 } derive(Eq, @debug.Debug)
 pub impl Show for CssMutationAction
+
+pub(all) struct PreparedVrtPage {
+  doc : @html.Document
+  viewport : @types.Size[Double]
+  ctx : @renderer.RenderContext
+  prepared : @renderer.PreparedRenderDocument
+}
 
 pub(all) struct RenderVariant {
   id : String

--- a/renderer/vrt/top.mbt
+++ b/renderer/vrt/top.mbt
@@ -10,6 +10,97 @@ fn make_render_context(
 }
 
 ///|
+fn paint_tree_from_node_layout(
+  node : @layout.Node,
+  layout : @types.Layout,
+  viewport : @types.Size[Double],
+) -> @paint_model.PaintNode {
+  match
+    @paint_render.from_node_and_layout_with_viewport_rect(
+      node,
+      layout,
+      0.0,
+      0.0,
+      viewport.width,
+      viewport.height,
+      0.0,
+      0.0,
+    ) {
+    Some(paint_tree) => paint_tree
+    None => @paint_render.from_node_and_layout(node, layout)
+  }
+}
+
+///|
+pub(all) struct PreparedVrtPage {
+  doc : @html.Document
+  viewport : @types.Size[Double]
+  ctx : @renderer.RenderContext
+  prepared : @renderer.PreparedRenderDocument
+}
+
+///|
+pub fn prepare_external_css(
+  external_css : Array[String],
+) -> @renderer.PreparedExternalCss {
+  @renderer.prepare_external_css(external_css)
+}
+
+///|
+pub fn prepare_vrt_page(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : Array[String],
+) -> PreparedVrtPage {
+  let doc = @html.parse_document(html)
+  let ctx = make_render_context(viewport)
+  {
+    doc,
+    viewport,
+    ctx,
+    prepared: @renderer.prepare_render_document(doc, ctx, external_css),
+  }
+}
+
+///|
+pub fn prepare_vrt_page_with_prepared_external_css(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : @renderer.PreparedExternalCss,
+) -> PreparedVrtPage {
+  let doc = @html.parse_document(html)
+  let ctx = make_render_context(viewport)
+  {
+    doc,
+    viewport,
+    ctx,
+    prepared: @renderer.prepare_render_document_with_prepared_external_css(
+      doc, ctx, external_css,
+    ),
+  }
+}
+
+///|
+pub fn render_prepared_vrt_page_to_paint_tree(
+  page : PreparedVrtPage,
+) -> @paint_model.PaintNode {
+  let node = @renderer.build_render_root_node(page.doc, page.ctx, page.prepared)
+  let layout = @renderer.compute_layout_from_render_root(
+    node,
+    page.prepared,
+    page.ctx,
+  )
+  paint_tree_from_node_layout(node, layout, page.viewport)
+}
+
+///|
+pub fn render_prepared_vrt_page_to_paint_tree_json(
+  page : PreparedVrtPage,
+) -> String {
+  render_prepared_vrt_page_to_paint_tree(page).to_json_string()
+}
+
+///|
 pub fn render_html_to_paint_tree(
   html : String,
   viewport : @types.Size[Double],
@@ -28,20 +119,7 @@ pub fn render_html_to_paint_tree_with_external_css(
     make_render_context(viewport),
     external_css,
   )
-  match
-    @paint_render.from_node_and_layout_with_viewport_rect(
-      node,
-      layout,
-      0.0,
-      0.0,
-      viewport.width,
-      viewport.height,
-      0.0,
-      0.0,
-    ) {
-    Some(paint_tree) => paint_tree
-    None => @paint_render.from_node_and_layout(node, layout)
-  }
+  paint_tree_from_node_layout(node, layout, viewport)
 }
 
 ///|
@@ -56,20 +134,7 @@ pub fn render_html_to_paint_tree_with_prepared_external_css(
     make_render_context(viewport),
     external_css,
   )
-  match
-    @paint_render.from_node_and_layout_with_viewport_rect(
-      node,
-      layout,
-      0.0,
-      0.0,
-      viewport.width,
-      viewport.height,
-      0.0,
-      0.0,
-    ) {
-    Some(paint_tree) => paint_tree
-    None => @paint_render.from_node_and_layout(node, layout)
-  }
+  paint_tree_from_node_layout(node, layout, viewport)
 }
 
 ///|
@@ -180,20 +245,7 @@ pub fn render_html_batch_variants(
     let (node, layout) = @renderer.render_to_node_and_layout_with_document(
       doc, ctx, external_css,
     )
-    let paint_tree = match
-      @paint_render.from_node_and_layout_with_viewport_rect(
-        node,
-        layout,
-        0.0,
-        0.0,
-        viewport.width,
-        viewport.height,
-        0.0,
-        0.0,
-      ) {
-      Some(pt) => pt
-      None => @paint_render.from_node_and_layout(node, layout)
-    }
+    let paint_tree = paint_tree_from_node_layout(node, layout, viewport)
     results.push({ id: variant.id, paint_tree })
   }
   results

--- a/renderer/vrt/top_test.mbt
+++ b/renderer/vrt/top_test.mbt
@@ -32,3 +32,22 @@ test "vrt package renders batch variants" {
   assert_eq(results[0].id, "baseline")
   assert_eq(results[1].id, "wider")
 }
+
+///|
+test "vrt prepared page matches direct paint tree rendering" {
+  let html =
+    #|<html><body><section class="box"><h1>Prepared</h1><p>cached css and document</p></section></body></html>
+  let viewport = @types.Size::new(640.0, 480.0)
+  let css = prepare_external_css([
+    ".box { width: 240px; height: 120px; padding: 16px; background: #ffffff; }",
+    ".box h1 { margin: 0 0 8px; font-size: 24px; }",
+  ])
+  let prepared = prepare_vrt_page_with_prepared_external_css(
+    html, viewport, css,
+  )
+  let expected = render_html_to_paint_tree_with_prepared_external_css(
+    html, viewport, css,
+  ).to_json_string()
+  let actual = render_prepared_vrt_page_to_paint_tree(prepared).to_json_string()
+  assert_eq(actual, expected)
+}

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -31,6 +31,10 @@ pub fn diff_rendered_paint_trees(String, String, @types.Size[Double]) -> @diff.P
 
 pub fn prepare_external_css(Array[String]) -> @renderer.PreparedExternalCss
 
+pub fn prepare_vrt_page(String, @types.Size[Double], Array[String]) -> @vrt.PreparedVrtPage
+
+pub fn prepare_vrt_page_with_prepared_external_css(String, @types.Size[Double], @renderer.PreparedExternalCss) -> @vrt.PreparedVrtPage
+
 pub fn render_html_batch_variants(String, @types.Size[Double], Array[@vrt.RenderVariant]) -> Array[@vrt.RenderVariantResult]
 
 pub fn render_html_to_paint_tree(String, @types.Size[Double]) -> @model.PaintNode
@@ -40,6 +44,10 @@ pub fn render_html_to_paint_tree_json(String, @types.Size[Double]) -> String
 pub fn render_html_to_paint_tree_with_external_css(String, @types.Size[Double], Array[String]) -> @model.PaintNode
 
 pub fn render_html_to_paint_tree_with_prepared_external_css(String, @types.Size[Double], @renderer.PreparedExternalCss) -> @model.PaintNode
+
+pub fn render_prepared_vrt_page_to_paint_tree(@vrt.PreparedVrtPage) -> @model.PaintNode
+
+pub fn render_prepared_vrt_page_to_paint_tree_json(@vrt.PreparedVrtPage) -> String
 
 pub fn validate_core_subset(@node.Node) -> Array[@core_subset.CoreIssue]
 
@@ -57,6 +65,8 @@ pub using @vrt {type CssMutation}
 pub using @vrt {type CssMutationAction}
 
 pub using @renderer {type PreparedExternalCss}
+
+pub using @vrt {type PreparedVrtPage}
 
 pub using @vrt {type RenderVariant}
 

--- a/src/top.mbt
+++ b/src/top.mbt
@@ -3,6 +3,7 @@ pub using @renderer_api {
   type CssMutation,
   type CssMutationAction,
   type PreparedExternalCss,
+  type PreparedVrtPage,
   type RenderVariant,
   type RenderVariantResult,
 }
@@ -103,6 +104,40 @@ pub fn prepare_external_css(
   external_css : Array[String],
 ) -> PreparedExternalCss {
   @renderer_api.prepare_external_css(external_css)
+}
+
+///|
+pub fn prepare_vrt_page(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : Array[String],
+) -> PreparedVrtPage {
+  @renderer_api.prepare_vrt_page(html, viewport, external_css)
+}
+
+///|
+pub fn prepare_vrt_page_with_prepared_external_css(
+  html : String,
+  viewport : @types.Size[Double],
+  external_css : PreparedExternalCss,
+) -> PreparedVrtPage {
+  @renderer_api.prepare_vrt_page_with_prepared_external_css(
+    html, viewport, external_css,
+  )
+}
+
+///|
+pub fn render_prepared_vrt_page_to_paint_tree(
+  page : PreparedVrtPage,
+) -> @paint.PaintNode {
+  @renderer_api.render_prepared_vrt_page_to_paint_tree(page)
+}
+
+///|
+pub fn render_prepared_vrt_page_to_paint_tree_json(
+  page : PreparedVrtPage,
+) -> String {
+  @renderer_api.render_prepared_vrt_page_to_paint_tree_json(page)
 }
 
 ///|

--- a/webdriver/webdriver/bidi_emulation_synthetic.mbt
+++ b/webdriver/webdriver/bidi_emulation_synthetic.mbt
@@ -161,26 +161,15 @@ fn BidiProtocol::resolve_effective_user_agent(
   self : BidiProtocol,
   ctx_id : String,
 ) -> String {
-  let ancestry = self.storage_context_ancestry(ctx_id)
-  let mut index = ancestry.length()
-  while index > 0 {
-    index = index - 1
-    let scope_id = ancestry[index]
-    match self.emulation_user_agent_by_context.get(scope_id) {
-      Some(user_agent) => return user_agent
-      None => ()
-    }
-  }
-  let user_context_id = self.context_user_context
-    .get(ctx_id)
-    .unwrap_or("default")
-  match self.emulation_user_agent_by_user_context.get(user_context_id) {
+  match
+    self.resolve_effective_scoped_override(
+      ctx_id,
+      self.emulation_user_agent_by_context,
+      self.emulation_user_agent_by_user_context,
+      self.emulation_user_agent_global,
+    ) {
     Some(user_agent) => user_agent
-    None =>
-      match self.emulation_user_agent_global {
-        Some(user_agent) => user_agent
-        None => default_runtime_user_agent()
-      }
+    None => default_runtime_user_agent()
   }
 }
 
@@ -189,26 +178,15 @@ fn BidiProtocol::resolve_effective_locale(
   self : BidiProtocol,
   ctx_id : String,
 ) -> String {
-  let ancestry = self.storage_context_ancestry(ctx_id)
-  let mut index = ancestry.length()
-  while index > 0 {
-    index = index - 1
-    let scope_id = ancestry[index]
-    match self.emulation_locale_by_context.get(scope_id) {
-      Some(locale) => return locale
-      None => ()
-    }
-  }
-  let user_context_id = self.context_user_context
-    .get(ctx_id)
-    .unwrap_or("default")
-  match self.emulation_locale_by_user_context.get(user_context_id) {
+  match
+    self.resolve_effective_scoped_override(
+      ctx_id,
+      self.emulation_locale_by_context,
+      self.emulation_locale_by_user_context,
+      self.emulation_locale_global,
+    ) {
     Some(locale) => locale
-    None =>
-      match self.emulation_locale_global {
-        Some(locale) => locale
-        None => default_runtime_locale()
-      }
+    None => default_runtime_locale()
   }
 }
 
@@ -217,26 +195,15 @@ fn BidiProtocol::resolve_effective_timezone(
   self : BidiProtocol,
   ctx_id : String,
 ) -> String {
-  let ancestry = self.storage_context_ancestry(ctx_id)
-  let mut index = ancestry.length()
-  while index > 0 {
-    index = index - 1
-    let scope_id = ancestry[index]
-    match self.emulation_timezone_by_context.get(scope_id) {
-      Some(timezone) => return timezone
-      None => ()
-    }
-  }
-  let user_context_id = self.context_user_context
-    .get(ctx_id)
-    .unwrap_or("default")
-  match self.emulation_timezone_by_user_context.get(user_context_id) {
+  match
+    self.resolve_effective_scoped_override(
+      ctx_id,
+      self.emulation_timezone_by_context,
+      self.emulation_timezone_by_user_context,
+      self.emulation_timezone_global,
+    ) {
     Some(timezone) => timezone
-    None =>
-      match self.emulation_timezone_global {
-        Some(timezone) => timezone
-        None => default_runtime_timezone()
-      }
+    None => default_runtime_timezone()
   }
 }
 

--- a/webdriver/webdriver/bidi_geolocation_synthetic.mbt
+++ b/webdriver/webdriver/bidi_geolocation_synthetic.mbt
@@ -28,23 +28,12 @@ fn BidiProtocol::resolve_effective_geolocation_override(
   self : BidiProtocol,
   ctx_id : String,
 ) -> Json? {
-  let ancestry = self.storage_context_ancestry(ctx_id)
-  let mut index = ancestry.length()
-  while index > 0 {
-    index = index - 1
-    let scope_id = ancestry[index]
-    match self.emulation_geolocation_by_context.get(scope_id) {
-      Some(override_value) => return Some(override_value)
-      None => ()
-    }
-  }
-  let user_context_id = self.context_user_context
-    .get(ctx_id)
-    .unwrap_or("default")
-  match self.emulation_geolocation_by_user_context.get(user_context_id) {
-    Some(override_value) => Some(override_value)
-    None => self.emulation_geolocation_global
-  }
+  self.resolve_effective_scoped_override(
+    ctx_id,
+    self.emulation_geolocation_by_context,
+    self.emulation_geolocation_by_user_context,
+    self.emulation_geolocation_global,
+  )
 }
 
 ///|

--- a/webdriver/webdriver/bidi_network_conditions_synthetic.mbt
+++ b/webdriver/webdriver/bidi_network_conditions_synthetic.mbt
@@ -135,23 +135,12 @@ fn BidiProtocol::resolve_effective_network_conditions(
   self : BidiProtocol,
   ctx_id : String,
 ) -> Json? {
-  let ancestry = self.storage_context_ancestry(ctx_id)
-  let mut index = ancestry.length()
-  while index > 0 {
-    index = index - 1
-    let scope_id = ancestry[index]
-    match self.emulation_network_conditions_by_context.get(scope_id) {
-      Some(override_value) => return Some(override_value)
-      None => ()
-    }
-  }
-  let user_context_id = self.context_user_context
-    .get(ctx_id)
-    .unwrap_or("default")
-  match self.emulation_network_conditions_by_user_context.get(user_context_id) {
-    Some(override_value) => Some(override_value)
-    None => self.emulation_network_conditions_global
-  }
+  self.resolve_effective_scoped_override(
+    ctx_id,
+    self.emulation_network_conditions_by_context,
+    self.emulation_network_conditions_by_user_context,
+    self.emulation_network_conditions_global,
+  )
 }
 
 ///|

--- a/webdriver/webdriver/bidi_protocol.mbt
+++ b/webdriver/webdriver/bidi_protocol.mbt
@@ -248,6 +248,33 @@ priv struct BidiProtocol {
 }
 
 ///|
+fn[T] BidiProtocol::resolve_effective_scoped_override(
+  self : BidiProtocol,
+  ctx_id : String,
+  by_context : Map[String, T],
+  by_user_context : Map[String, T],
+  global : T?,
+) -> T? {
+  let ancestry = self.storage_context_ancestry(ctx_id)
+  let mut index = ancestry.length()
+  while index > 0 {
+    index = index - 1
+    let scope_id = ancestry[index]
+    match by_context.get(scope_id) {
+      Some(override_value) => return Some(override_value)
+      None => ()
+    }
+  }
+  let user_context_id = self.context_user_context
+    .get(ctx_id)
+    .unwrap_or("default")
+  match by_user_context.get(user_context_id) {
+    Some(override_value) => Some(override_value)
+    None => global
+  }
+}
+
+///|
 /// Create new BiDi protocol instance
 fn BidiProtocol::new() -> BidiProtocol {
   let user_contexts : Map[String, Bool] = {}
@@ -1497,7 +1524,7 @@ fn BidiProtocol::dispatch_session(
       }
       let session_id = "bidi-" + request.id.to_string()
       let ctx_id = self.ensure_default_context()
-      let caps = self.build_capabilities()
+      let caps = build_capabilities()
       let result = make_object({
         "sessionId": Json::string(session_id),
         "capabilities": caps,
@@ -10336,7 +10363,7 @@ fn BidiProtocol::handle_input_perform_actions(
             normalized_key,
             action_type == "keyDown",
           )
-          self.dispatch_interaction_key_command(
+          dispatch_interaction_key_command(
             bidi_key_interaction_command(action_type, normalized_key),
             key_value,
             ctrl,
@@ -10532,7 +10559,7 @@ fn BidiProtocol::handle_input_perform_actions(
             let should_emit_move = pointer_type == "mouse" ||
               button_state_contains(buttons, button_to_mask(0))
             if should_emit_move {
-              self.dispatch_interaction_hover_sequence(
+              dispatch_interaction_hover_sequence(
                 @interaction.pointer_hover_event_sequence(
                   pointer_type,
                   previous_target_shared != "" &&
@@ -10724,7 +10751,7 @@ fn BidiProtocol::handle_input_perform_actions(
                 width, height, pressure, tangential_pressure, twist, altitude_angle,
                 azimuth_angle,
               )
-              self.dispatch_interaction_pointer_sequence(
+              dispatch_interaction_pointer_sequence(
                 @interaction.pointer_press_event_sequence(pointer_type, button),
                 target_shared,
                 current_x,
@@ -10823,7 +10850,7 @@ fn BidiProtocol::handle_input_perform_actions(
               input_set_pointer_event_properties(
                 width, height, 0.0, tangential_pressure, twist, altitude_angle, azimuth_angle,
               )
-              self.dispatch_interaction_pointer_sequence(
+              dispatch_interaction_pointer_sequence(
                 @interaction.pointer_release_event_sequence(
                   pointer_type, button,
                 ),
@@ -10842,7 +10869,7 @@ fn BidiProtocol::handle_input_perform_actions(
                 ctrl &&
                 input_is_mac_platform()
               if is_mac_ctrl_left_click {
-                self.dispatch_interaction_pointer_sequence(
+                dispatch_interaction_pointer_sequence(
                   @interaction.pointer_post_release_mouse_event_sequence(
                     button, true, false, false,
                   ),
@@ -10969,7 +10996,7 @@ fn BidiProtocol::handle_input_perform_actions(
                 let was_dragged = self.input_pointer_dragged
                   .get(ctx_id)
                   .unwrap_or(false)
-                self.dispatch_interaction_pointer_sequence(
+                dispatch_interaction_pointer_sequence(
                   @interaction.pointer_post_release_mouse_event_sequence(
                     button,
                     false,
@@ -11012,7 +11039,7 @@ fn BidiProtocol::handle_input_perform_actions(
                 }
                 self.input_html_drag_transfer_id.remove(ctx_id)
               } else if button == 2 {
-                self.dispatch_interaction_pointer_sequence(
+                dispatch_interaction_pointer_sequence(
                   @interaction.pointer_post_release_mouse_event_sequence(
                     button, true, false, false,
                   ),
@@ -11028,7 +11055,7 @@ fn BidiProtocol::handle_input_perform_actions(
                 )
                 self.input_pending_double_click.remove(ctx_id)
               } else {
-                self.dispatch_interaction_pointer_sequence(
+                dispatch_interaction_pointer_sequence(
                   @interaction.pointer_post_release_mouse_event_sequence(
                     button, false, false, false,
                   ),
@@ -11195,7 +11222,7 @@ fn BidiProtocol::handle_input_release_actions(
     let (ctrl, alt, shift, meta) = self.resolve_input_modifiers(
       ctx_id, "", false,
     )
-    self.dispatch_interaction_key_command(
+    dispatch_interaction_key_command(
       bidi_key_interaction_command("keyUp", key),
       dispatch_key,
       ctrl,
@@ -11212,7 +11239,7 @@ fn BidiProtocol::handle_input_release_actions(
   let target_shared = self.input_pointer_target_shared.get(ctx_id).unwrap_or("")
   let current_buttons = self.input_pointer_buttons.get(ctx_id).unwrap_or(0)
   if button_state_contains(current_buttons, button_to_mask(2)) {
-    self.dispatch_interaction_pointer_command(
+    dispatch_interaction_pointer_command(
       bidi_pointer_interaction_command("pointerUp", current_x, current_y, 2),
       target_shared,
       current_x,
@@ -11239,7 +11266,7 @@ fn BidiProtocol::handle_input_release_actions(
     )
   }
   if button_state_contains(current_buttons, button_to_mask(1)) {
-    self.dispatch_interaction_pointer_command(
+    dispatch_interaction_pointer_command(
       bidi_pointer_interaction_command("pointerUp", current_x, current_y, 1),
       target_shared,
       current_x,
@@ -11266,7 +11293,7 @@ fn BidiProtocol::handle_input_release_actions(
     )
   }
   if button_state_contains(current_buttons, button_to_mask(0)) {
-    self.dispatch_interaction_pointer_command(
+    dispatch_interaction_pointer_command(
       bidi_pointer_interaction_command("pointerUp", current_x, current_y, 0),
       target_shared,
       current_x,
@@ -11997,7 +12024,6 @@ fn BidiProtocol::ensure_pointer_within_viewport(
   x : Double,
   y : Double,
 ) -> Bool {
-  let _ = self
   if x < 0.0 || y < 0.0 || x > 1024.0 || y > 768.0 {
     self.send_error(
       request_id, "move target out of bounds", "Target coordinate is outside viewport",
@@ -17655,8 +17681,7 @@ fn BidiProtocol::get_or_create_sandbox_realm(
 
 ///|
 /// Build capabilities response
-fn BidiProtocol::build_capabilities(self : BidiProtocol) -> Json {
-  let _ = self
+fn build_capabilities() -> Json {
   make_object({
     "browserName": Json::string("crater"),
     "browserVersion": Json::string("0.1.0"),

--- a/webdriver/webdriver/bidi_screen_orientation_synthetic.mbt
+++ b/webdriver/webdriver/bidi_screen_orientation_synthetic.mbt
@@ -74,26 +74,15 @@ fn BidiProtocol::resolve_effective_screen_orientation(
   self : BidiProtocol,
   ctx_id : String,
 ) -> Json {
-  let ancestry = self.storage_context_ancestry(ctx_id)
-  let mut index = ancestry.length()
-  while index > 0 {
-    index = index - 1
-    let scope_id = ancestry[index]
-    match self.emulation_screen_orientation_by_context.get(scope_id) {
-      Some(override_value) => return override_value
-      None => ()
-    }
-  }
-  let user_context_id = self.context_user_context
-    .get(ctx_id)
-    .unwrap_or("default")
-  match self.emulation_screen_orientation_by_user_context.get(user_context_id) {
+  match
+    self.resolve_effective_scoped_override(
+      ctx_id,
+      self.emulation_screen_orientation_by_context,
+      self.emulation_screen_orientation_by_user_context,
+      self.emulation_screen_orientation_global,
+    ) {
     Some(override_value) => override_value
-    None =>
-      match self.emulation_screen_orientation_global {
-        Some(override_value) => override_value
-        None => default_screen_orientation_json()
-      }
+    None => default_screen_orientation_json()
   }
 }
 

--- a/webdriver/webdriver/bidi_screen_settings_synthetic.mbt
+++ b/webdriver/webdriver/bidi_screen_settings_synthetic.mbt
@@ -33,30 +33,19 @@ fn BidiProtocol::resolve_effective_screen_area(
   self : BidiProtocol,
   ctx_id : String,
 ) -> Json {
-  let ancestry = self.storage_context_ancestry(ctx_id)
-  let mut index = ancestry.length()
-  while index > 0 {
-    index = index - 1
-    let scope_id = ancestry[index]
-    match self.emulation_screen_area_by_context.get(scope_id) {
-      Some(override_value) => return override_value
-      None => ()
-    }
-  }
-  let user_context_id = self.context_user_context
-    .get(ctx_id)
-    .unwrap_or("default")
-  match self.emulation_screen_area_by_user_context.get(user_context_id) {
+  match
+    self.resolve_effective_scoped_override(
+      ctx_id,
+      self.emulation_screen_area_by_context,
+      self.emulation_screen_area_by_user_context,
+      self.emulation_screen_area_global,
+    ) {
     Some(override_value) => override_value
     None =>
-      match self.emulation_screen_area_global {
-        Some(override_value) => override_value
-        None =>
-          build_screen_area_json(
-            self.resolve_effective_viewport_width(ctx_id),
-            self.resolve_effective_viewport_height(ctx_id),
-          )
-      }
+      build_screen_area_json(
+        self.resolve_effective_viewport_width(ctx_id),
+        self.resolve_effective_viewport_height(ctx_id),
+      )
   }
 }
 

--- a/webdriver/webdriver/input_interaction.mbt
+++ b/webdriver/webdriver/input_interaction.mbt
@@ -28,8 +28,7 @@ fn bidi_pointer_interaction_command(
 }
 
 ///|
-fn BidiProtocol::dispatch_interaction_key_command(
-  self : BidiProtocol,
+fn dispatch_interaction_key_command(
   command : @interaction.InteractionCommand,
   raw_key : String,
   ctrl : Bool,
@@ -37,7 +36,6 @@ fn BidiProtocol::dispatch_interaction_key_command(
   shift : Bool,
   meta : Bool,
 ) -> Unit {
-  let _ = self
   match command {
     @interaction.KeyDown(_) =>
       input_dispatch_key_action("keyDown", raw_key, ctrl, alt, shift, meta)
@@ -48,8 +46,7 @@ fn BidiProtocol::dispatch_interaction_key_command(
 }
 
 ///|
-fn BidiProtocol::dispatch_interaction_pointer_command(
-  self : BidiProtocol,
+fn dispatch_interaction_pointer_command(
   command : @interaction.InteractionCommand,
   target_shared : String,
   x : Double,
@@ -61,7 +58,6 @@ fn BidiProtocol::dispatch_interaction_pointer_command(
   shift : Bool,
   meta : Bool,
 ) -> Unit {
-  let _ = self
   match command {
     @interaction.PointerMove(_, _) => {
       input_dispatch_pointer_event(
@@ -90,8 +86,7 @@ fn BidiProtocol::dispatch_interaction_pointer_command(
 }
 
 ///|
-fn BidiProtocol::dispatch_interaction_pointer_sequence(
-  self : BidiProtocol,
+fn dispatch_interaction_pointer_sequence(
   events : Array[@interaction.PointerDispatchEvent],
   target_shared : String,
   x : Double,
@@ -103,7 +98,6 @@ fn BidiProtocol::dispatch_interaction_pointer_sequence(
   shift : Bool,
   meta : Bool,
 ) -> Unit {
-  let _ = self
   for event in events {
     input_dispatch_pointer_event(
       target_shared,
@@ -122,8 +116,7 @@ fn BidiProtocol::dispatch_interaction_pointer_sequence(
 }
 
 ///|
-fn BidiProtocol::dispatch_interaction_hover_sequence(
-  self : BidiProtocol,
+fn dispatch_interaction_hover_sequence(
   events : Array[@interaction.HoverDispatchEvent],
   previous_target_shared : String,
   current_target_shared : String,
@@ -136,7 +129,6 @@ fn BidiProtocol::dispatch_interaction_hover_sequence(
   shift : Bool,
   meta : Bool,
 ) -> Unit {
-  let _ = self
   for event in events {
     let target_shared = match event.target {
       @interaction.HoverPreviousTarget => previous_target_shared

--- a/webdriver/webdriver/server.mbt
+++ b/webdriver/webdriver/server.mbt
@@ -109,7 +109,7 @@ pub fn SessionManager::handle_request(
 ) -> (Int, WebDriverResponse) {
   match request.command {
     // Status endpoint (no session required)
-    Status => (200, self.handle_status())
+    Status => (200, handle_status())
 
     // Session management
     NewSession => {
@@ -224,8 +224,7 @@ pub fn SessionManager::handle_request(
 
 ///|
 /// Handle status request
-fn SessionManager::handle_status(self : SessionManager) -> WebDriverResponse {
-  let _ = self // suppress unused warning
+fn handle_status() -> WebDriverResponse {
   let map : Map[String, WebDriverValue] = {}
   map["ready"] = Bool(true)
   map["message"] = String("Crater WebDriver is ready")


### PR DESCRIPTION
## Summary
- add prepared VRT page render APIs and phase benchmarks
- cache browser graphics render state for repeated Sixel/Kitty renders
- optimize Kitty uniform framebuffer encoding
- refactor unused MoonBit helpers and fix transformed viewport culling

## Validation
- moon fmt
- moon info --target js
- moon check --target all --deny-warn -j 1
- moon test --target js -j 1 (4886 passed)
- moon bench --manifest-path benchmarks/moon.mod.json --target js -p mizchi/crater-benchmarks/browser_shell -j 1

## Bench Notes
- browser_sixel_github_mizchi_hot: ~7.01ms
- browser_kitty_github_mizchi_hot: ~4.88ms
- browser_sixel_github_mizchi: ~74.57ms
- browser_kitty_github_mizchi: ~62.70ms