### PR TITLE
Introduce LayoutView trait; webvitals drops crater-layout dep

### DIFF
--- a/core/layout_view/moon.pkg
+++ b/core/layout_view/moon.pkg
@@ -1,0 +1,2 @@
+import {
+} for "wbtest"

--- a/core/layout_view/pkg.generated.mbti
+++ b/core/layout_view/pkg.generated.mbti
@@ -1,0 +1,28 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "mizchi/crater-core/layout_view"
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) enum ResourceLoadState {
+  Pending
+  Resolved
+  Error
+}
+
+// Type aliases
+
+// Traits
+pub(open) trait LayoutView {
+  uid(Self) -> Int
+  computed_x(Self) -> Double
+  computed_y(Self) -> Double
+  computed_width(Self) -> Double
+  computed_height(Self) -> Double
+  children(Self) -> Array[Self]
+  text(Self) -> String?
+  resource_state(Self) -> ResourceLoadState?
+}
+

--- a/core/layout_view/view.mbt
+++ b/core/layout_view/view.mbt
@@ -1,0 +1,30 @@
+///|
+/// Loading state of an intrinsic-sized resource (image, etc).
+/// Abstract view of layout-engine-specific resource tracking so that
+/// downstream consumers (web vitals, accessibility walks, ...) can
+/// reason about resource readiness without depending on the layout
+/// engine's internal state representation.
+pub(all) enum ResourceLoadState {
+  Pending
+  Resolved
+  Error
+}
+
+///|
+/// Read-only view of a computed layout tree node.
+///
+/// Implementations expose just the fields needed by external consumers
+/// (web vitals metrics, accessibility tree walks, etc.) without leaking
+/// layout-engine state. The layout engine's `LayoutNode` (in
+/// `mizchi/crater-layout/tree`) is the canonical implementation; tests
+/// and alternative engines can provide their own.
+pub(open) trait LayoutView {
+  uid(Self) -> Int
+  computed_x(Self) -> Double
+  computed_y(Self) -> Double
+  computed_width(Self) -> Double
+  computed_height(Self) -> Double
+  children(Self) -> Array[Self]
+  text(Self) -> String?
+  resource_state(Self) -> ResourceLoadState?
+}

--- a/docs/module-graph.dot
+++ b/docs/module-graph.dot
@@ -126,5 +126,4 @@ digraph crater_modules {
   mizchi_crater_webdriver_bidi -> mizchi_crater_browser;
   mizchi_crater_webdriver_bidi -> mizchi_crater_browser_helpers;
   mizchi_crater_webvitals -> mizchi_crater_core;
-  mizchi_crater_webvitals -> mizchi_crater_layout;
 }

--- a/docs/module-graph.md
+++ b/docs/module-graph.md
@@ -126,7 +126,6 @@ graph LR
   mizchi_crater_webdriver_bidi --> mizchi_crater_browser
   mizchi_crater_webdriver_bidi --> mizchi_crater_browser_helpers
   mizchi_crater_webvitals --> mizchi_crater_core
