### PR TITLE
Lock painter and webdriver module boundaries

### DIFF
--- a/scripts/moon-module-boundary-painter-raster-entry.test.ts
+++ b/scripts/moon-module-boundary-painter-raster-entry.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { REPO_ROOT, countLines } from "./moon-module-boundary-helpers";
+
+const read = (relativePath: string): string => {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+};
+
+const EXPECTED_RASTER_LEAVES = [
+  "painter/paint/raster/paint_raster.mbt",
+  "painter/paint/raster/glyph_blit.mbt",
+  "painter/paint/raster/glyph_render.mbt",
+  "painter/paint/raster/glyph_compat.mbt",
+  "painter/paint/raster/framebuffer.mbt",
+  "painter/paint/raster/framebuffer_encode.mbt",
+  "painter/paint/raster/bitmap_text.mbt",
+  "painter/paint/raster/bitmap_font_data.mbt",
+  "painter/paint/raster/bitmap_font_metrics.mbt",
+] as const;
+
+const PAINT_RASTER_FORBIDDEN_MARKERS = [
+  "fn rasterize_glyph_to_bitmap(",
+  "fn layout_glyph_bitmaps(",
+  "fn scanline_intersections_even_odd(",
+  "let glyph_bitmap_cache",
+  "let glyph_cache",
+  "fn glyph_cache_key(",
+  "pub fn pre_rasterize_glyphs(",
+  "pub fn cached_glyph_bitmap(",
+  "pub(all) struct GlyphBitmap",
+  "pub(all) struct GlyphProvider",
+  "fn measure_word_width(",
+  "fn split_text_into_words(",
+  "fn collapsed_space_advance(",
+];
+
+describe("MoonBit painter raster entry boundaries", () => {
+  it("keeps paint_raster.mbt as a thin renderer entry, with leaves split out", () => {
+    const missing = EXPECTED_RASTER_LEAVES.filter(
+      (file) => !fs.existsSync(path.join(REPO_ROOT, file)),
+    );
+    expect(missing).toEqual([]);
+
+    const entrySource = read("painter/paint/raster/paint_raster.mbt");
+    for (const marker of PAINT_RASTER_FORBIDDEN_MARKERS) {
+      expect(entrySource).not.toContain(marker);
+    }
+
+    // The entry should stay small: just the public render_* funcs and one private dispatcher.
+    expect(countLines("painter/paint/raster/paint_raster.mbt")).toBeLessThanOrEqual(150);
+
+    // glyph_compat.mbt must remain a thin facade over @glyph.
+    const glyphCompat = read("painter/paint/raster/glyph_compat.mbt");
+    expect(glyphCompat).toContain("pub using @glyph {type GlyphProvider}");
+    expect(glyphCompat).toContain("@glyph.set_glyph_provider(provider)");
+    expect(countLines("painter/paint/raster/glyph_compat.mbt")).toBeLessThanOrEqual(60);
+
+    // glyph_blit.mbt must hold only the bitmap compositing helpers.
+    const glyphBlit = read("painter/paint/raster/glyph_blit.mbt");
+    expect(glyphBlit).toContain("fn blit_glyph_bitmap(");
+    expect(glyphBlit).not.toContain("fn rasterize_glyph_to_bitmap(");
+    expect(glyphBlit).not.toContain("fn layout_glyph_bitmaps(");
+    expect(countLines("painter/paint/raster/glyph_blit.mbt")).toBeLessThanOrEqual(120);
+  });
+
+  it("keeps this boundary test small enough to stay focused", () => {
+    expect(countLines("scripts/moon-module-boundary-painter-raster-entry.test.ts")).toBeLessThanOrEqual(80);
+  });
+});

--- a/scripts/moon-module-boundary-painter-svg-interop.test.ts
+++ b/scripts/moon-module-boundary-painter-svg-interop.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { REPO_ROOT, countLines } from "./moon-module-boundary-helpers";
+
+const read = (relativePath: string): string => {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+};
+
+const INTEROP_FILES = [
+  "painter/svg/interop.mbt",
+  "painter/svg/interop_core.mbt",
+  "painter/svg/interop_animation_resource.mbt",
+  "painter/svg/interop_geometry_node.mbt",
+  "painter/svg/interop_paint_effects.mbt",
+  "painter/svg/interop_text_symbol.mbt",
+] as const;
+
+describe("MoonBit painter/svg interop boundaries", () => {
+  it("keeps @msvg interop helpers split by responsibility", () => {
+    const missing = INTEROP_FILES.filter((file) => !fs.existsSync(path.join(REPO_ROOT, file)));
+    expect(missing).toEqual([]);
+
+    // interop.mbt is the package overview: only a comment, no logic.
+    const overview = read("painter/svg/interop.mbt");
+    expect(overview).toContain("mizchi/svg interop adapters are split by responsibility");
+    expect(countLines("painter/svg/interop.mbt")).toBeLessThanOrEqual(5);
+
+    // interop_core.mbt holds the foundational shape converters.
+    const core = read("painter/svg/interop_core.mbt");
+    expect(core).toContain("pub fn extract_root_view_box(");
+    expect(core).toContain("fn transform_from_msvg(");
+    expect(core).toContain("fn color_from_msvg(");
+    expect(core).toContain("fn pointer_event_from_msvg(");
+
+    // Specialized adapters own their own helpers, not interop_core.
+    for (const [otherFile, markers] of [
+      [
+        "painter/svg/interop_animation_resource.mbt",
+        ["fn image_from_msvg(", "fn sprite_from_msvg(", "fn animated_sprite_from_msvg("],
+      ],
+      ["painter/svg/interop_geometry_node.mbt", ["fn svg_node_from_msvg("]],
+      ["painter/svg/interop_paint_effects.mbt", ["fn filter_from_msvg("]],
+      ["painter/svg/interop_text_symbol.mbt", ["fn text_anchor_from_msvg("]],
+    ] as const) {
+      const adapter = read(otherFile);
+      for (const marker of markers) {
+        expect(adapter).toContain(marker);
+        expect(core).not.toContain(marker);
+      }
+    }
+
+    // The moon.pkg imports mizchi/svg as @msvg (the only upstream dependency the
+    // adapters legitimately reach for).
+    const moonPkg = read("painter/svg/moon.pkg");
+    expect(moonPkg).toContain('"mizchi/svg" @msvg');
+    for (const forbidden of [
+      "mizchi/crater-webdriver",
+      "mizchi/crater-browser",
+      "mizchi/crater-renderer",
+      "mizchi/crater-dom",
+      "mizchi/js",
+      "mizchi/webdriver",
+    ]) {
+      expect(moonPkg).not.toContain(forbidden);
+    }
+  });
+
+  it("keeps this boundary test small enough to stay focused", () => {
+    expect(countLines("scripts/moon-module-boundary-painter-svg-interop.test.ts")).toBeLessThanOrEqual(80);
+  });
+});

