### PR TITLE
Gate WPT and VRT jobs on pkfire affected output (restack of #110)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
     env:
       PKFIRE_CACHE_DIR: ${{ github.workspace }}/.cache/pkfire
       GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+    outputs:
+      wpt_css: ${{ steps.gates.outputs.wpt_css }}
+      wpt_dom: ${{ steps.gates.outputs.wpt_dom }}
+      wpt_webdriver: ${{ steps.gates.outputs.wpt_webdriver }}
+      paint_vrt: ${{ steps.gates.outputs.paint_vrt }}
+      wpt_vrt: ${{ steps.gates.outputs.wpt_vrt }}
 
     steps:
       - name: Checkout code
@@ -109,6 +115,11 @@ jobs:
             --keep-going \
             --timing \
             check test test-taffy test-wasm test-native-smoke
+
+      - name: Decide which heavy gates to run
+        id: gates
+        if: always()
+        run: bash scripts/ci/affected-gates.sh --base "${{ steps.affected_base.outputs.base }}"
 
   test:
     runs-on: ubuntu-latest
@@ -238,7 +249,13 @@ jobs:
   wpt-css-tests:
     name: wpt-css (${{ matrix.name }})
     runs-on: ubuntu-latest
-    needs: wasm-component
+    needs: [wasm-component, affected]
+    if: >-
+      always()
+      && needs.wasm-component.result == 'success'
+      && (github.event_name == 'schedule'
+        || github.event_name == 'push'
+        || needs.affected.outputs.wpt_css == 'true')
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -306,6 +323,12 @@ jobs:
   wpt-dom-tests:
     name: wpt-dom
     runs-on: ubuntu-latest
+    needs: [affected]
+    if: >-
+      always()
+      && (github.event_name == 'schedule'
+        || github.event_name == 'push'
+        || needs.affected.outputs.wpt_dom == 'true')
 
     steps:
       - name: Checkout code
@@ -392,6 +415,12 @@ jobs:
   wpt-webdriver-tests:
     name: wpt-webdriver
     runs-on: ubuntu-latest
+    needs: [affected]
+    if: >-
+      always()
+      && (github.event_name == 'schedule'
+        || github.event_name == 'push'
+        || needs.affected.outputs.wpt_webdriver == 'true')
 
     steps:
       - name: Checkout code
@@ -652,6 +681,12 @@ jobs:
   playwright-paint-vrt:
     name: paint-vrt (${{ matrix.name }})
     runs-on: ubuntu-latest
+    needs: [affected]
+    if: >-
+      always()
+      && (github.event_name == 'schedule'
+        || github.event_name == 'push'
+        || needs.affected.outputs.paint_vrt == 'true')
     env:
       METRIC_CI_ROOT: ${{ github.workspace }}/metric-ci
     strategy:
@@ -906,6 +941,12 @@ jobs:
 
   wpt-vrt-matrix:
     runs-on: ubuntu-latest
+    needs: [affected]
+    if: >-
+      always()
+      && (github.event_name == 'schedule'
+        || github.event_name == 'push'
+        || needs.affected.outputs.wpt_vrt == 'true')
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,9 +363,16 @@ jobs:
           if-no-files-found: warn
 
   wpt-compat-summary:
-    if: always()
+    if: >-
+      always()
+      && (github.event_name == 'schedule'
+        || github.event_name == 'push'
+        || needs.affected.outputs.wpt_css == 'true'
+        || needs.affected.outputs.wpt_dom == 'true'
+        || needs.affected.outputs.wpt_webdriver == 'true')
     runs-on: ubuntu-latest
     needs:
+      - affected
       - wpt-css-tests
       - wpt-dom-tests
       - wpt-webdriver-tests
@@ -891,9 +898,14 @@ jobs:
         run: exit 1
 
   paint-vrt-summary:
-    if: always()
+    if: >-
+      always()
+      && (github.event_name == 'schedule'
+        || github.event_name == 'push'
+        || needs.affected.outputs.paint_vrt == 'true')
     runs-on: ubuntu-latest
     needs:
+      - affected
       - playwright-paint-vrt
 
     steps:
@@ -1064,9 +1076,14 @@ jobs:
           if-no-files-found: warn
 
   wpt-vrt-summary:
-    if: always()
+    if: >-
+      always()
+      && (github.event_name == 'schedule'
+        || github.event_name == 'push'
+        || needs.affected.outputs.wpt_vrt == 'true')
     runs-on: ubuntu-latest
     needs:
+      - affected
       - playwright-wpt-vrt
 
     steps:

--- a/scripts/ci/affected-gates.sh
+++ b/scripts/ci/affected-gates.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Decide which heavy CI gates need to run based on `pkf affected`.
+# Writes gate booleans (wpt_css, wpt_dom, wpt_webdriver, paint_vrt, wpt_vrt)
+# to $GITHUB_OUTPUT and prints a summary to stdout.
+#
+# Falls back to running everything when:
+# - the event is `push` to main (gating shouldn't hide regressions in mainline)
+# - the event is `schedule` (nightly runs the full matrix)
+# - the `--force-all` flag is given (debugging knob)
+set -euo pipefail
+
+force_all=false
+base=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force-all) force_all=true; shift ;;
+    --base) base="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+gates=(wpt_css wpt_dom wpt_webdriver paint_vrt wpt_vrt)
+
+emit_all_true() {
+  local reason="$1"
+  echo "all gates -> true (reason: ${reason})"
+  for gate in "${gates[@]}"; do
+    echo "${gate}=true" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+  done
+}
+
+event="${GITHUB_EVENT_NAME:-}"
+if $force_all; then
+  emit_all_true "--force-all"
+  exit 0
+fi
+if [[ "$event" == "schedule" ]]; then
+  emit_all_true "schedule event"
+  exit 0
+fi
+if [[ "$event" == "push" ]]; then
+  emit_all_true "push event"
+  exit 0
+fi
+
+if [[ -z "$base" ]]; then
+  base="$(bash scripts/ci/pkfire-affected-base.sh)"
+fi
+echo "affected base: ${base}"
+
+set +e
+plan="$(pkf affected \
+  --since="$base" \
+  --dry-run \
+  test-wpt-css test-wpt-dom test-wpt-webdriver test-vrt test-wpt-vrt 2>&1)"
+status=$?
+set -e
+echo "${plan}"
+
+if [[ $status -ne 0 ]]; then
+  echo "pkf affected exited with ${status}; running every heavy gate to be safe"
+  emit_all_true "pkf affected error"
+  exit 0
+fi
+
+# `pkf affected --dry-run` prints a plan table whose rows look like:
+#   uncached                test-wpt-css        just wpt-all
+# We grep each task name. When the task name appears in a plan row, the
+# gate is considered affected.
+declare -A task_for=(
+  [wpt_css]=test-wpt-css
+  [wpt_dom]=test-wpt-dom
+  [wpt_webdriver]=test-wpt-webdriver
+  [paint_vrt]=test-vrt
+  [wpt_vrt]=test-wpt-vrt
+)
+
+for gate in "${gates[@]}"; do
+  task="${task_for[$gate]}"
+  if echo "${plan}" | awk -v t="${task}" '$0 ~ ("[[:space:]]" t "[[:space:]]")' | grep -q .; then
+    value=true
+  else
+    value=false
+  fi
+  echo "${gate}=${value}"
+  echo "${gate}=${value}" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+done


