### PR TITLE
Drop stale css/ references after crater/css removal

### DIFF
--- a/justfile
+++ b/justfile
@@ -112,7 +112,6 @@ check:
     moon check --manifest-path testing/moon.mod.json --target js -j 1
     moon check --manifest-path webvitals/moon.mod.json --target js -j 1
     moon check --manifest-path http/moon.mod.json --target js -j 1
-    moon check --manifest-path css/moon.mod.json --target js -j 1
     moon check --manifest-path dom/moon.mod.json --target js -j 1
     moon check --manifest-path layout/moon.mod.json --target js -j 1
     moon check --manifest-path painter/moon.mod.json --target js -j 1
@@ -132,7 +131,6 @@ fmt:
     moon fmt --manifest-path testing/moon.mod.json
     moon fmt --manifest-path webvitals/moon.mod.json
     moon fmt --manifest-path http/moon.mod.json
-    moon fmt --manifest-path css/moon.mod.json
     moon fmt --manifest-path dom/moon.mod.json
     moon fmt --manifest-path layout/moon.mod.json
     moon fmt --manifest-path painter/moon.mod.json

--- a/scripts/moon-module-boundary-core.test.ts
+++ b/scripts/moon-module-boundary-core.test.ts
@@ -24,9 +24,7 @@ describe("crater-core module boundary", () => {
     const work = fs.readFileSync(path.join(REPO_ROOT, "moon.work"), "utf8");
     const coreIdx = work.indexOf('"./core"');
     const layoutIdx = work.indexOf('"./layout"');
-    const cssIdx = work.indexOf('"./css"');
     expect(coreIdx).toBeGreaterThan(-1);
     expect(coreIdx).toBeLessThan(layoutIdx);
-    expect(coreIdx).toBeLessThan(cssIdx);
   });
 });


### PR DESCRIPTION
## Summary
- Remove the `--manifest-path css/moon.mod.json` lines from `just check` and `just fmt` recipes
- Drop the `"./css"` assertion in `scripts/moon-module-boundary-core.test.ts`

## Why
PR #106 dropped the in-repo `crater/css` module in favor of the `mizchi/css` registry release, but missed these two references. `just check` (and therefore the `test` CI job and `pkf affected check`) fails with `failed to resolve manifest path` `css/moon.mod.json` `, and `moon-module-boundary-core.test.ts` fails because `"./css"` is no longer in `moon.work`. Both failures are reproducible on `main` (the latest CI run on `5863bad` is red).

## Test plan
- [x] `just check` succeeds locally
- [x] `pnpm exec vitest run scripts/moon-module-boundary-core.test.ts` passes 3/3
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)