-  mizchi_crater_webvitals --> mizchi_crater_layout
 ```
 
 ## Modules and incoming-edge counts
@@ -137,11 +136,11 @@ graph LR
 | Foundation | `crater-css` | `css` | 9 | crater-core |
 | Foundation | `crater-dom` | `dom` | 11 | crater-core, crater-css, crater-layout |
 | Foundation | `crater-html-assets` | `html_assets` | 1 | — |
-| Foundation | `crater-layout` | `layout` | 11 | crater-core |
+| Foundation | `crater-layout` | `layout` | 10 | crater-core |
 | Foundation | `crater-network` | `network` | 1 | — |
 | Render | `crater-painter` | `painter` | 6 | crater-core, crater-terminal-protocol |
 | Render | `crater-renderer` | `renderer` | 7 | crater-core, crater-css, crater-dom, crater-layout, crater-painter |
-| Render | `crater-webvitals` | `webvitals` | 1 | crater-core, crater-layout |
+| Render | `crater-webvitals` | `webvitals` | 1 | crater-core |
 | Terminal | `crater-terminal-image-cache` | `terminal_image_cache` | 1 | — |
 | Terminal | `crater-terminal-protocol` | `terminal_protocol` | 2 | — |
 | Browser | `crater-browser` | `browser` | 3 | crater-aomx, crater-browser-helpers, crater-browser-http, crater-browser-runtime, crater-core, crater-css, crater-dom, crater-html-assets, crater-layout, crater-painter, crater-renderer, crater-terminal-image-cache, crater-terminal-protocol |

--- a/layout/tree/layout_view_impl.mbt
+++ b/layout/tree/layout_view_impl.mbt
@@ -1,0 +1,50 @@
+///|
+/// Implementation of the abstract `@view.LayoutView` interface for
+/// the layout engine's concrete `LayoutNode`. Consumers (web vitals,
+/// accessibility walks, ...) can stay generic over `LayoutView` and
+/// avoid taking a direct dependency on the layout engine.
+
+///|
+pub impl @view.LayoutView for LayoutNode with uid(self) {
+  self.uid
+}
+
+///|
+pub impl @view.LayoutView for LayoutNode with computed_x(self) {
+  self.computed_x
+}
+
+///|
+pub impl @view.LayoutView for LayoutNode with computed_y(self) {
+  self.computed_y
+}
+
+///|
+pub impl @view.LayoutView for LayoutNode with computed_width(self) {
+  self.computed_width
+}
+
+///|
+pub impl @view.LayoutView for LayoutNode with computed_height(self) {
+  self.computed_height
+}
+
+///|
+pub impl @view.LayoutView for LayoutNode with children(self) {
+  self.children
+}
+
+///|
+pub impl @view.LayoutView for LayoutNode with text(self) {
+  self.text
+}
+
+///|
+pub impl @view.LayoutView for LayoutNode with resource_state(self) {
+  match self.intrinsic_state {
+    Some(Resolved(..)) => Some(@view.ResourceLoadState::Resolved)
+    Some(Pending(..)) => Some(@view.ResourceLoadState::Pending)
+    Some(Error) => Some(@view.ResourceLoadState::Error)
+    None => None
+  }
+}

--- a/layout/tree/moon.pkg
+++ b/layout/tree/moon.pkg
@@ -3,6 +3,7 @@ import {
   "mizchi/crater-core" @types,
   "mizchi/crater-core/style",
   "mizchi/crater-core/node",
+  "mizchi/crater-core/layout_view" @view,
   "mizchi/crater-layout/dispatch",
 }
 

--- a/layout/tree/pkg.generated.mbti
+++ b/layout/tree/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "mizchi/crater-layout/tree"
 
 import {
   "mizchi/crater-core",
+  "mizchi/crater-core/layout_view",
   "mizchi/crater-core/node",
   "mizchi/crater-core/style",
   "moonbitlang/core/debug",
@@ -172,6 +173,7 @@ pub fn LayoutNode::set_width_auto(Self) -> Self
 pub fn LayoutNode::set_width_percent(Self, Double) -> Self
 pub fn LayoutNode::to_node(Self) -> @node.Node
 pub fn LayoutNode::with_measure(String, @style.Style, @crater-core.MeasureFunc) -> Self
+pub impl @layout_view.LayoutView for LayoutNode
 
 pub struct LayoutTree {
   root : LayoutNode

--- a/webvitals/lcp.mbt
+++ b/webvitals/lcp.mbt
@@ -297,33 +297,34 @@ fn LCPTracker::update_current_lcp(self : LCPTracker) -> Unit {
 // =============================================================================
 
 ///|
-/// Extract LCP candidates from a LayoutTree
-pub fn extract_lcp_candidates(
-  layout : @tree.LayoutTree,
+/// Extract LCP candidates from any layout view tree root.
+///
+/// The function is generic over the layout impl: pass the root of a
+/// concrete tree (e.g. `LayoutTree::root` from `crater-layout/tree`) or
+/// any other type that implements `@view.LayoutView`.
+pub fn[T : @view.LayoutView] extract_lcp_candidates(
+  root : T,
   viewport_width : Double,
   viewport_height : Double,
 ) -> Array[LCPCandidate] {
   let candidates : Array[LCPCandidate] = []
   extract_candidates_recursive(
-    layout.root,
-    candidates,
-    viewport_width,
-    viewport_height,
+    root, candidates, viewport_width, viewport_height,
   )
   candidates
 }
 
 ///|
-fn extract_candidates_recursive(
-  node : @tree.LayoutNode,
+fn[T : @view.LayoutView] extract_candidates_recursive(
+  node : T,
   candidates : Array[LCPCandidate],
   viewport_width : Double,
   viewport_height : Double,
 ) -> Unit {
-  let x = node.computed_x
-  let y = node.computed_y
-  let width = node.computed_width
-  let height = node.computed_height
+  let x = node.computed_x()
+  let y = node.computed_y()
+  let width = node.computed_width()
+  let height = node.computed_height()
 
   // Skip if completely outside viewport
   if x >= viewport_width ||
@@ -331,7 +332,7 @@ fn extract_candidates_recursive(
     x + width <= 0.0 ||
     y + height <= 0.0 {
     // Still check children as they might be positioned differently
-    for child in node.children {
+    for child in node.children() {
       extract_candidates_recursive(
         child, candidates, viewport_width, viewport_height,
       )
@@ -343,7 +344,7 @@ fn extract_candidates_recursive(
   match classify_lcp_element(node) {
     Some(element_type) => {
       let candidate = LCPCandidate::new(
-        node.uid.to_string(),
+        node.uid().to_string(),
         element_type,
         x,
         y,
@@ -361,7 +362,7 @@ fn extract_candidates_recursive(
   }
 
   // Recurse into children
-  for child in node.children {
+  for child in node.children() {
     extract_candidates_recursive(
       child, candidates, viewport_width, viewport_height,
     )
@@ -369,28 +370,26 @@ fn extract_candidates_recursive(
 }
 
 ///|
-/// Classify a layout node as an LCP element type (if applicable)
-fn classify_lcp_element(node : @tree.LayoutNode) -> LCPElementType? {
-  // Check for image elements (nodes with intrinsic state)
-  match node.intrinsic_state {
-    Some(state) =>
-      match state {
-        @tree.IntrinsicState::Pending(_) | @tree.IntrinsicState::Resolved(_) =>
-          // This is an image/resource node
-          return Some(Image(src=node.uid.to_string()))
-        @tree.IntrinsicState::Error => return None
-      }
+/// Classify a layout view node as an LCP element type (if applicable)
+fn[T : @view.LayoutView] classify_lcp_element(node : T) -> LCPElementType? {
+  // Check for image elements (nodes with a resource load state)
+  match node.resource_state() {
+    Some(@view.ResourceLoadState::Pending)
+    | Some(@view.ResourceLoadState::Resolved) =>
+      // This is an image/resource node
+      return Some(Image(src=node.uid().to_string()))
+    Some(@view.ResourceLoadState::Error) => return None
     None => ()
   }
 
   // Check node type for text blocks
   // Large text blocks (paragraphs, headings) are LCP candidates
   // Minimum size threshold: 10x10 pixels
-  let width = node.computed_width
-  let height = node.computed_height
+  let width = node.computed_width()
+  let height = node.computed_height()
   if width >= 10.0 && height >= 10.0 {
     // If it has no children and has text content, it's likely a text node
-    if node.children.is_empty() && node.text is Some(_) {
+    if node.children().is_empty() && node.text() is Some(_) {
       return Some(TextBlock)
     }
   }

--- a/webvitals/moon.mod.json
+++ b/webvitals/moon.mod.json
@@ -5,10 +5,6 @@
     "mizchi/crater-core": {
       "path": "../core",
       "version": "0.17.1"
-    },
-    "mizchi/crater-layout": {
-      "path": "../layout",
-      "version": "0.17.1"
     }
   },
   "repository": "https://github.com/mizchi/crater",

--- a/webvitals/moon.pkg
+++ b/webvitals/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "mizchi/crater-core" @types,
-  "mizchi/crater-layout" @tree,
+  "mizchi/crater-core/layout_view" @view,
 }
 
 import {

--- a/webvitals/pkg.generated.mbti
+++ b/webvitals/pkg.generated.mbti
@@ -3,7 +3,7 @@ package "mizchi/crater-webvitals"
 
 import {
   "mizchi/crater-core",
-  "mizchi/crater-layout/tree",
+  "mizchi/crater-core/layout_view",
   "moonbitlang/core/debug",
 }
 
@@ -12,7 +12,7 @@ pub fn compute_element_shift(@crater-core.BoundingRect, @crater-core.BoundingRec
 
 pub fn compute_total(Array[@crater-core.BoundingRect], Array[@crater-core.BoundingRect], @crater-core.Size[Double]) -> Double
 
-pub fn extract_lcp_candidates(@tree.LayoutTree, Double, Double) -> Array[LCPCandidate]
+pub fn[T : @layout_view.LayoutView] extract_lcp_candidates(T, Double, Double) -> Array[LCPCandidate]
 
 // Errors
 


### PR DESCRIPTION
## Summary

Introduce a `LayoutView` trait + abstract `ResourceLoadState` enum in a new `core/layout_view/` sub-package. This is the first piece of genuine trait-based DIP in the project.

**Trait surface** — just the fields LCP detection actually reads:
```moonbit
pub(open) trait LayoutView {
  uid(Self) -> Int
  computed_x(Self) -> Double
  computed_y(Self) -> Double
  computed_width(Self) -> Double
  computed_height(Self) -> Double
  children(Self) -> Array[Self]
  text(Self) -> String?
  resource_state(Self) -> ResourceLoadState?
}

