### PR TITLE
Split LayoutTree-flavored AOM helpers into dom/layout/aom_bridge

### DIFF
--- a/dom/aom/layout_test.mbt
+++ b/dom/aom/layout_test.mbt
@@ -1,59 +1,9 @@
 ///|
-/// Tests for AOM + Layout integration
-
-///|
-test "extract bounds from LayoutTree" {
-  @layout.setup()
-  // Create a simple layout tree manually
-  let child = @layout.LayoutNode::new(
-    "btn1",
-    @style.Style::{
-      ..@style.Style::default(),
-      width: @types.Length(100.0),
-      height: @types.Length(40.0),
-    },
-    [],
-  )
-  let root = @layout.LayoutNode::new(
-    "container",
-    @style.Style::{
-      ..@style.Style::default(),
-      width: @types.Length(800.0),
-      height: @types.Length(600.0),
-      display: @types.Flex,
-      justify_content: @types.Center,
-      align_items: @types.Center,
-    },
-    [child],
-  )
-  let layout_tree = @layout.LayoutTree::new(root, 800.0, 600.0)
-  // Use calculate_layout which populates computed_* fields
-  let _ = layout_tree.calculate_layout(800.0, 600.0)
-  // Extract bounds
-  let bounds_map = extract_bounds_from_layout(layout_tree)
-  // Check container bounds
-  match bounds_map.get("container") {
-    Some(b) => {
-      inspect(b.x, content="0")
-      inspect(b.y, content="0")
-      inspect(b.width, content="800")
-      inspect(b.height, content="600")
-    }
-    None => panic()
-  }
-  // Check button bounds (centered)
-  match bounds_map.get("btn1") {
-    Some(b) => {
-      inspect(b.width, content="100")
-      inspect(b.height, content="40")
-      // Centered: x = (800 - 100) / 2 = 350
-      inspect(b.x, content="350")
-      // Centered: y = (600 - 40) / 2 = 280
-      inspect(b.y, content="280")
-    }
-    None => panic()
-  }
-}
+/// Tests for AOM + Layout integration.
+///
+/// The `LayoutTree`-flavored tests (`extract bounds from LayoutTree`,
+/// `build_accessibility_tree_with_layout - full integration`) live in
+/// `dom/layout/aom_bridge/` so this package does not need a layout dep.
 
 ///|
 test "attach bounds to AccessibilityTree" {
@@ -101,35 +51,6 @@ test "attach bounds to AccessibilityTree" {
         }
         None => panic()
       }
