### PR TITLE
Resolve max-width / max-height calc() against parent width

### DIFF
--- a/css/computed/compute.mbt
+++ b/css/computed/compute.mbt
@@ -1317,8 +1317,14 @@ fn apply_property(
       builder.min_height = resolve_dimension_with_mixed_calc_fallback(
         "min-height", value, ctx,
       )
-    "max-width" => builder.max_width = resolve_dimension(value, ctx)
-    "max-height" => builder.max_height = resolve_dimension(value, ctx)
+    "max-width" =>
+      builder.max_width = resolve_dimension_with_calc_percent_fallback(
+        value, ctx,
+      )
+    "max-height" =>
+      builder.max_height = resolve_dimension_with_calc_percent_fallback(
+        value, ctx,
+      )
     // Logical sizing properties
     // In vertical writing-modes:
     // - inline axis is vertical -> inline-size maps to height


### PR DESCRIPTION
## Summary
- `max-width: calc(50% - 3px)` and similar mixed-unit calc expressions were silently dropped because `resolve_dimension` cannot collapse mixed calc into a single `Length`/`Percent` variant.
- The width/height sites already use `resolve_dimension_with_calc_percent_fallback`, which substitutes the parent's resolved width when the calc has both terms.
- Apply the same fallback to `max-width` and `max-height` so they at least resolve correctly when the parent is definite.

## What this does NOT fix
- `wpt/css/css-values/calc-max-width-block-intrinsic-1.html` still fails. That test puts the calc on a shrink-to-fit float whose width is indefinite at compute time; the calc needs layout-time resolution to match Chromium. Same root cause as the table-column-calc tracked in #67. Marked for a follow-up that lifts calc into layout.

## Test plan
- [x] `moon test` → 4973/4973 js, 52/52 native (no regressions)
- [x] `moon info && moon fmt` (no mbti drift; this is an internal change)
- [ ] CI green

Refs #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)