--- a/scripts/moon-module-boundary-webdriver-bidi-main.test.ts
+++ b/scripts/moon-module-boundary-webdriver-bidi-main.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { REPO_ROOT, countLines } from "./moon-module-boundary-helpers";
+
+const read = (relativePath: string): string => {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+};
+
+const ALLOWED_WEBDRIVER_REFS = new Set<string>([
+  "@webdriver.BidiServer",
+  "@webdriver.BidiServerConfig",
+  "@webdriver.generate_auth_token",
+  "@webdriver.warmup_glyph_cache",
+]);
+
+describe("MoonBit webdriver/bidi_main boundary", () => {
+  it("only consumes the minimum BiDi server surface from @webdriver", () => {
+    const mainSource = read("webdriver/bidi_main/main.mbt");
+    const moonPkg = read("webdriver/bidi_main/moon.pkg");
+
+    // bidi_main's only crater-side dependency must be @webdriver.
+    expect(moonPkg).toContain('"mizchi/crater-webdriver-bidi/webdriver" @webdriver');
+    for (const forbidden of [
+      "mizchi/crater-webdriver-bidi/runtime",
+      "mizchi/crater-webdriver-bidi/rendering",
+      "mizchi/crater-webdriver-bidi/browser_domain",
+      "mizchi/crater-webdriver-bidi/protocol",
+      "mizchi/crater-webdriver-bidi/rpc",
+      "mizchi/crater-network",
+      "mizchi/crater-renderer",
+      "mizchi/crater-painter",
+      "mizchi/crater-browser",
+      "mizchi/crater-dom",
+    ]) {
+      expect(moonPkg).not.toContain(forbidden);
+    }
+
+    const matches = mainSource.match(/@webdriver\.[a-zA-Z_][a-zA-Z_0-9]*/g) ?? [];
+    const uniqueRefs = new Set(matches);
+    expect(uniqueRefs.size).toBeGreaterThan(0);
+
+    const unexpected = [...uniqueRefs].filter((ref) => !ALLOWED_WEBDRIVER_REFS.has(ref));
+    expect(unexpected).toEqual([]);
+  });
+
+  it("keeps this boundary test small enough to stay focused", () => {
+    expect(countLines("scripts/moon-module-boundary-webdriver-bidi-main.test.ts")).toBeLessThanOrEqual(60);
+  });
+});


### PR DESCRIPTION
## Summary
Three boundary guards to freeze the current module organization before the next release. Each guard fails fast on accidental reintroduction of the issues these splits were created to solve.

### \`painter-raster-entry\`
- \`paint_raster.mbt\` stays a thin renderer entry (rasterize/cache/layout/provider helpers stay in \`painter/paint/glyph\`)
- \`glyph_compat.mbt\` keeps its \`@glyph\` facade shape
- \`glyph_blit.mbt\` holds only bitmap compositing

### \`painter-svg-interop\`
- \`interop_*.mbt\` split by responsibility (animation_resource, geometry_node, paint_effects, text_symbol)
- Specialized helpers don't leak back into \`interop_core\`
- Only imports \`mizchi/svg\` as \`@msvg\`, no crater siblings

### \`webdriver-bidi-main\`
- \`bidi_main\` consumes exactly four symbols from \`@webdriver\` (\`BidiServer\`, \`BidiServerConfig\`, \`generate_auth_token\`, \`warmup_glyph_cache\`)
- Any new reach into the implementation package fails the guard, preserving the de facto release public API

## Out of scope (follow-up)
- A: Full \`painter/svg\` direct alias migration (Color/Transform/ViewBox → \`@msvg.*\`) — ~200 conversion sites, multi-PR work
- C: Reducing the 133 public symbols in \`webdriver/webdriver\` itself — separate audit

## Test plan
- [x] \`pnpm exec vitest run scripts/moon-module-boundary-painter-raster-entry.test.ts\` → 2/2 pass
- [x] \`pnpm exec vitest run scripts/moon-module-boundary-painter-svg-interop.test.ts\` → 2/2 pass
- [x] \`pnpm exec vitest run scripts/moon-module-boundary-webdriver-bidi-main.test.ts\` → 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)