### PR TITLE
Extract webdriver/server (REST handler) into its own package

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,8 +59,9 @@ Last organized: 2026-05-15
 - [ ] `painter/paint/raster/paint_raster.mbt` / glyph 周辺の責務整理を閉じる
   - bitmap font fallback と glyph path render の境界を見直す
   - `mizchi/font` / `mizchi/svg` へ委譲できる処理は crater 側を adapter にする
-- [ ] `webdriver/server` を `webdriver/webdriver` から切り出す
-  - WebSocket transport / server state / session wiring
+- [ ] `webdriver/server` の WebSocket transport (`bidi_server.mbt`) を移す
+  - REST handler / session manager は `webdriver/server` に分離済 (#71)
+  - WebSocket 側は `reset_runtime_js_state` / `reset_paint_provider` のコールバック化が必要なので別 PR
 - [ ] `scripts/crater_bidi_adapter.py` から transport 以外の実装責務を削る
 - [ ] WebDriver tooling の `.ts` runner (`scripts/wpt-webdriver-runner.ts` / `scripts/wpt-runner.ts` / `scripts/wpt-dom-runner.ts`) の責務を整理する
 

--- a/scripts/moon-module-boundary-webdriver-server.test.ts
+++ b/scripts/moon-module-boundary-webdriver-server.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { REPO_ROOT, countLines } from "./moon-module-boundary-helpers";
+
+const read = (relativePath: string): string => {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+};
+
+const SERVER_FILES = [
+  "webdriver/server/moon.pkg",
+  "webdriver/server/server.mbt",
+  "webdriver/server/server_test.mbt",
+] as const;
+
+const MOVED_DEFINITIONS = [
+  "struct SessionManager",
+  "struct SessionState",
+  "fn SessionManager::new",
+  "fn SessionManager::create_session",
+  "fn SessionManager::delete_session",
+  "fn SessionManager::get_session",
+  "fn SessionManager::handle_request",
+  "fn capabilities_to_value",
+  "fn handle_status",
+  "fn parse_navigation_url",
+  "fn navigation_title_for_url",
+  "fn is_example_domain_url",
+  "fn navigation_host_for_url",
+] as const;
+
+describe("webdriver/server isolation", () => {
+  it("declares only the REST/session-handler surface", () => {
+    for (const file of SERVER_FILES) {
+      expect(fs.existsSync(path.join(REPO_ROOT, file))).toBe(true);
+    }
+  });
+
+  it("server package is small and self-contained", () => {
+    const server = read("webdriver/server/server.mbt");
+    expect(countLines("webdriver/server/server.mbt")).toBeLessThan(400);
+    // Should not pull in protocol/runtime/rendering internals.
+    expect(server).not.toContain("@protocol");
+    expect(server).not.toContain("@runtime");
+    expect(server).not.toContain("@rendering");
+    expect(server).not.toContain("@browser_domain");
+    expect(server).not.toContain("@raster");
+    expect(server).not.toContain("@renderer");
+    // Transport-specific FFIs belong in bidi_server, not the REST handler.
+    expect(server).not.toContain("@deno");
+    expect(server).not.toContain("@core");
+    expect(server).not.toContain("upgrade_websocket");
+  });
+
+  it("REST handler definitions live only in the server package", () => {
+    for (const def of MOVED_DEFINITIONS) {
+      const server = read("webdriver/server/server.mbt");
+      expect(server.includes(def)).toBe(true);
+    }
+  });
+
+  it("webdriver/webdriver no longer owns the REST handler implementation", () => {
+    const oldServerExists = fs.existsSync(
+      path.join(REPO_ROOT, "webdriver/webdriver/server.mbt"),
+    );
+    expect(oldServerExists).toBe(false);
+    const oldTestExists = fs.existsSync(
+      path.join(REPO_ROOT, "webdriver/webdriver/server_test.mbt"),
+    );
+    expect(oldTestExists).toBe(false);
+  });
+
+  it("webdriver/webdriver re-exports SessionManager/SessionState via a thin facade", () => {
+    const facade = read("webdriver/webdriver/server_facade.mbt");
+    expect(facade).toContain("pub using @server");
+    expect(facade).toContain("type SessionManager");
+    expect(facade).toContain("type SessionState");
+  });
+
+  it("server package only depends on contract + core/json", () => {
+    const pkg = read("webdriver/server/moon.pkg");
+    expect(pkg).toContain("mizchi/crater-webdriver-bidi/contract");
+    expect(pkg).toContain("moonbitlang/core/json");
+    expect(pkg).not.toContain("protocol");
+    expect(pkg).not.toContain("runtime");
+    expect(pkg).not.toContain("rendering");
+    expect(pkg).not.toContain("browser_domain");
+  });
+});

--- a/webdriver/pkg.generated.mbti
+++ b/webdriver/pkg.generated.mbti
@@ -5,6 +5,7 @@ import {
   "mizchi/crater-browser/cdp",
   "mizchi/crater-webdriver-bidi/contract",
   "mizchi/crater-webdriver-bidi/rpc",
+  "mizchi/crater-webdriver-bidi/server",
   "mizchi/crater-webdriver-bidi/webdriver",
 }
 
@@ -70,9 +71,9 @@ pub using @contract {type Selector}
 
 pub using @contract {type Session}
 
-pub using @webdriver {type SessionManager}
+pub using @server {type SessionManager}
 
-pub using @webdriver {type SessionState}
+pub using @server {type SessionState}
 
 pub using @contract {type Timeouts}
 

--- a/webdriver/server/moon.pkg
+++ b/webdriver/server/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "mizchi/crater-webdriver-bidi/contract" @contract,
+  "moonbitlang/core/json",
+}
+
+import {
+  "mizchi/crater-webdriver-bidi/contract" @contract,
+} for "test"
+
+supported_targets = "js"

