### PR TITLE
Switch more sub-packages from crater-layout to crater-core/node

### DIFF
--- a/browser/component_artifact/moon.pkg
+++ b/browser/component_artifact/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "mizchi/crater-dom/html",
   "mizchi/crater-renderer/renderer",
-  "mizchi/crater-layout" @node,
+  "mizchi/crater-core/node" @node,
   "mizchi/crater-core" @types,
   "mizchi/crater-css" @css,
   "mizchi/crater-dom/aom",

--- a/browser/tui/moon.pkg
+++ b/browser/tui/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "mizchi/crater-core" @types,
-  "mizchi/crater-layout" @node,
+  "mizchi/crater-core/node" @node,
   "mizchi/crater-browser/tui/primitives" @tui_primitives,
   "mizchi/crater-browser/tui/paint/plain" @tui_paint_plain,
   "mizchi/crater-browser/tui/paint/runtime" @tui_paint_runtime,

--- a/browser/tui/paint/export/moon.pkg
+++ b/browser/tui/paint/export/moon.pkg
@@ -4,7 +4,7 @@ import {
 }
 
 import {
-  "mizchi/crater-layout" @node,
+  "mizchi/crater-core/node" @node,
   "mizchi/crater-core/style",
   "mizchi/crater-core" @types,
 } for "test"

--- a/browser/tui/paint/moon.pkg
+++ b/browser/tui/paint/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "mizchi/crater-layout" @node,
+  "mizchi/crater-core/node" @node,
   "mizchi/crater-core" @types,
   "mizchi/crater-browser/tui/paint/plain" @paint_plain,
   "mizchi/crater-browser/tui/paint/runtime" @paint_runtime,

--- a/browser/tui/paint/plain/moon.pkg
+++ b/browser/tui/paint/plain/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "mizchi/crater-layout" @node,
+  "mizchi/crater-core/node" @node,
   "mizchi/crater-painter/paint/model" @paint_model,
   "mizchi/crater-painter/paint/node_bridge" @paint_node,
   "mizchi/crater-core" @types,

--- a/browser/tui/paint/png/moon.pkg
+++ b/browser/tui/paint/png/moon.pkg
@@ -3,7 +3,7 @@ import {
 }
 
 import {
-  "mizchi/crater-layout" @node,
+  "mizchi/crater-core/node" @node,
   "mizchi/crater-core/style",
   "mizchi/crater-core" @types,
   "mizchi/crater-browser/tui/paint/plain" @paint_plain,

--- a/browser/tui/paint/runtime/moon.pkg
+++ b/browser/tui/paint/runtime/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "mizchi/crater-layout" @node,
+  "mizchi/crater-core/node" @node,
   "mizchi/crater-painter/paint/scroll" @paint_scroll,
   "mizchi/crater-painter/paint/traversal" @paint_traversal,
   "mizchi/crater-core" @types,

--- a/browser/tui/paint/viewport/moon.pkg
+++ b/browser/tui/paint/viewport/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "mizchi/crater-layout" @node,
+  "mizchi/crater-core/node" @node,
   "mizchi/crater-painter/paint/model" @paint_model,
   "mizchi/crater-painter/paint/viewport_bridge" @paint_viewport,
   "mizchi/crater-core" @types,

--- a/renderer/vrt/moon.pkg
+++ b/renderer/vrt/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "mizchi/crater-layout" @layout,
+  "mizchi/crater-core/node" @layout,
   "mizchi/crater-core" @types,
   "mizchi/crater-dom/html",
   "mizchi/crater-painter/paint/model" @paint_model,


### PR DESCRIPTION
## Summary

Follow-up to #90's Node move. Several sub-packages still imported `mizchi/crater-layout` purely to access `@*.Node` (the type). Switch their `moon.pkg` imports to `mizchi/crater-core/node` while keeping the local alias name (`@node` / `@layout`) unchanged — zero source-code churn.

Affected sub-packages (9 `moon.pkg` files):
- `browser/tui/{,paint/,paint/plain/,paint/runtime/,paint/viewport/,paint/png/,paint/export/}` — all only used `@node.Node`
- `browser/component_artifact` — only used `@node.Node`
- `renderer/vrt` — only used `@layout.Node`

Module-level `crater-layout` deps stay where the module still has other sub-packages using the layout engine (`browser/shell` uses `LayoutTree`; `renderer/renderer` uses engine functions). Clean-up is per-sub-package.

## Test plan

- [x] `moon check --target js`
- [x] `moon test --target js` — 4964 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