-    }
-    None => panic()
-  }
-}
-
-///|
-test "build_accessibility_tree_with_layout - full integration" {
-  @layout.setup()
-  // Create HTML
-  let html =
-    #|<div id="nav">
-    #|  <button id="btn">Menu</button>
-    #|</div>
-  let doc = @html.parse_document(html)
-  // Build layout tree from HTML
-  let layout_tree = @layout_html_tree.layout_tree_from_html_document(
-    doc, 800.0, 600.0,
-  )
-  // Use calculate_layout which populates computed_* fields
-  let _ = layout_tree.calculate_layout(800.0, 600.0)
-  // Build integrated accessibility tree with bounds
-  let a11y_tree = build_accessibility_tree_with_layout(doc, layout_tree)
-  // Check that button has bounds
-  match a11y_tree.find_by_source_id("btn") {
-    Some(node) => {
-      inspect(node.role, content="Button")
-      debug_inspect(node.name, content="Some(\"Menu\")")
-      // Bounds should be attached from layout
-      inspect(node.bounds is Some(_), content="true")
     }
     None => panic()
   }

--- a/dom/aom/moon.pkg
+++ b/dom/aom/moon.pkg
@@ -2,14 +2,8 @@ import {
   "moonbitlang/core/string",
   "mizchi/crater-dom/html",
   "mizchi/crater-css" @css,
-  "mizchi/crater-layout" @layout,
   "mizchi/crater-core" @types,
 }
-
-import {
-  "mizchi/crater-dom/layout/html_tree" @layout_html_tree,
-  "mizchi/crater-core/style",
-} for "test"
 
 import {
 } for "wbtest"

--- a/dom/aom/pkg.generated.mbti
+++ b/dom/aom/pkg.generated.mbti
@@ -4,7 +4,6 @@ package "mizchi/crater-dom/aom"
 import {
   "mizchi/crater-core",
   "mizchi/crater-dom/html",
-  "mizchi/crater-layout/tree",
   "moonbitlang/core/debug",
 }
 
@@ -16,8 +15,6 @@ pub fn build_accessibility_tree(@html.Document) -> AccessibilityTree
 pub fn build_accessibility_tree_from_element(@html.Element) -> AccessibilityTree
 
 pub fn build_accessibility_tree_lightweight(@html.Document) -> AccessibilityTree
-
-pub fn build_accessibility_tree_with_layout(@html.Document, @tree.LayoutTree) -> AccessibilityTree
 
 pub fn build_accessibility_tree_with_node_layout(@html.Document, @crater-core.Layout) -> AccessibilityTree
 
@@ -34,8 +31,6 @@ pub fn compute_accessible_name_with_label(@html.Element, (String) -> @html.Eleme
 pub fn compute_role(@html.Element, RoleMappingContext) -> Role
 
 pub fn compute_tab_order(AccessibilityTree) -> Array[FocusableItem]
-
-pub fn extract_bounds_from_layout(@tree.LayoutTree) -> Map[String, Bounds]
 
 pub fn extract_bounds_from_node_layout(@crater-core.Layout) -> Map[String, Bounds]
 

--- a/dom/aom/tree.mbt
+++ b/dom/aom/tree.mbt
@@ -1170,57 +1170,12 @@ fn find_headings_recursive(
 // =============================================================================
 // LayoutTree Integration
 // =============================================================================
-
-///|
-/// Extract bounds from LayoutTree node map into a Map[String, Bounds]
-/// Uses the layout node's id as key (which corresponds to HTML element id)
-pub fn extract_bounds_from_layout(
-  layout_tree : @layout.LayoutTree,
-) -> Map[String, Bounds] {
-  let bounds_map : Map[String, Bounds] = {}
-  extract_bounds_recursive(layout_tree.root, bounds_map)
-  bounds_map
-}
-
-///|
-fn extract_bounds_recursive(
-  node : @layout.LayoutNode,
-  bounds_map : Map[String, Bounds],
-) -> Unit {
-  // Add bounds for this node if it has a non-empty id
-  if !node.id.is_empty() {
-    let bounds = Bounds::new(
-      node.computed_x,
-      node.computed_y,
-      node.computed_width,
-      node.computed_height,
-    )
-    bounds_map[node.id] = bounds
-    let source_id = extract_element_id(node.id)
-    if !source_id.is_empty() {
-      bounds_map[source_id] = bounds
-    }
-  }
-  // Recurse into children
-  for child in node.children {
-    extract_bounds_recursive(child, bounds_map)
-  }
-}
-
-///|
-/// Build AccessibilityTree from HTML and attach layout bounds from LayoutTree
-/// This is the main integration function for combining a11y and layout
-pub fn build_accessibility_tree_with_layout(
-  doc : @html.Document,
-  layout_tree : @layout.LayoutTree,
-) -> AccessibilityTree {
-  // Build accessibility tree
-  let a11y_tree = build_accessibility_tree(doc)
-  // Extract bounds from layout tree
-  let bounds_map = extract_bounds_from_layout(layout_tree)
-  // Attach bounds to accessibility nodes
-  attach_bounds(a11y_tree, bounds_map)
-}
+//
+// The `LayoutTree`-flavored helpers (extract_bounds_from_layout,
+// build_accessibility_tree_with_layout) live in
+// `dom/layout/aom_bridge/` so this package does not need a layout dep.
+// Consumers using the renderer's `@core.Layout` output should call
+// `build_accessibility_tree_with_node_layout` below.
 
 ///|
 /// Extract bounds from @types.Layout (renderer's layout result)

--- a/dom/layout/aom_bridge/aom_layout_bridge.mbt
+++ b/dom/layout/aom_bridge/aom_layout_bridge.mbt
@@ -1,0 +1,66 @@
+///|
+/// Bridge between the layout engine's `LayoutTree` / `LayoutNode` and
+/// the AOM. Lives in the dom/layout bridge layer so that
+/// `mizchi/crater-dom/aom` itself does not need a `mizchi/crater-layout`
+/// dependency. Consumers that work with `@core.Layout` (renderer output,
+/// pure data) can call `@aom.build_accessibility_tree_with_node_layout`
+/// directly without touching this module.
+
+///|
+/// Extract bounds from a LayoutTree into a `(source_id -> Bounds)` map.
+/// Uses each layout node's id as the AOM lookup key.
+pub fn extract_bounds_from_layout(
+  layout_tree : @layout.LayoutTree,
+) -> Map[String, @aom.Bounds] {
+  let bounds_map : Map[String, @aom.Bounds] = {}
+  extract_bounds_recursive(layout_tree.root, bounds_map)
+  bounds_map
+}
+
+///|
+fn extract_bounds_recursive(
+  node : @layout.LayoutNode,
+  bounds_map : Map[String, @aom.Bounds],
+) -> Unit {
+  if !node.id.is_empty() {
+    let bounds = @aom.Bounds::new(
+      node.computed_x,
+      node.computed_y,
+      node.computed_width,
+      node.computed_height,
+    )
+    bounds_map[node.id] = bounds
+    let source_id = extract_element_id(node.id)
+    if !source_id.is_empty() {
+      bounds_map[source_id] = bounds
+    }
+  }
+  for child in node.children {
+    extract_bounds_recursive(child, bounds_map)
+  }
+}
+
+///|
+/// Extract the element id portion from a renderer-style node id of the
+/// form `tag#id` / `tag.class` / `tag`. Returns the empty string when
+/// no `#id` segment is present.
+fn extract_element_id(node_id : String) -> String {
+  match node_id.find("#") {
+    Some(idx) => node_id.unsafe_substring(start=idx + 1, end=node_id.length())
+    None => ""
+  }
+}
+
+///|
+/// Build AccessibilityTree from HTML and attach layout bounds from
+/// `LayoutTree`. Equivalent to
+/// `@aom.build_accessibility_tree_with_node_layout` but accepts the
+/// layout engine's mutable tree directly.
+pub fn build_accessibility_tree_with_layout(
+  doc : @html.Document,
+  layout_tree : @layout.LayoutTree,
+) -> @aom.AccessibilityTree {
+  let a11y_tree = @aom.build_accessibility_tree(doc)
+  let bounds_map = extract_bounds_from_layout(layout_tree)
+  @aom.attach_bounds(a11y_tree, bounds_map)
+}

--- a/dom/layout/aom_bridge/aom_layout_bridge_test.mbt
+++ b/dom/layout/aom_bridge/aom_layout_bridge_test.mbt
@@ -1,0 +1,72 @@
+///|
+test "extract bounds from LayoutTree" {
+  @layout.setup()
+  // Create a simple layout tree manually
+  let child = @layout.LayoutNode::new(
+    "btn1",
+    @style.Style::{
+      ..@style.Style::default(),
+      width: @types.Length(100.0),
+      height: @types.Length(40.0),
+    },
+    [],
+  )
+  let root = @layout.LayoutNode::new(
+    "container",
+    @style.Style::{
+      ..@style.Style::default(),
+      width: @types.Length(800.0),
+      height: @types.Length(600.0),
+      display: @types.Flex,
+      justify_content: @types.Center,
+      align_items: @types.Center,
+    },
+    [child],
+  )
+  let layout_tree = @layout.LayoutTree::new(root, 800.0, 600.0)
+  let _ = layout_tree.calculate_layout(800.0, 600.0)
+  let bounds_map = extract_bounds_from_layout(layout_tree)
+  match bounds_map.get("container") {
+    Some(b) => {
+      inspect(b.x, content="0")
+      inspect(b.y, content="0")
+      inspect(b.width, content="800")
+      inspect(b.height, content="600")
+    }
+    None => panic()
+  }
+  match bounds_map.get("btn1") {
+    Some(b) => {
+      inspect(b.width, content="100")
+      inspect(b.height, content="40")
+      // Centered: x = (800 - 100) / 2 = 350
+      inspect(b.x, content="350")
+      // Centered: y = (600 - 40) / 2 = 280
+      inspect(b.y, content="280")
+    }
+    None => panic()
+  }
+}
+
+///|
+test "build_accessibility_tree_with_layout - full integration" {
+  @layout.setup()
+  let html =
+    #|<div id="nav">
+    #|  <button id="btn">Menu</button>
+    #|</div>
+  let doc = @html.parse_document(html)
+  let layout_tree = @layout_html_tree.layout_tree_from_html_document(
+    doc, 800.0, 600.0,
+  )
+  let _ = layout_tree.calculate_layout(800.0, 600.0)
+  let a11y_tree = build_accessibility_tree_with_layout(doc, layout_tree)
+  match a11y_tree.find_by_source_id("btn") {
+    Some(node) => {
+      inspect(node.role, content="Button")
+      debug_inspect(node.name, content="Some(\"Menu\")")
+      inspect(node.bounds is Some(_), content="true")
+    }
+    None => panic()
+  }
+}

--- a/dom/layout/aom_bridge/moon.pkg
+++ b/dom/layout/aom_bridge/moon.pkg
@@ -2,8 +2,10 @@ import {
   "mizchi/crater-dom/aom" @aom,
   "mizchi/crater-dom/html" @html,
   "mizchi/crater-layout" @layout,
-  "mizchi/crater-dom/layout/html_tree" @layout_html_tree,
-  "mizchi/crater-dom/layout/aom_bridge" @aom_bridge,
-} for "test"
+}
 
-supported_targets = "js+native"
+import {
+  "mizchi/crater-core" @types,
+  "mizchi/crater-core/style" @style,
+  "mizchi/crater-dom/layout/html_tree" @layout_html_tree,
+} for "test"

--- a/dom/layout/aom_bridge/pkg.generated.mbti
+++ b/dom/layout/aom_bridge/pkg.generated.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "mizchi/crater-dom/layout/aom_bridge"
+
+import {
+  "mizchi/crater-dom/aom",
+  "mizchi/crater-dom/html",
+  "mizchi/crater-layout/tree",
+}
+
+// Values
+pub fn build_accessibility_tree_with_layout(@html.Document, @tree.LayoutTree) -> @aom.AccessibilityTree
+
+pub fn extract_bounds_from_layout(@tree.LayoutTree) -> Map[String, @aom.Bounds]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/testing/e2e/aom_grounding/aom_grounding_test.mbt
+++ b/testing/e2e/aom_grounding/aom_grounding_test.mbt
@@ -21,7 +21,7 @@ test "grounding pipeline: layout produces AOM with bounds" {
     doc, 800.0, 600.0,
   )
   let _ = layout_tree.calculate_layout(800.0, 600.0)
-  let tree = @aom.build_accessibility_tree_with_layout(doc, layout_tree)
+  let tree = @aom_bridge.build_accessibility_tree_with_layout(doc, layout_tree)
   let interactive = @aom.find_interactive(tree)
   inspect(interactive.length(), content="3")
   let mut buttons_with_bounds = 0


### PR DESCRIPTION
## Summary

`mizchi/crater-dom/aom` had two AOM-with-bounds builders:
- `build_accessibility_tree_with_layout(doc, layout_tree)` — takes the layout engine's mutable `LayoutTree` (forces dom/aom to depend on `mizchi/crater-layout`).
- `build_accessibility_tree_with_node_layout(doc, layout)` — takes the renderer's `@core.Layout` snapshot (pure data, no engine dep).

In-repo production callers (`js/js.mbt`, `browser/shell/`) use only `_with_node_layout`. The `_with_layout` variant was only exercised by two internal tests and the E2E integration test in `testing/e2e/aom_grounding`.

Move the `LayoutTree`-flavored helpers (`extract_bounds_from_layout`, `extract_bounds_recursive`, `build_accessibility_tree_with_layout`) into a new sub-package `dom/layout/aom_bridge/`, alongside the other dom → layout bridges. Relocate the two LayoutTree-using tests there.

**Win**: `dom/aom/moon.pkg` drops `mizchi/crater-layout`. The `dom/aom` sub-package is now layout-engine-free at the package level. (The `dom` module still declares `crater-layout` because other bridges in `dom/layout/` — `html_tree`, `html_bridge`, `dom_bridge`, `style_bridge` — still need it.)

- New `dom/layout/aom_bridge/{moon.pkg,aom_layout_bridge.mbt,aom_layout_bridge_test.mbt}`
- Remove the moved functions from `dom/aom/tree.mbt` (left a comment pointing to the new home)
- Remove the moved tests from `dom/aom/layout_test.mbt`
- `dom/aom/moon.pkg`: drop `mizchi/crater-layout` and the test-only `crater-dom/layout/html_tree` import
- `testing/e2e/aom_grounding/`: switch from `@aom.build_accessibility_tree_with_layout` to `@aom_bridge.build_accessibility_tree_with_layout`

## Test plan

- [x] `moon check --target js`
- [x] `moon test --target js` — 4964 tests pass
- [x] `node --test scripts/moon-publish-workspace.test.mjs` — 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