--- a/webdriver/server/pkg.generated.mbti
+++ b/webdriver/server/pkg.generated.mbti
@@ -1,0 +1,59 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "mizchi/crater-webdriver-bidi/server"
+
+import {
+  "mizchi/crater-webdriver-bidi/contract",
+}
+
+// Values
+pub fn error_response(@contract.ErrorCode, String) -> @contract.WebDriverResponse
+
+pub fn success_null() -> @contract.WebDriverResponse
+
+pub fn success_object(Map[String, @contract.WebDriverValue]) -> @contract.WebDriverResponse
+
+pub fn success_string(String) -> @contract.WebDriverResponse
+
+// Errors
+
+// Types and methods
+pub(all) struct SessionManager {
+  sessions : Map[String, SessionState]
+  mut next_id : Int
+}
+pub fn SessionManager::create_session(Self, String) -> @contract.WebDriverResponse
+pub fn SessionManager::delete_session(Self, String) -> @contract.WebDriverResponse
+pub fn SessionManager::generate_id(Self) -> String
+pub fn SessionManager::get_session(Self, String) -> SessionState?
+pub fn SessionManager::handle_request(Self, @contract.WebDriverRequest) -> (Int, @contract.WebDriverResponse)
+pub fn SessionManager::new() -> Self
+
+pub(all) struct SessionState {
+  id : String
+  capabilities : @contract.Capabilities
+  mut current_url : String
+  mut title : String
+  window_rect : @contract.WindowRect
+}
+
+// Type aliases
+pub using @contract {type Capabilities}
+
+pub using @contract {type ErrorCode}
+
+pub using @contract {type PageLoadStrategy}
+
+pub using @contract {type Timeouts}
+
+pub using @contract {type WebDriverCommand}
+
+pub using @contract {type WebDriverRequest}
+
+pub using @contract {type WebDriverResponse}
+
+pub using @contract {type WebDriverValue}
+
+pub using @contract {type WindowRect}
+
+// Traits
+

--- a/webdriver/server/server.mbt
+++ b/webdriver/server/server.mbt
@@ -1,6 +1,24 @@
 ///|
-/// WebDriver Server Handler
-/// Dispatches WebDriver commands to the browser implementation
+/// WebDriver HTTP/REST request handler.
+///
+/// Stateful dispatcher for non-BiDi (legacy REST) WebDriver commands.
+/// Lives in its own package so the transport surface is decoupled from
+/// the BiDi protocol implementation.
+pub using @contract {
+  type Capabilities,
+  type ErrorCode,
+  type PageLoadStrategy,
+  type Timeouts,
+  type WebDriverCommand,
+  type WebDriverRequest,
+  type WebDriverResponse,
+  type WebDriverValue,
+  type WindowRect,
+  error_response,
+  success_null,
+  success_object,
+  success_string,
+}
 
 ///|
 /// Session manager

