### PR TITLE
Move aomx grounding integration test to testing/e2e; aomx drops layout dep

### DIFF
--- a/aomx/grounding/grounding_test.mbt
+++ b/aomx/grounding/grounding_test.mbt
@@ -110,34 +110,6 @@ test "spatial_region_to_string" {
   inspect(SpatialRegion::BottomRight.to_string(), content="bottom-right")
 }
 
-///|
-test "grounding with html integration" {
-  @layout.setup()
-  // Simple HTML with buttons at different positions
-  let html =
-    #|<div id="container" style="width:800px;height:600px">
-    #|  <button id="btn-top-left" style="position:absolute;left:50px;top:50px;width:100px;height:40px">Top Left</button>
-    #|  <button id="btn-center" style="position:absolute;left:350px;top:280px;width:100px;height:40px">Center</button>
-    #|  <button id="btn-bottom-right" style="position:absolute;left:650px;top:510px;width:100px;height:40px">Bottom Right</button>
-    #|</div>
-  // Parse and assign synthetic IDs
-  let doc = @html.assign_synthetic_ids(@html.parse_document(html))
-  // Build layout tree
-  let layout_tree = @layout_html_tree.layout_tree_from_html_document(
-    doc, 800.0, 600.0,
-  )
-  let _ = layout_tree.calculate_layout(800.0, 600.0)
-  // Build AOM with bounds
-  let tree = @aom.build_accessibility_tree_with_layout(doc, layout_tree)
-  // Check that buttons have bounds attached
-  let interactive = @aom.find_interactive(tree)
-  inspect(interactive.length(), content="3")
-  // All buttons should have bounds
-  let mut buttons_with_bounds = 0
-  for node in interactive {
-    if node.bounds is Some(_) {
-      buttons_with_bounds += 1
-    }
-  }
-  inspect(buttons_with_bounds, content="3")
-}
+// The HTML → layout → AOM-with-bounds integration test lives in
+// `testing/e2e/aom_grounding/` so that `crater-aomx` itself does not
+// require a `crater-layout` dep.

--- a/aomx/grounding/moon.pkg
+++ b/aomx/grounding/moon.pkg
@@ -3,10 +3,4 @@ import {
 }
 
 import {
-  "mizchi/crater-dom/html",
-  "mizchi/crater-layout" @layout,
-  "mizchi/crater-dom/layout/html_tree" @layout_html_tree,
-} for "test"
-
-import {
 } for "wbtest"

--- a/aomx/moon.mod.json
+++ b/aomx/moon.mod.json
@@ -5,10 +5,6 @@
     "mizchi/crater-dom": {
       "path": "../dom",
       "version": "0.17.1"
-    },
-    "mizchi/crater-layout": {
-      "path": "../layout",
-      "version": "0.17.1"
     }
   },
   "repository": "https://github.com/mizchi/crater",

--- a/docs/module-graph.dot
+++ b/docs/module-graph.dot
@@ -51,7 +51,6 @@ digraph crater_modules {
     mizchi_crater_tools [label="crater-tools"];
   }
   mizchi_crater_aomx -> mizchi_crater_dom;
-  mizchi_crater_aomx -> mizchi_crater_layout;
   mizchi_crater_benchmarks -> mizchi_crater_core;
   mizchi_crater_benchmarks -> mizchi_crater_browser;
   mizchi_crater_benchmarks -> mizchi_crater_css;

--- a/docs/module-graph.md
+++ b/docs/module-graph.md
@@ -51,7 +51,6 @@ graph LR
   end
 
   mizchi_crater_aomx --> mizchi_crater_dom
-  mizchi_crater_aomx --> mizchi_crater_layout
   mizchi_crater_benchmarks --> mizchi_crater_core
   mizchi_crater_benchmarks --> mizchi_crater_browser
   mizchi_crater_benchmarks --> mizchi_crater_css
@@ -136,7 +135,7 @@ graph LR
 | Foundation | `crater-css` | `css` | 9 | crater-core |
 | Foundation | `crater-dom` | `dom` | 11 | crater-core, crater-css, crater-layout |
 | Foundation | `crater-html-assets` | `html_assets` | 1 | — |
-| Foundation | `crater-layout` | `layout` | 10 | crater-core |
+| Foundation | `crater-layout` | `layout` | 9 | crater-core |
 | Foundation | `crater-network` | `network` | 1 | — |
 | Render | `crater-painter` | `painter` | 6 | crater-core, crater-terminal-protocol |
 | Render | `crater-renderer` | `renderer` | 7 | crater-core, crater-css, crater-dom, crater-layout, crater-painter |
@@ -152,7 +151,7 @@ graph LR
 | Distribution | `crater (umbrella)` | `.` | 0 | crater-css, crater-dom, crater-layout, crater-painter, crater-renderer, crater-webvitals |
 | Distribution | `crater-js` | `js` | 1 | crater-aomx, crater-core, crater-css, crater-dom, crater-layout, crater-painter, crater-renderer |
 | Distribution | `crater-wasm` | `wasm` | 0 | crater-js |
