### PR TITLE
Remove painter/svg interop facade item from TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,9 +53,6 @@ Last organized: 2026-05-15
 
 ### Refactor residuals (module boundary 大物は本リリースサイクルで完了済)
 
-- [ ] `painter/svg` facade の直接 re-export 候補を棚卸しする
-  - `interop_*.mbt` の adapter 群から direct alias 可能な primitive を分ける
-  - public `.mbti` を維持したまま `mizchi/svg` の公開型へ寄せる
 - [ ] `painter/paint/raster/paint_raster.mbt` / glyph 周辺の責務整理を閉じる
   - bitmap font fallback と glyph path render の境界を見直す
   - `mizchi/font` / `mizchi/svg` へ委譲できる処理は crater 側を adapter にする


### PR DESCRIPTION
The interop_*.mbt method-ification is complete with #95-#99 stacked. All 5 interop_*.mbt files removed, 150 free helpers method-ified across the corresponding struct/enum definition files. Public .mbti is unchanged.

Once #95 → #96 → #97 → #98 → #99 are merged, this PR is the cleanup of the TODO entry that they collectively close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)