### PR DESCRIPTION
Restack of #110 after PR #108 (`refactor/ci-composite-actions`) was squash-merged with `--delete-branch`, which auto-closed #110.

## Summary
- New `scripts/ci/affected-gates.sh` runs `pkf affected --dry-run` against the five heavy tasks (`test-wpt-css`, `test-wpt-dom`, `test-wpt-webdriver`, `test-vrt`, `test-wpt-vrt`) and writes `wpt_css` / `wpt_dom` / `wpt_webdriver` / `paint_vrt` / `wpt_vrt` to `$GITHUB_OUTPUT`
- The `affected` job exposes these booleans as job outputs
- `wpt-css-tests`, `wpt-dom-tests`, `wpt-webdriver-tests`, `playwright-paint-vrt`, and `wpt-vrt-matrix` now only run when the matching gate is true (or on push/schedule)
- `playwright-wpt-vrt` inherits skipping via its existing dependency on `wpt-vrt-matrix`

## Why
The pkfire Taskfile already declares accurate inputs for each heavy task. PRs that only touch unrelated code (docs, http internals, dev scripts) currently still pay 5+ shards of WPT + 5 shards of paint-VRT + 8+ shards of WPT-VRT. Routing the heavy matrix through the affected set should drop unrelated PRs by 30-50% in wall time. Pushes to main and scheduled runs always go through the full matrix, so regressions can't land silently.

## Test plan
- [ ] CI green on this PR
- [ ] Verify a no-op-to-WPT PR skips all WPT/VRT jobs
- [ ] Verify a CSS-touching PR triggers wpt-css-tests
- [ ] Verify push to main runs the full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)