-| Test / Dev | `crater-aomx` | `aomx` | 3 | crater-dom, crater-layout |
+| Test / Dev | `crater-aomx` | `aomx` | 3 | crater-dom |
 | Test / Dev | `crater-benchmarks` | `benchmarks` | 0 | crater-browser, crater-core, crater-css, crater-dom, crater-layout, crater-painter, crater-renderer |
 | Test / Dev | `crater-conformance` | `conformance` | 0 | crater-core, crater-css, crater-layout, crater-renderer |
 | Test / Dev | `crater-testing` | `testing` | 0 | crater-browser, crater-browser-native, crater-browser-runtime, crater-core, crater-css, crater-dom, crater-layout |

--- a/testing/e2e/aom_grounding/aom_grounding_test.mbt
+++ b/testing/e2e/aom_grounding/aom_grounding_test.mbt
@@ -1,0 +1,34 @@
+///|
+/// HTML → layout → AOM-with-bounds integration test.
+///
+/// Verifies that running the layout engine on a simple HTML snippet and
+/// then building an accessibility tree against the layout produces
+/// elements whose bounds are attached — which is what `crater-aomx`
+/// `grounding` relies on for spatial queries.
+///
+/// Lives here (rather than under `aomx/grounding`) so that
+/// `mizchi/crater-aomx` itself does not need a `crater-layout` dep.
+test "grounding pipeline: layout produces AOM with bounds" {
+  @layout.setup()
+  let html =
+    #|<div id="container" style="width:800px;height:600px">
+    #|  <button id="btn-top-left" style="position:absolute;left:50px;top:50px;width:100px;height:40px">Top Left</button>
+    #|  <button id="btn-center" style="position:absolute;left:350px;top:280px;width:100px;height:40px">Center</button>
+    #|  <button id="btn-bottom-right" style="position:absolute;left:650px;top:510px;width:100px;height:40px">Bottom Right</button>
+    #|</div>
+  let doc = @html.assign_synthetic_ids(@html.parse_document(html))
+  let layout_tree = @layout_html_tree.layout_tree_from_html_document(
+    doc, 800.0, 600.0,
+  )
+  let _ = layout_tree.calculate_layout(800.0, 600.0)
+  let tree = @aom.build_accessibility_tree_with_layout(doc, layout_tree)
+  let interactive = @aom.find_interactive(tree)
+  inspect(interactive.length(), content="3")
+  let mut buttons_with_bounds = 0
+  for node in interactive {
+    if node.bounds is Some(_) {
+      buttons_with_bounds += 1
+    }
+  }
+  inspect(buttons_with_bounds, content="3")
+}

--- a/testing/e2e/aom_grounding/moon.pkg
+++ b/testing/e2e/aom_grounding/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "mizchi/crater-dom/aom" @aom,
+  "mizchi/crater-dom/html" @html,
+  "mizchi/crater-layout" @layout,
+  "mizchi/crater-dom/layout/html_tree" @layout_html_tree,
+} for "test"
+
+supported_targets = "js+native"

--- a/testing/e2e/aom_grounding/pkg.generated.mbti
+++ b/testing/e2e/aom_grounding/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "mizchi/crater-testing/e2e/aom_grounding"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary

`crater-aomx` production code was already engine-independent — only one test ("grounding with html integration") used `mizchi/crater-layout` to bootstrap the engine and build a layout tree from HTML, then exercised the HTML → layout → AOM-with-bounds pipeline.

That test is genuinely an E2E integration test, not a unit test of grounding's spatial logic. Move it to a new `testing/e2e/aom_grounding/` sub-package which can freely depend on the layout engine. The remaining grounding tests (spatial region helpers, viewport math, click coord extraction) stay in `aomx/grounding/` and exercise grounding's own logic against hand-built AOM trees.

With that test gone, `aomx/grounding/moon.pkg` no longer needs `crater-layout` or `crater-dom/layout/html_tree` test-imports, and `aomx/moon.mod.json` drops `mizchi/crater-layout` entirely.

**Major win**: `mizchi/crater-aomx` drops its `crater-layout` dep. AOM extraction (arc90, diff, grounding) is now pure: it depends only on `crater-dom`.

- New `testing/e2e/aom_grounding/{moon.pkg,aom_grounding_test.mbt}`
- Delete the integration test from `aomx/grounding/grounding_test.mbt` (left a one-line comment pointing to its new home)
- `aomx/grounding/moon.pkg`: drop the test-only `crater-layout` imports
- `aomx/moon.mod.json`: drop `mizchi/crater-layout`
- regen `docs/module-graph.{md,dot}`

## Test plan

- [x] `moon check --target js`
- [x] `moon test --target js -p mizchi/crater-testing/e2e/aom_grounding` — 1/1
- [x] `moon test --target js` — 4964 tests pass
- [x] `node --test scripts/moon-publish-workspace.test.mjs` — 12/12
- [x] `pnpm vitest run scripts/moon-module-boundary-{core,package}.test.ts` — 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
