### PR TITLE
Drop conformance from moon.work members

### DIFF
--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ test-update:
 
 # Run taffy compatibility tests
 test-taffy:
-    moon test -p mizchi/crater-conformance/taffy --target js
+    moon -C conformance test -p mizchi/crater-conformance/taffy --target js
 
 # Verify moon test result does not regress from recorded baseline
 test-baseline:

--- a/moon.work
+++ b/moon.work
@@ -5,7 +5,6 @@ members = [
   "./benchmarks",
   "./browser_helpers",
   "./testing",
-  "./conformance",
   "./tools",
   "./webvitals",
   "./http",


### PR DESCRIPTION
## Summary
- Remove \`./conformance\` from \`moon.work\` members so root \`moon check\` and \`moon info\` no longer traverse the conformance source tree
- Switch \`just test-taffy\` to \`moon -C conformance test ...\` so the recipe still runs the suite against the now-detached module

## Why
The conformance package only holds taffy/WPT compatibility tests and is not imported by any other workspace member. Keeping it as a workspace member was dead weight on every root build/check outside the test-taffy gate. Verified locally: \`moon check --target js\` runs 34 tasks (was including conformance subtasks before), \`just test-taffy\` passes 1030/1030 with the new \`-C conformance\` form.

## Test plan
- [x] \`moon check --target js\` passes locally without conformance in the tree
- [x] \`just test-taffy\` passes locally (1030/1030)
- [ ] CI green on this PR
- [ ] pkfire \`test-taffy\` affected gate keeps firing on .mbt changes (inputs are src.moonSources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)