### PR TITLE
Guard committed .mbti against source drift

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -31,6 +31,7 @@ workflowTests {
     direct { check.checkFlaker.name }
     tasks {
       check.checkFlaker.name
+      check.checkMbti.name
       check.checkMoon.name
       check.checkTaskfile.name
       check.checkTs.name
@@ -94,6 +95,7 @@ workflowTests {
     }
     tasks {
       check.checkFlaker.name
+      check.checkMbti.name
       check.checkMoon.name
       check.checkTaskfile.name
       check.checkTs.name

--- a/tasks/check.pkl
+++ b/tasks/check.pkl
@@ -35,6 +35,14 @@ checkTaskfile: pkfire.Task = new {
   cache = false
 }
 
+checkMbti: pkfire.Task = new {
+  name = "check-mbti"
+  description = "Verify committed .mbti files match the current MoonBit sources"
+  visibility = "internal"
+  cmd = "moon info >/dev/null && git diff --exit-code -- '**/*.mbti'"
+  cache = false
+}
+
 check: pkfire.Task = new {
   name = "check"
   description = "Run fast local correctness gates"
@@ -44,6 +52,7 @@ check: pkfire.Task = new {
     checkTs
     checkFlaker
     checkTaskfile
+    checkMbti
     spec.specCheck
     spec.specLint
   }
@@ -54,5 +63,6 @@ tasks: Listing<pkfire.Task> = new {
   checkTs
   checkFlaker
   checkTaskfile
+  checkMbti
   check
 }


### PR DESCRIPTION
## Summary
- Add \`check-mbti\` to the fast correctness gate (\`check\`) so CI fails if any committed \`pkg.generated.mbti\` is stale relative to its MoonBit source. Catches accidental public API drift before release.
- Wire \`check-mbti\` into \`Taskfile.pkl\` workflowTests for the flaker/config and ci.yml change scenarios so \`pkf affected --check\` keeps preview tasks honest.

## Test plan
- [x] \`pkf run check-mbti\` clean locally
- [x] \`pkf affected --check\` → 6/6 workflow tests pass
- [x] \`pkf run spec\` → 18/18 scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)