pub(all) enum ResourceLoadState {
  Pending
  Resolved
  Error
}
```

Implement for `@tree.LayoutNode` in `layout/tree/layout_view_impl.mbt`. The impl translates the engine's `IntrinsicState::{Pending,Resolved,Error}` to `ResourceLoadState::{Pending,Resolved,Error}` so consumers never see the engine encoding.

Make `extract_lcp_candidates` and its helpers generic over `T : @view.LayoutView`. Callers now pass the tree root directly (`tree.root` instead of `tree`) — no in-repo callers existed yet, so the signature change is safe.

**Major win**: `mizchi/crater-webvitals` drops its `mizchi/crater-layout` dep entirely. Web vitals metrics now depend only on `crater-core`, exactly as they conceptually should — metrics shouldn't know about layout-engine internals.

- New `core/layout_view/{moon.pkg,view.mbt}`
- New `layout/tree/layout_view_impl.mbt`
- `layout/tree/moon.pkg`: import the new view trait pkg
- `webvitals/moon.pkg`: `mizchi/crater-layout @tree` → `mizchi/crater-core/layout_view @view`
- `webvitals/lcp.mbt`: rewrite extraction to be generic over `LayoutView`
- Drop `mizchi/crater-layout` from `webvitals/moon.mod.json`
- regen `docs/module-graph.{md,dot}`

## Test plan

- [x] `moon check --target js`
- [x] `moon test --target js -p mizchi/crater-webvitals` — 12/12
- [x] `moon test --target js` — 4964 tests pass
- [x] `node --test scripts/moon-publish-workspace.test.mjs` — 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
