### PR TITLE
Collapse webdriver facade layers; expose contract types directly

### DIFF
--- a/scripts/moon-module-boundary-webdriver-facade.test.ts
+++ b/scripts/moon-module-boundary-webdriver-facade.test.ts
@@ -54,24 +54,25 @@ describe("MoonBit WebDriver facade and contract boundaries", () => {
     expect(contractPackage).not.toContain("mizchi/js");
   });
 
-  it("keeps webdriver/webdriver as a compatibility facade over contract types", () => {
-    const packageSource = read("webdriver/webdriver/moon.pkg");
-    const facadeSource = read("webdriver/webdriver/contract.mbt");
-
-    expect(packageSource).toContain('"mizchi/crater-webdriver-bidi/contract" @contract');
-    expect(facadeSource).toContain("pub using @contract");
+  it("exposes contract types directly from the top-level facade", () => {
+    // Public re-exports now live on the top-level package; the
+    // intermediate `webdriver/webdriver/contract.mbt` only keeps a private
+    // `using` for the names actually referenced from internal code.
+    const topSource = read("webdriver/top.mbt");
+    expect(topSource).toContain('pub using @contract');
     for (const typeName of [
       "ApiError",
       "ApiMethod",
       "ErrorCode",
-      "HttpMethod",
       "WebDriverCommand",
       "WebDriverRequest",
       "WebDriverResponse",
       "WebDriverValue",
     ] as const) {
-      expect(facadeSource).toContain(`type ${typeName}`);
+      expect(topSource).toContain(`type ${typeName}`);
     }
+    const topPackage = read("webdriver/moon.pkg");
+    expect(topPackage).toContain('"mizchi/crater-webdriver-bidi/contract" @contract');
   });
 
   it("keeps JSON-RPC protocol helpers outside the implementation facade", () => {
@@ -95,13 +96,21 @@ describe("MoonBit WebDriver facade and contract boundaries", () => {
 
     const webdriverPackage = read("webdriver/webdriver/moon.pkg");
     const facadeSource = read("webdriver/webdriver/contract.mbt");
+    const topSource = read("webdriver/top.mbt");
     expect(webdriverPackage).toContain('"mizchi/crater-webdriver-bidi/rpc" @rpc');
-    expect(facadeSource).toContain("pub using @rpc");
-    for (const symbol of [
+    // RPC types are now re-exported from the top-level facade directly.
+    expect(topSource).toContain("pub using @rpc");
+    for (const typeName of [
       "RpcErrorCode",
       "RpcId",
       "RpcRequest",
       "RpcResponse",
+    ] as const) {
+      expect(topSource).toContain(`type ${typeName}`);
+    }
+    // The intermediate facade keeps thin pass-throughs that internal
+    // handlers still call without qualification.
+    for (const symbol of [
       "parse_method",
       "parse_json_object",
       "api_error_to_rpc",

--- a/scripts/moon-module-boundary-webdriver-server.test.ts
+++ b/scripts/moon-module-boundary-webdriver-server.test.ts
@@ -70,11 +70,15 @@ describe("webdriver/server isolation", () => {
     expect(oldTestExists).toBe(false);
   });
 
-  it("webdriver/webdriver re-exports SessionManager/SessionState via a thin facade", () => {
-    const facade = read("webdriver/webdriver/server_facade.mbt");
-    expect(facade).toContain("pub using @server");
-    expect(facade).toContain("type SessionManager");
-    expect(facade).toContain("type SessionState");
+  it("top-level webdriver facade exposes SessionManager/SessionState directly from @server", () => {
+    const top = read("webdriver/top.mbt");
+    expect(top).toContain("pub using @server");
+    expect(top).toContain("type SessionManager");
+    expect(top).toContain("type SessionState");
+    // The intermediate `webdriver/webdriver` facade has been dropped.
+    expect(
+      fs.existsSync(path.join(REPO_ROOT, "webdriver/webdriver/server_facade.mbt")),
+    ).toBe(false);
   });
 
   it("server package only depends on contract + core/json", () => {

--- a/webdriver/moon.pkg
+++ b/webdriver/moon.pkg
@@ -1,5 +1,8 @@
 import {
   "mizchi/crater-browser/cdp",
+  "mizchi/crater-webdriver-bidi/contract" @contract,
+  "mizchi/crater-webdriver-bidi/rpc" @rpc,
+  "mizchi/crater-webdriver-bidi/server" @server,
   "mizchi/crater-webdriver-bidi/webdriver",
 }
 

--- a/webdriver/top.mbt
+++ b/webdriver/top.mbt
@@ -1,24 +1,21 @@
 ///|
-pub using @webdriver {
+/// Top-level public API surface for `mizchi/crater-webdriver-bidi`.
+///
+/// Re-exports come straight from the source packages (`contract` / `rpc` /
+/// `server`) rather than the kitchen-sink `webdriver` facade, so downstream
+/// consumers see a single hop to the real definition. `webdriver` is still
+/// re-exported for the transport (`BidiServer*`) and CDP-handler types that
+/// have not been split out yet.
+pub using @contract {
   type ApiError,
   type ApiMethod,
-  type BidiServer,
-  type BidiServerConfig,
   type Capabilities,
-  type CdpHandlerError,
-  type CdpSessionManager,
   type ErrorCode,
   type PageLoadStrategy,
   type ProxyConfig,
   type Rect,
-  type RpcErrorCode,
-  type RpcId,
-  type RpcRequest,
-  type RpcResponse,
   type Selector,
   type Session,
-  type SessionManager,
-  type SessionState,
   type Timeouts,
   type Viewport,
   type WebDriverCommand,
@@ -27,6 +24,25 @@ pub using @webdriver {
   type WebDriverResponse,
   type WebDriverValue,
   type WindowRect,
+}
+
+///|
+pub using @rpc {
+  type RpcErrorCode,
+  type RpcId,
+  type RpcRequest,
+  type RpcResponse,
+}
+
+///|
+pub using @server {type SessionManager, type SessionState}
+
+///|
+pub using @webdriver {
+  type BidiServer,
+  type BidiServerConfig,
+  type CdpHandlerError,
+  type CdpSessionManager,
 }
 
 ///|

--- a/webdriver/webdriver/contract.mbt
+++ b/webdriver/webdriver/contract.mbt
@@ -1,138 +1,43 @@
 ///|
-/// Compatibility facade for WebDriver contract types.
+/// Local contract / rpc aliases for the webdriver kitchen-sink package.
 ///
-/// Keep transport, runtime, and browser-domain implementation out of the
-/// contract package. This package re-exports the pure request/response/API
-/// shapes so existing `mizchi/crater-webdriver-bidi/webdriver` imports keep
-/// compiling while new code can depend on `.../contract` directly.
-pub using @contract {
-  type ApiError,
-  type ApiMethod,
-  type ApiResult,
-  type Capabilities,
-  type ContextId,
-  type ElementId,
-  type ElementRect,
-  type ErrorCode,
-  type HttpMethod,
-  type LocatorStrategy,
-  type Modifiers,
-  type MouseButton,
-  type PageId,
-  type PageLoadStrategy,
-  type Point,
-  type ProxyConfig,
-  type Rect,
-  type Selector,
-  type Session,
-  type Timeouts,
-  type Viewport,
-  type WebDriverCommand,
-  type WebDriverError,
-  type WebDriverRequest,
-  type WebDriverResponse,
-  type WebDriverValue,
-  type WindowRect,
-}
+/// `webdriver/top.mbt` re-exports the contract / rpc types directly to
+/// downstream consumers, so this file only pulls the names actually
+/// referenced from internal code into scope, and keeps the rpc helpers that
+/// are still called without the `@rpc.` prefix from handler / protocol /
+/// transport code.
+using @contract {type ApiError, type ApiMethod, type ApiResult}
 
 ///|
-pub using @rpc {
-  type RpcErrorCode,
-  type RpcId,
-  type RpcRequest,
-  type RpcResponse,
-}
+using @rpc {type RpcErrorCode, type RpcId, type RpcRequest, type RpcResponse}
 
 ///|
-pub fn escape_json_string(s : String) -> String {
+fn escape_json_string(s : String) -> String {
   @contract.escape_json_string(s)
 }
 
 ///|
-pub fn success_null() -> WebDriverResponse {
-  @contract.success_null()
-}
-
-///|
-pub fn success_string(s : String) -> WebDriverResponse {
-  @contract.success_string(s)
-}
-
-///|
-pub fn success_bool(b : Bool) -> WebDriverResponse {
-  @contract.success_bool(b)
-}
-
-///|
-pub fn success_element(element_id : String) -> WebDriverResponse {
-  @contract.success_element(element_id)
-}
-
-///|
-pub fn success_object(map : Map[String, WebDriverValue]) -> WebDriverResponse {
-  @contract.success_object(map)
-}
-
-///|
-pub fn error_response(code : ErrorCode, message : String) -> WebDriverResponse {
-  @contract.error_response(code, message)
-}
-
-///|
-pub fn parse_request(
-  method_str : String,
-  path : String,
-  body : String,
-) -> WebDriverRequest {
-  @contract.parse_request(method_str, path, body)
-}
-
-///|
-pub fn rpc_success_null(id : RpcId) -> RpcResponse {
+fn rpc_success_null(id : RpcId) -> RpcResponse {
   @rpc.rpc_success_null(id)
 }
 
 ///|
-pub fn rpc_success_string(id : RpcId, value : String) -> RpcResponse {
+fn rpc_success_string(id : RpcId, value : String) -> RpcResponse {
   @rpc.rpc_success_string(id, value)
 }
 
 ///|
-pub fn rpc_success_bool(id : RpcId, value : Bool) -> RpcResponse {
-  @rpc.rpc_success_bool(id, value)
-}
-
-///|
-pub fn rpc_success_number(id : RpcId, value : Double) -> RpcResponse {
-  @rpc.rpc_success_number(id, value)
-}
-
-///|
-pub fn rpc_success_json(id : RpcId, json : String) -> RpcResponse {
+fn rpc_success_json(id : RpcId, json : String) -> RpcResponse {
   @rpc.rpc_success_json(id, json)
 }
 
 ///|
-pub fn rpc_error(
-  id : RpcId,
-  code : RpcErrorCode,
-  message : String,
-) -> RpcResponse {
+fn rpc_error(id : RpcId, code : RpcErrorCode, message : String) -> RpcResponse {
   @rpc.rpc_error(id, code, message)
 }
 
 ///|
-pub fn rpc_error_with_data(
-  id : RpcId,
-  code : RpcErrorCode,
-  message : String,
-  data : String,
-) -> RpcResponse {
-  @rpc.rpc_error_with_data(id, code, message, data)
-}
-
-///|
-pub fn api_error_to_rpc(id : RpcId, err : ApiError) -> RpcResponse {
+fn api_error_to_rpc(id : RpcId, err : ApiError) -> RpcResponse {
   @rpc.api_error_to_rpc(id, err)
 }
 
@@ -142,6 +47,6 @@ pub fn parse_method(name : String) -> ApiMethod? {
 }
 
 ///|
-pub fn parse_json_object(json : String) -> Map[String, String] {
+fn parse_json_object(json : String) -> Map[String, String] {
   @rpc.parse_json_object(json)
 }

--- a/webdriver/webdriver/moon.pkg
+++ b/webdriver/webdriver/moon.pkg
@@ -6,7 +6,6 @@ import {
   "mizchi/crater-webdriver-bidi/protocol/wire" @protocol_wire,
   "mizchi/crater-webdriver-bidi/rendering" @rendering,
   "mizchi/crater-webdriver-bidi/browser_domain" @browser_domain,
-  "mizchi/crater-webdriver-bidi/server" @server,
   "mizchi/crater-network" @crater_network,
   "mizchi/crater-renderer/vrt" @vrt,
   "mizchi/crater-browser-contract" @browser_contract,

--- a/webdriver/webdriver/pkg.generated.mbti
+++ b/webdriver/webdriver/pkg.generated.mbti
@@ -5,23 +5,16 @@ import {
   "mizchi/crater-browser/cdp",
   "mizchi/crater-webdriver-bidi/contract",
   "mizchi/crater-webdriver-bidi/rpc",
-  "mizchi/crater-webdriver-bidi/server",
   "mizchi/js/core",
   "moonbitlang/core/debug",
 }
 
 // Values
-pub fn api_error_to_rpc(@rpc.RpcId, @contract.ApiError) -> @rpc.RpcResponse
-
 pub fn await_promise(@core.Any) -> String
 
 pub fn decode_base64(String) -> String
 
 pub fn delete_runtime_handle(String) -> Unit
-
-pub fn error_response(@contract.ErrorCode, String) -> @contract.WebDriverResponse
-
-pub fn escape_json_string(String) -> String
 
 pub fn eval_and_send_async(@core.Any, Int, String, String) -> Unit
 
@@ -107,11 +100,7 @@ pub fn mark_quickjs_initialized() -> Unit
 
 pub fn parse_data_url(String) -> (String, String)?
 
-pub fn parse_json_object(String) -> Map[String, String]
-
 pub fn parse_method(String) -> @contract.ApiMethod?
-
-pub fn parse_request(String, String, String) -> @contract.WebDriverRequest
 
 pub fn quickjs_eval_async(String, Bool) -> @core.Any
 
@@ -128,20 +117,6 @@ pub fn quickjs_load(String) -> @core.Any
 pub fn reset_paint_provider() -> Unit
 
 pub fn reset_runtime_event_buffers(String) -> Unit
-
-pub fn rpc_error(@rpc.RpcId, @rpc.RpcErrorCode, String) -> @rpc.RpcResponse
-
-pub fn rpc_error_with_data(@rpc.RpcId, @rpc.RpcErrorCode, String, String) -> @rpc.RpcResponse
-
-pub fn rpc_success_bool(@rpc.RpcId, Bool) -> @rpc.RpcResponse
-
-pub fn rpc_success_json(@rpc.RpcId, String) -> @rpc.RpcResponse
-
-pub fn rpc_success_null(@rpc.RpcId) -> @rpc.RpcResponse
-
-pub fn rpc_success_number(@rpc.RpcId, Double) -> @rpc.RpcResponse
-
-pub fn rpc_success_string(@rpc.RpcId, String) -> @rpc.RpcResponse
 
 pub fn runtime_shared_node_is_document(String) -> Bool
 
@@ -168,16 +143,6 @@ pub fn set_runtime_context_screen_orientation(String, String, Int) -> Unit
 pub fn set_runtime_context_user_agent(String, String) -> Unit
 
 pub fn set_runtime_context_viewport(String, Int, Int, Double) -> Unit
-
-pub fn success_bool(Bool) -> @contract.WebDriverResponse
-
-pub fn success_element(String) -> @contract.WebDriverResponse
-
-pub fn success_null() -> @contract.WebDriverResponse
-
-pub fn success_object(Map[String, @contract.WebDriverValue]) -> @contract.WebDriverResponse
-
-pub fn success_string(String) -> @contract.WebDriverResponse
 
 pub fn sync_runtime_html(String, String, Bool) -> Unit
 
@@ -253,71 +218,6 @@ pub fn Executor::title(Self, String) -> @contract.ApiResult[String]
 pub fn Executor::url(Self, String) -> @contract.ApiResult[String]
 
 // Type aliases
-pub using @contract {type ApiError}
-
-pub using @contract {type ApiMethod}
-
-pub using @contract {type ApiResult}
-
-pub using @contract {type Capabilities}
-
-pub using @contract {type ContextId}
-
-pub using @contract {type ElementId}
-
-pub using @contract {type ElementRect}
-
-pub using @contract {type ErrorCode}
-
-pub using @contract {type HttpMethod}
-
-pub using @contract {type LocatorStrategy}
-
-pub using @contract {type Modifiers}
-
-pub using @contract {type MouseButton}
-
-pub using @contract {type PageId}
-
-pub using @contract {type PageLoadStrategy}
-
-pub using @contract {type Point}
-
-pub using @contract {type ProxyConfig}
-
-pub using @contract {type Rect}
-
-pub using @rpc {type RpcErrorCode}
-
-pub using @rpc {type RpcId}
-
-pub using @rpc {type RpcRequest}
-
-pub using @rpc {type RpcResponse}
-
-pub using @contract {type Selector}
-
-pub using @contract {type Session}
-
-pub using @server {type SessionManager}
-
-pub using @server {type SessionState}
-
-pub using @contract {type Timeouts}
-
-pub using @contract {type Viewport}
-
-pub using @contract {type WebDriverCommand}
-
-pub using @contract {type WebDriverError}
-
-pub using @contract {type WebDriverRequest}
-
-pub using @contract {type WebDriverResponse}
-
-pub using @contract {type WebDriverValue}
-
-pub using @contract {type WindowRect}
 
 // Traits
 

--- a/webdriver/webdriver/server_facade.mbt
+++ b/webdriver/webdriver/server_facade.mbt
@@ -1,6 +1,0 @@
-///|
-/// Compatibility facade re-exporting the HTTP/REST session manager from
-/// `mizchi/crater-webdriver-bidi/server`. Keeps `@webdriver.SessionManager`
-/// usages compiling while the real implementation lives in the smaller
-/// `server` package.
-pub using @server {type SessionManager, type SessionState}


### PR DESCRIPTION
## Summary
Drop the legacy two-hop facade chain (consumer → \`@webdriver\` → \`@webdriver/webdriver\` → \`@contract/@rpc/@server\`) now that the implementation has been split out into separate packages.

- \`webdriver/top.mbt\` re-exports contract / rpc / server types directly via \`pub using @contract\`, \`pub using @rpc\`, \`pub using @server\`.
- \`webdriver/webdriver/server_facade.mbt\` deleted (only existed to bridge \`@server.SessionManager\` to \`@webdriver.SessionManager\`).
- \`webdriver/webdriver/contract.mbt\` reduced to a private \`using\` for the names the handler/executor still call unqualified, plus pass-through helpers. The \`pub using\` form is gone.
- Boundary tests updated to reflect the new shape.

\`@webdriver\` is still re-exported for transport / CDP-handler types that haven't been split out yet (\`BidiServer*\`, \`CdpHandlerError\`, \`CdpSessionManager\`).

## Test plan
- [x] \`moon test\` → 4973/4973 js, 52/52 native
- [x] \`pnpm vitest run scripts/moon-module-boundary\` → 311/311
- [x] \`moon check\` → warning-free for webdriver
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)