### PR TITLE
Gate VRT jobs behind the vrt PR label (restack of #111)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,7 +693,9 @@ jobs:
       always()
       && (github.event_name == 'schedule'
         || github.event_name == 'push'
-        || needs.affected.outputs.paint_vrt == 'true')
+        || (github.event_name == 'pull_request'
+          && contains(github.event.pull_request.labels.*.name, 'vrt')
+          && needs.affected.outputs.paint_vrt == 'true'))
     env:
       METRIC_CI_ROOT: ${{ github.workspace }}/metric-ci
     strategy:
@@ -958,7 +960,9 @@ jobs:
       always()
       && (github.event_name == 'schedule'
         || github.event_name == 'push'
-        || needs.affected.outputs.wpt_vrt == 'true')
+        || (github.event_name == 'pull_request'
+          && contains(github.event.pull_request.labels.*.name, 'vrt')
+          && needs.affected.outputs.wpt_vrt == 'true'))
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
 


### PR DESCRIPTION
Restack of #111 after PR #110 (and its restack #113) were squash-merged with `--delete-branch`, which left #111 with a missing base.

## Summary
- `playwright-paint-vrt` and `wpt-vrt-matrix` now run only when one of:
  - the `schedule` event (nightly)
  - the `push` event (main integration)
  - a `pull_request` carrying the `vrt` label AND the matching affected gate (`affected.paint_vrt` / `affected.wpt_vrt`) is true
- `playwright-wpt-vrt` inherits skipping via its dependency on `wpt-vrt-matrix`

## Why
Paint and WPT VRT shards together account for the largest share of PR wall time (5 + 8+ shards at 10-20 min each). #113 already skips them when no related file changed, but they still run on every CSS/layout/painter PR that touches an affected input. Requiring an explicit `vrt` label lets authors opt in only when they need the visual signal; main and nightly always run the full matrix so regressions can't ship silently.

## Test plan
- [ ] Without `vrt` label: paint-vrt and wpt-vrt jobs skip even when CSS files change
- [ ] With `vrt` label + CSS change: paint-vrt and wpt-vrt jobs run
- [ ] Push to main: full matrix runs regardless of label

🤖 Generated with [Claude Code](https://claude.com/claude-code)