### PR TITLE
Decode PNGs for sixel render on non-darwin hosts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,8 @@ importers:
         specifier: ^8.18.0
         version: 8.18.3
 
+  js: {}
+
   js/playground:
     devDependencies:
       vite:

--- a/terminal_image_cache/entry.mbt
+++ b/terminal_image_cache/entry.mbt
@@ -193,7 +193,7 @@ extern "js" fn js_decode_raster_image_to_rgba_base64(
 ) -> String =
   #| (imageFormat, b64Data) => {
   #|   try {
-  #|     if (typeof process === 'undefined' || process.platform !== 'darwin') {
+  #|     if (typeof process === 'undefined') {
   #|       return '';
   #|     }
   #|     const format = String(imageFormat || '').toLowerCase();
@@ -230,6 +230,9 @@ extern "js" fn js_decode_raster_image_to_rgba_base64(
   #|         ':' +
   #|         Buffer.from(decoded.data).toString('base64')
   #|       );
+  #|     }
+  #|     if (process.platform !== 'darwin') {
+  #|       return '';
   #|     }
   #|     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'crater-kitty-'));
   #|     const inputExt = format === 'jpeg' ? 'jpg' : 'gif';


### PR DESCRIPTION
## Summary
- `js_decode_raster_image_to_rgba_base64` short-circuited to `''` on any non-darwin host, but the darwin gate is only required for the sips-based JPEG/GIF transcode path. PNG decoding uses `pngjs` (pure JS) and is platform-agnostic.
- Move the darwin gate to just before the sips invocation so PNG decoding works on Linux runners. Fixes `sixel render composites cached data png image for img src` failing in `moon test --target js` on Linux CI.
- Refresh `pnpm-lock.yaml` after the workspace migration in #52 so the `js/` importer is recorded and `pngjs` is materialized under `.pnpm`.

## Test plan
- [x] Local: `moon test --target js -p mizchi/crater-browser/shell` → 159/159 pass
- [ ] CI: `test-moon` (`moon test --target js`) green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)