--- a/webdriver/server/server_test.mbt
+++ b/webdriver/server/server_test.mbt
@@ -1,8 +1,8 @@
 ///|
 /// Tests for WebDriver Server Handler
 test "status endpoint returns ready" {
-  let manager = SessionManager::new()
-  let req = parse_request("GET", "/status", "")
+  let manager = @server.SessionManager::new()
+  let req = @contract.parse_request("GET", "/status", "")
   let (status, resp) = manager.handle_request(req)
   inspect(status, content="200")
   let json = resp.to_json()
@@ -12,8 +12,8 @@ test "status endpoint returns ready" {
 
 ///|
 test "create new session" {
-  let manager = SessionManager::new()
-  let req = parse_request("POST", "/session", "{}")
+  let manager = @server.SessionManager::new()
+  let req = @contract.parse_request("POST", "/session", "{}")
   let (status, resp) = manager.handle_request(req)
   inspect(status, content="200")
   let json = resp.to_json()
@@ -24,12 +24,12 @@ test "create new session" {
 
 ///|
 test "delete session" {
-  let manager = SessionManager::new()
+  let manager = @server.SessionManager::new()
   // Create session first
-  let create_req = parse_request("POST", "/session", "{}")
+  let create_req = @contract.parse_request("POST", "/session", "{}")
   let (_, _) = manager.handle_request(create_req)
   // Delete session
-  let delete_req = parse_request("DELETE", "/session/session-1", "")
+  let delete_req = @contract.parse_request("DELETE", "/session/session-1", "")
   let (status, resp) = manager.handle_request(delete_req)
   inspect(status, content="200")
   inspect(resp.to_json(), content="{\"value\":null}")
@@ -37,8 +37,8 @@ test "delete session" {
 
 ///|
 test "delete non-existent session returns error" {
-  let manager = SessionManager::new()
-  let req = parse_request("DELETE", "/session/invalid-id", "")
+  let manager = @server.SessionManager::new()
+  let req = @contract.parse_request("DELETE", "/session/invalid-id", "")
   let (status, resp) = manager.handle_request(req)
   inspect(status, content="404")
   let json = resp.to_json()
@@ -47,12 +47,12 @@ test "delete non-existent session returns error" {
 
 ///|
 test "get current url" {
-  let manager = SessionManager::new()
+  let manager = @server.SessionManager::new()
   // Create session
-  let create_req = parse_request("POST", "/session", "{}")
+  let create_req = @contract.parse_request("POST", "/session", "{}")
   let (_, _) = manager.handle_request(create_req)
   // Get URL
-  let url_req = parse_request("GET", "/session/session-1/url", "")
+  let url_req = @contract.parse_request("GET", "/session/session-1/url", "")
   let (status, resp) = manager.handle_request(url_req)
   inspect(status, content="200")
   let json = resp.to_json()
@@ -61,18 +61,18 @@ test "get current url" {
 
 ///|
 test "navigate to url" {
-  let manager = SessionManager::new()
+  let manager = @server.SessionManager::new()
   // Create session
-  let create_req = parse_request("POST", "/session", "{}")
+  let create_req = @contract.parse_request("POST", "/session", "{}")
   let (_, _) = manager.handle_request(create_req)
   // Navigate
-  let nav_req = parse_request(
+  let nav_req = @contract.parse_request(
     "POST", "/session/session-1/url", "{\"url\":\"https://example.com\"}",
   )
   let (status, _) = manager.handle_request(nav_req)
   inspect(status, content="200")
   // Verify URL changed
-  let url_req = parse_request("GET", "/session/session-1/url", "")
+  let url_req = @contract.parse_request("GET", "/session/session-1/url", "")
   let (_, resp) = manager.handle_request(url_req)
   let json = resp.to_json()
   assert_true(json.contains("example.com"))
@@ -80,18 +80,18 @@ test "navigate to url" {
 
 ///|
 test "navigate to arbitrary url preserves request url" {
-  let manager = SessionManager::new()
-  let create_req = parse_request("POST", "/session", "{}")
+  let manager = @server.SessionManager::new()
+  let create_req = @contract.parse_request("POST", "/session", "{}")
   let (_, _) = manager.handle_request(create_req)
   let target = "https://mizchi.dev/docs?q=1#frag"
-  let nav_req = parse_request(
+  let nav_req = @contract.parse_request(
     "POST",
     "/session/session-1/url",
     "{\"url\":\"" + target + "\"}",
   )
   let (status, _) = manager.handle_request(nav_req)
   inspect(status, content="200")
-  let url_req = parse_request("GET", "/session/session-1/url", "")
+  let url_req = @contract.parse_request("GET", "/session/session-1/url", "")
   let (_, resp) = manager.handle_request(url_req)
   inspect(
     resp.to_json(),
@@ -101,10 +101,10 @@ test "navigate to arbitrary url preserves request url" {
 
 ///|
 test "navigate without url returns invalid argument" {
-  let manager = SessionManager::new()
-  let create_req = parse_request("POST", "/session", "{}")
+  let manager = @server.SessionManager::new()
+  let create_req = @contract.parse_request("POST", "/session", "{}")
   let (_, _) = manager.handle_request(create_req)
-  let nav_req = parse_request("POST", "/session/session-1/url", "{}")
+  let nav_req = @contract.parse_request("POST", "/session/session-1/url", "{}")
   let (status, resp) = manager.handle_request(nav_req)
   inspect(status, content="400")
   let json = resp.to_json()
@@ -114,17 +114,17 @@ test "navigate without url returns invalid argument" {
 
 ///|
 test "get title" {
-  let manager = SessionManager::new()
+  let manager = @server.SessionManager::new()
   // Create session
-  let create_req = parse_request("POST", "/session", "{}")
+  let create_req = @contract.parse_request("POST", "/session", "{}")
   let (_, _) = manager.handle_request(create_req)
   // Navigate
-  let nav_req = parse_request(
+  let nav_req = @contract.parse_request(
     "POST", "/session/session-1/url", "{\"url\":\"https://example.com\"}",
   )
   let (_, _) = manager.handle_request(nav_req)
   // Get title
-  let title_req = parse_request("GET", "/session/session-1/title", "")
+  let title_req = @contract.parse_request("GET", "/session/session-1/title", "")
   let (status, resp) = manager.handle_request(title_req)
   inspect(status, content="200")
   let json = resp.to_json()
@@ -133,12 +133,14 @@ test "get title" {
 
 ///|
 test "get window rect" {
-  let manager = SessionManager::new()
+  let manager = @server.SessionManager::new()
   // Create session
-  let create_req = parse_request("POST", "/session", "{}")
+  let create_req = @contract.parse_request("POST", "/session", "{}")
   let (_, _) = manager.handle_request(create_req)
   // Get window rect
-  let rect_req = parse_request("GET", "/session/session-1/window/rect", "")
+  let rect_req = @contract.parse_request(
+    "GET", "/session/session-1/window/rect", "",
+  )
   let (status, resp) = manager.handle_request(rect_req)
   inspect(status, content="200")
   let json = resp.to_json()
@@ -148,8 +150,8 @@ test "get window rect" {
 
 ///|
 test "unknown command returns 404" {
-  let manager = SessionManager::new()
-  let req = parse_request("GET", "/unknown/path", "")
+  let manager = @server.SessionManager::new()
+  let req = @contract.parse_request("GET", "/unknown/path", "")
   let (status, resp) = manager.handle_request(req)
   inspect(status, content="404")
   let json = resp.to_json()
@@ -158,12 +160,12 @@ test "unknown command returns 404" {
 
 ///|
 test "unimplemented command returns 501" {
-  let manager = SessionManager::new()
+  let manager = @server.SessionManager::new()
   // Create session
-  let create_req = parse_request("POST", "/session", "{}")
+  let create_req = @contract.parse_request("POST", "/session", "{}")
   let (_, _) = manager.handle_request(create_req)
   // Try to take screenshot (not yet implemented)
-  let req = parse_request("GET", "/session/session-1/screenshot", "")
+  let req = @contract.parse_request("GET", "/session/session-1/screenshot", "")
   let (status, resp) = manager.handle_request(req)
   inspect(status, content="501")
   let json = resp.to_json()

--- a/webdriver/webdriver/moon.pkg
+++ b/webdriver/webdriver/moon.pkg
@@ -6,6 +6,7 @@ import {
   "mizchi/crater-webdriver-bidi/protocol/wire" @protocol_wire,
   "mizchi/crater-webdriver-bidi/rendering" @rendering,
   "mizchi/crater-webdriver-bidi/browser_domain" @browser_domain,
+  "mizchi/crater-webdriver-bidi/server" @server,
   "mizchi/crater-network" @crater_network,
   "mizchi/crater-renderer/vrt" @vrt,
   "mizchi/crater-browser-contract" @browser_contract,

--- a/webdriver/webdriver/pkg.generated.mbti
+++ b/webdriver/webdriver/pkg.generated.mbti
@@ -5,6 +5,7 @@ import {
   "mizchi/crater-browser/cdp",
   "mizchi/crater-webdriver-bidi/contract",
   "mizchi/crater-webdriver-bidi/rpc",
+  "mizchi/crater-webdriver-bidi/server",
   "mizchi/js/core",
   "moonbitlang/core/debug",
 }
@@ -251,25 +252,6 @@ pub fn Executor::screenshot(Self, String) -> @contract.ApiResult[String]
 pub fn Executor::title(Self, String) -> @contract.ApiResult[String]
 pub fn Executor::url(Self, String) -> @contract.ApiResult[String]
 
-pub(all) struct SessionManager {
-  sessions : Map[String, SessionState]
-  mut next_id : Int
-}
-pub fn SessionManager::create_session(Self, String) -> @contract.WebDriverResponse
-pub fn SessionManager::delete_session(Self, String) -> @contract.WebDriverResponse
-pub fn SessionManager::generate_id(Self) -> String
-pub fn SessionManager::get_session(Self, String) -> SessionState?
-pub fn SessionManager::handle_request(Self, @contract.WebDriverRequest) -> (Int, @contract.WebDriverResponse)
-pub fn SessionManager::new() -> Self
-
-pub(all) struct SessionState {
-  id : String
-  capabilities : @contract.Capabilities
-  mut current_url : String
-  mut title : String
-  window_rect : @contract.WindowRect
-}
-
 // Type aliases
 pub using @contract {type ApiError}
 
@@ -316,6 +298,10 @@ pub using @rpc {type RpcResponse}
 pub using @contract {type Selector}
 
 pub using @contract {type Session}
+
+pub using @server {type SessionManager}
+
+pub using @server {type SessionState}
 
 pub using @contract {type Timeouts}
 

--- a/webdriver/webdriver/server_facade.mbt
+++ b/webdriver/webdriver/server_facade.mbt
@@ -1,0 +1,6 @@
+///|
+/// Compatibility facade re-exporting the HTTP/REST session manager from
+/// `mizchi/crater-webdriver-bidi/server`. Keeps `@webdriver.SessionManager`
+/// usages compiling while the real implementation lives in the smaller
+/// `server` package.
+pub using @server {type SessionManager, type SessionState}


### PR DESCRIPTION
## Summary
- Move `SessionManager` + REST WebDriver dispatcher from `webdriver/webdriver/server.mbt` into a new `webdriver/server` package
- Only deps: `webdriver/contract` + `moonbitlang/core/json` (no protocol, no transport, no rendering)
- `webdriver/webdriver/server_facade.mbt` re-exports `SessionManager` / `SessionState` for backward compat (`@webdriver.SessionManager` keeps working)
- Adds `scripts/moon-module-boundary-webdriver-server.test.ts` guard (no @protocol / @runtime / @rendering / @deno imports, < 400 lines)

## Scope notes
The WebSocket transport (`bidi_server.mbt`) is intentionally left in `webdriver/webdriver` for a follow-up. It calls `reset_runtime_js_state` / `reset_paint_provider` directly, which need callback-injection before they can move out. TODO.md updated to reflect partial scope.

## Test plan
- [x] `moon test` → 4973/4973 js, 52/52 native
- [x] `moon info && moon fmt` → mbti diffs reviewed (SessionManager moved from @webdriver to @server in the top-level facade)
- [x] `pnpm vitest run scripts/moon-module-boundary-webdriver-server.test.ts` → 6/6
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)