### PR TITLE
Drop TODO-prose boundary guard

### DIFF
--- a/scripts/moon-module-boundary-webdriver-facade.test.ts
+++ b/scripts/moon-module-boundary-webdriver-facade.test.ts
@@ -570,15 +570,4 @@ describe("MoonBit WebDriver facade and contract boundaries", () => {
     }
   });
 
-  it("documents next module boundaries before further WebDriver extraction", () => {
-    const todo = read("TODO.md");
-    // contract / rpc / runtime / network / protocol / rendering / browser_domain
-    // are now extracted and protected by their own boundary guards in scripts/.
-    // The only remaining sub-module from the original webdriver split is
-    // webdriver/server. Track its mention so the next session picks it up.
-    const requiredBoundaries = ["`webdriver/server`"] as const;
-
-    const missingBoundaries = requiredBoundaries.filter((boundary) => !todo.includes(boundary));
-    expect(missingBoundaries).toEqual([]);
-  });
 });


### PR DESCRIPTION
## Summary
- Remove the `documents next module boundaries` test in `scripts/moon-module-boundary-webdriver-facade.test.ts`.
- That test only asserted that TODO.md contained the literal string `` `webdriver/server` ``, which guards prose rather than code.
- The coupling caused PR #69 to need a same-commit patch when the prior TODO triage (PR #63) shrank the file.

## Test plan
- [x] pnpm vitest run scripts/moon-module-boundary-webdriver-facade.test.ts → 18/18 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)