### PR TITLE
Promote remote_value helpers, finish synthetic split

### DIFF
--- a/scripts/moon-module-boundary-webdriver-browser-domain.test.ts
+++ b/scripts/moon-module-boundary-webdriver-browser-domain.test.ts
@@ -68,6 +68,8 @@ const MOVED_DEFINITIONS = [
   "fn extract_bluetooth_byte_array_literal",
   "fn extract_bluetooth_call_string_argument",
   "fn extract_bluetooth_uint8_array_data",
+  "fn extract_script_channel_name",
+  "fn get_first_numeric_argument",
 ] as const;
 
 describe("MoonBit WebDriver browser_domain boundaries", () => {

--- a/webdriver/browser_domain/geolocation.mbt
+++ b/webdriver/browser_domain/geolocation.mbt
@@ -109,3 +109,42 @@ pub fn normalize_geolocation_number_json(
 ) -> Double? {
   @protocol.json_as_safe_number(value, min, max)
 }
+
+///|
+pub fn extract_script_channel_name(params : Json?) -> String? {
+  match @protocol.get_param_raw(params, "arguments") {
+    Some(Array(arguments)) =>
+      for argument in arguments {
+        match argument {
+          Object(argument_map) =>
+            match (argument_map.get("type"), argument_map.get("value")) {
+              (Some(String("channel")), Some(Object(channel_map))) =>
+                match channel_map.get("channel") {
+                  Some(String(channel_name)) =>
+                    if channel_name != "" {
+                      return Some(channel_name)
+                    }
+                  _ => ()
+                }
+              _ => ()
+            }
+          _ => ()
+        }
+      }
+    _ => ()
+  }
+  None
+}
+
+///|
+pub fn get_first_numeric_argument(params : Json?) -> Double? {
+  match @protocol.get_param_raw(params, "arguments") {
+    Some(Array(arguments)) =>
+      if arguments.length() > 0 {
+        @protocol.remote_value_as_number(arguments[0])
+      } else {
+        None
+      }
+    _ => None
+  }
+}

--- a/webdriver/browser_domain/pkg.generated.mbti
+++ b/webdriver/browser_domain/pkg.generated.mbti
@@ -46,11 +46,15 @@ pub fn extract_first_bluetooth_string_argument(Json?) -> String?
 
 pub fn extract_permissions_query_name(String) -> String?
 
+pub fn extract_script_channel_name(Json?) -> String?
+
 pub fn find_bluetooth_device_for_name(Array[Json], String?) -> Json
 
 pub fn geolocation_watch_scope_context(String) -> String
 
 pub fn geolocation_watch_scope_key(String, Int) -> String
+
+pub fn get_first_numeric_argument(Json?) -> Double?
 
 pub fn is_supported_permission_name(String) -> Bool
 

--- a/webdriver/protocol/pkg.generated.mbti
+++ b/webdriver/protocol/pkg.generated.mbti
@@ -44,6 +44,12 @@ pub fn make_object(Map[String, Json]) -> Json
 
 pub fn parse_decimal_string(String) -> Int?
 
+pub fn remote_value_as_bool(Json) -> Bool?
+
+pub fn remote_value_as_number(Json) -> Double?
+
+pub fn remote_value_as_string(Json) -> String?
+
 pub fn resolve_runtime_context_id(Json?, String, String, Bool) -> String
 
 // Errors

--- a/webdriver/protocol/remote_value.mbt
+++ b/webdriver/protocol/remote_value.mbt
@@ -1,0 +1,39 @@
+///|
+/// Pure helpers for reading BiDi script remote-value JSON objects.
+
+///|
+pub fn remote_value_as_bool(value : Json) -> Bool? {
+  match value {
+    Object(map) =>
+      match (map.get("type"), map.get("value")) {
+        (Some(String("boolean")), Some(True)) => Some(true)
+        (Some(String("boolean")), Some(False)) => Some(false)
+        _ => None
+      }
+    _ => None
+  }
+}
+
+///|
+pub fn remote_value_as_string(value : Json) -> String? {
+  match value {
+    Object(map) =>
+      match (map.get("type"), map.get("value")) {
+        (Some(String("string")), Some(String(value))) => Some(value)
+        _ => None
+      }
+    _ => None
+  }
+}
+
+///|
+pub fn remote_value_as_number(value : Json) -> Double? {
+  match value {
+    Object(map) =>
+      match (map.get("type"), map.get("value")) {
+        (Some(String("number")), Some(Number(n, ..))) => Some(n)
+        _ => None
+      }
+    _ => None
+  }
+}

--- a/webdriver/webdriver/bidi_geolocation_synthetic.mbt
+++ b/webdriver/webdriver/bidi_geolocation_synthetic.mbt
@@ -52,45 +52,6 @@ fn BidiProtocol::resolve_effective_geolocation_coordinates(
 }
 
 ///|
-fn extract_script_channel_name(params : Json?) -> String? {
-  match get_param_raw(params, "arguments") {
-    Some(Array(arguments)) =>
-      for argument in arguments {
-        match argument {
-          Object(argument_map) =>
-            match (argument_map.get("type"), argument_map.get("value")) {
-              (Some(String("channel")), Some(Object(channel_map))) =>
-                match channel_map.get("channel") {
-                  Some(String(channel_name)) =>
-                    if channel_name != "" {
-                      return Some(channel_name)
-                    }
-                  _ => ()
-                }
-              _ => ()
-            }
-          _ => ()
-        }
-      }
-    _ => ()
-  }
-  None
-}
-
-///|
-fn get_first_numeric_argument(params : Json?) -> Double? {
-  match get_param_raw(params, "arguments") {
-    Some(Array(arguments)) =>
-      if arguments.length() > 0 {
-        remote_value_as_number(arguments[0])
-      } else {
-        None
-      }
-    _ => None
-  }
-}
-
-///|
 fn BidiProtocol::emit_geolocation_watch_update_for_scope(
   self : BidiProtocol,
   scope_key : String,
@@ -597,7 +558,7 @@ fn BidiProtocol::try_handle_synthetic_geolocation_call(
   unwrap_result : Bool,
 ) -> Bool {
   if function_declaration.contains("navigator.geolocation.clearWatch(") {
-    let watch_id = match get_first_numeric_argument(params) {
+    let watch_id = match @browser_domain.get_first_numeric_argument(params) {
       Some(value) => value.to_int()
       None => 0
     }
@@ -607,7 +568,8 @@ fn BidiProtocol::try_handle_synthetic_geolocation_call(
   }
 
   if function_declaration.contains("navigator.geolocation.watchPosition(") {
-    let channel_name = match extract_script_channel_name(params) {
+    let channel_name = match
+      @browser_domain.extract_script_channel_name(params) {
       Some(channel_name) => channel_name
       None => return false
     }

--- a/webdriver/webdriver/bidi_network_conditions_synthetic.mbt
+++ b/webdriver/webdriver/bidi_network_conditions_synthetic.mbt
@@ -53,7 +53,7 @@ fn BidiProtocol::remember_network_state_channel_if_applicable(
   if !is_network_conditions_listener_registration(function_declaration) {
     return
   }
-  match extract_script_channel_name(params) {
+  match @browser_domain.extract_script_channel_name(params) {
     Some(channel_name) =>
       if channel_name != "" {
         self.network_state.network_state_channel_by_context[ctx_id] = channel_name

--- a/webdriver/webdriver/bidi_protocol_script_result.mbt
+++ b/webdriver/webdriver/bidi_protocol_script_result.mbt
@@ -299,40 +299,21 @@ fn BidiProtocol::send_script_prompt_result(
 }
 
 ///|
+/// Compatibility facade for the canonical remote_value_as_bool in @protocol.
 fn remote_value_as_bool(value : Json) -> Bool? {
-  match value {
-    Object(map) =>
-      match (map.get("type"), map.get("value")) {
-        (Some(String("boolean")), Some(True)) => Some(true)
-        (Some(String("boolean")), Some(False)) => Some(false)
-        _ => None
-      }
-    _ => None
-  }
+  @protocol.remote_value_as_bool(value)
 }
 
 ///|
+/// Compatibility facade for the canonical remote_value_as_string in @protocol.
 fn remote_value_as_string(value : Json) -> String? {
-  match value {
-    Object(map) =>
-      match (map.get("type"), map.get("value")) {
-        (Some(String("string")), Some(String(value))) => Some(value)
-        _ => None
-      }
-    _ => None
-  }
+  @protocol.remote_value_as_string(value)
 }
 
 ///|
+/// Compatibility facade for the canonical remote_value_as_number in @protocol.
 fn remote_value_as_number(value : Json) -> Double? {
-  match value {
-    Object(map) =>
-      match (map.get("type"), map.get("value")) {
-        (Some(String("number")), Some(Number(n, ..))) => Some(n)
-        _ => None
-      }
-    _ => None
-  }
+  @protocol.remote_value_as_number(value)
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Surface \`remote_value_as_bool/string/number\` as public helpers in \`webdriver/protocol\`. The copies in \`bidi_protocol_script_result.mbt\` become thin facades.
- Move the last two pure synthetic helpers (\`extract_script_channel_name\`, \`get_first_numeric_argument\`) into \`webdriver/browser_domain/geolocation.mbt\`. \`bidi_geolocation_synthetic.mbt\` and \`bidi_network_conditions_synthetic.mbt\` now route through \`@browser_domain.*\`.
- Extends the browser_domain boundary guard with the two new symbols.

\`browser_domain\` now owns 41 helpers across seven domain files — every pure helper from the synthetic BiDi domains has a home outside the implementation package.

## Test plan
- [x] \`moon check --target js\` clean
- [x] \`moon test --target js -p mizchi/crater-webdriver-bidi/webdriver\` → 310/310 pass
- [x] \`pnpm exec vitest run scripts/moon-module-boundary-webdriver-browser-domain.test.ts\` → 2/2 pass
- [x] \`moon info && moon fmt\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)