### PR TITLE
Reify quality contracts as pkspec scenarios

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,123 +1,110 @@
 # TODO
 
-Last organized: 2026-05-15
+Last organized: 2026-05-17
 
-このファイルは「次に着手できる未完了タスク」だけを置く。完了済みの作業ログ、過去の WPT 数値、実装履歴は git history / docs / issue に寄せる。
+このファイルは pkspec scenario の navigation index と、 scenario に reify していない backlog の置き場。
 
-優先度は UX 影響軸で付ける:
+- **master**: `specs/crater.pkl` (Goal + Scenario)
+- **個別バグ・契約**: GitHub issue
+- **このファイル**: scenario への pointer + scenario 化対象外の運用メモ・外部依存
 
-- **Now (P0)** — 描画品質・互換性に直結し、 次リリースで体感差が出るもの
-- **Next (P1)** — UX 改善だが scope 大、 release を跨ぐ可能性があるもの
-- **Backlog (P2/P3)** — developer 体験 / 内部品質 / refactor。 一段先回し
-- **External / Blocker** — 外部 repo や環境依存
+```sh
+pkspec spec --goals specs/crater.pkl specs/tasks.Test.pkl   # 全 goal coverage
+pkspec spec --next  specs/crater.pkl specs/tasks.Test.pkl   # 未実装 scenario を priority 順
+pkf run spec-check                                          # contract が壊れていないか
+```
 
-## Now (P0)
+## Now (P0) — pkspec scenarios
 
-- [ ] `filter-effects` の WPT 数値を再計測し、 残 failure を潰す
-  - 旧 memo は `99 / 106 passed`、 現在の通過率を `npm run wpt -- wpt-tests/filter-effects/...` 系で再計測する
-  - filter / composite は modern CSS で頻出、 SaaS UI で目立つ箇所
-- [ ] テキスト折り返し精度を改善する
-  - paint の単語単位 wrap と layout engine の精密 wrap の差を縮める
-  - layout と同じスペース考慮の行幅累積を paint 側にも寄せる
-  - real-world VRT diff% に最も効くと予想
-- [ ] WPT 対象 module を順次拡張する (UX 頻出順)
-  - `css-text` — 文字レイアウトの根幹
-  - `css-backgrounds`
-  - `css-color`
-  - `css-transforms`
-  - `css-pseudo`
-  - `css-writing-modes`
-  - `css-ruby`
-  - 各 module を 1 PR ペースで追加して baseline を引き上げる
+| scenario id | 概要 | link |
+|---|---|---|
+| `compat.css-text-baseline` | css-text WPT baseline | — |
+| `compat.css-backgrounds-baseline` | css-backgrounds WPT baseline | — |
+| `compat.css-color-baseline` | css-color WPT baseline | — |
+| `compat.css-transforms-baseline` | css-transforms WPT baseline | — |
+| `compat.css-pseudo-baseline` | css-pseudo WPT baseline | — |
+| `compat.css-writing-modes-baseline` | css-writing-modes WPT baseline | — |
+| `compat.css-ruby-baseline` | css-ruby WPT baseline | — |
+| `compat.css-images-baseline` | css-images WPT baseline 有効化 | #65, #68 |
+| `compat.css-values-baseline` | css-values WPT baseline 有効化 | #65, #67 |
+| `compat.css-inline-baseline` | css-inline WPT baseline 有効化 | #65, #66 |
+| `compat.css-filter-effects` | filter-effects 残 failure 潰し | #64 |
+| `paint.text-wrap-layout-parity` | painter / layout の text wrap 一致 | — |
+| `paint.font-weight-numeric` | numeric font-weight 保持 | #48 |
+| `paint.text-glyph-metrics` | glyph metrics / AA Chromium parity | #47 |
 
-## Next (P1)
+## Next (P1) — pkspec scenarios
 
-- [ ] Web Components 残件を埋める
-  - selector/style: `:host` 複合 selector, `::slotted`, `:host-context`
-  - DOM surface: `closed` shadow root, declarative shadow DOM, customized built-in, form-associated custom elements / `ElementInternals`
-  - Playwright / CDP / jsbidi の query / action / inspection surface を shadow-aware に揃え切る
-- [ ] Browser shell の control default action 残件を潰す
-  - `select` popup UI
-  - blur 時 `change` の細かい spec 差分
-  - IME / selection / caret
-- [ ] built-in real-world snapshot を 3-5 ページに増やし、 CI で比較できるようにする
-- [ ] GitHub 実 URL VRT の `--mask-assets` 後も残る差分を最小 fixture 化する
-  - sticky nav / card border / list marker
-- [ ] CSS background gradient / repeating-gradient の VRT fixture を増やす
-- [ ] SVG/logo の intrinsic size と paint path を実 URL fixture から分離する
-- [ ] select / button など native form control の appearance 差分を、 mask 対象にするか paint 実装対象にするか決める
-- [ ] Browser shell fixture を実ページ寄りに拡張する
-  - article / dashboard / GitHub snapshot で DOM mutation + repaint を固定観測する
+| scenario id | 概要 | link |
+|---|---|---|
+| `compat.web-components-shadow-selectors` | `:host` 複合 / `::slotted` / `:host-context` | — |
+| `compat.web-components-element-internals` | closed shadow / declarative SD / form-associated | — |
+| `compat.browser-shell-form-controls` | select popup / blur change / IME / caret | — |
+| `compat.native-form-control-appearance` | select / button native appearance 方針 | — |
+| `protocol.playwright-shadow-aware` | Playwright / CDP / jsbidi shadow-aware | — |
+| `paint.real-world-snapshots` | built-in real-world snapshot 3-5 ページ | — |
+| `paint.github-residual-diff` | GitHub VRT 残差 (sticky nav / card border / list marker) | — |
+| `paint.svg-logo-intrinsic` | SVG / logo intrinsic を実 URL fixture から分離 | — |
+| `paint.browser-shell-fixture-expansion` | browser shell fixture を実ページ寄りに | — |
+| `compat.css-background-gradient-vrt` | CSS gradient VRT fixture 拡張 | — |
+| `diagnostic.paint-tree-diff` | paint tree diff API | #23 |
+| `diagnostic.css-property-mutation` | CSS property mutation API | #24 |
+| `diagnostic.selector-scoped-render` | selector-scoped rendering API | #25 |
+| `protocol.bidi-computed-style` | BiDi `getComputedStyle()` | #26 |
+| `diagnostic.vrt-prescanner-tracker` | VRT prescanner benchmark tracker | #29 |
+| `ci.parallel-vrt-bottleneck` | VRT shard 並列化 | #44 |
+| `ci.flaker-effectiveness` | flaker quarantine / fixture tighten | #79 |
 
-## Backlog (P2/P3)
+## Backlog (P2/P3) — pkspec scenarios
 
-### Refactor residuals (module boundary 大物は本リリースサイクルで完了済)
+| scenario id | 概要 | link |
+|---|---|---|
+| `bug.flexbox-min-width-justify` | flexbox min_width + justify-content | #2 |
+| `bug.inline-abspos-width-ahem` | inline abspos width Ahem | #17 |
+| `bug.border-radius-paint` | border-radius pixel diff | #19 |
+| `bug.flexbox-align-items` | align-items 反映 | #22 |
+| `diagnostic.css-rule-usage-tracking` | dead CSS rule tracking | #27 |
+| `tui.raster-image-display` | TUI JPEG / PNG / GIF | #16 |
+| `ci.dead-module-detection` | dead-module sweep 続き | #60 |
+| `ci.affected-required-check` | affected pkfire の required 化判断 | — |
+| `ci.flaker-vrt-harness-contract` | vrt-harness consumer payload 接続 | — |
 
-- [ ] `painter/paint/raster/paint_raster.mbt` / glyph 周辺の責務整理を閉じる
-  - bitmap font fallback と glyph path render の境界を見直す
-  - `mizchi/font` / `mizchi/svg` へ委譲できる処理は crater 側を adapter にする
-- [ ] `webdriver/server` の WebSocket transport (`bidi_server.mbt`) を移す
-  - REST handler / session manager は `webdriver/server` に分離済 (#71)
-  - WebSocket 側は `reset_runtime_js_state` / `reset_paint_provider` のコールバック化が必要なので別 PR
-- [ ] `scripts/crater_bidi_adapter.py` から transport 以外の実装責務を削る
-- [ ] WebDriver tooling の `.ts` runner (`scripts/wpt-webdriver-runner.ts` / `scripts/wpt-runner.ts` / `scripts/wpt-dom-runner.ts`) の責務を整理する
+## Not reified — operational / refactor 残務
 
-### VRT / Paint cleanup
+scenario 化していない (contract として書く粒度ではない) もの。 必要になったタイミングで issue 化するか、 該当 module の TODO コメントで管理する。
 
-- [ ] low diff ページの pseudo / icon / border-radius 残差は、 font 差分除外 VRT の budget tighten 後に個別対応する
-- [ ] WPT VRT ベースラインを `just wpt-vrt-baseline-update` で更新する
-- [ ] fixture ごとの threshold を artifact を見ながら段階的に tighten する
+### Refactor
 
-### Flaker / Test Management
-
-- [ ] `vrt-harness` consumer payload を crater contract に接続する
-  - external `vrt-artifact` fixture は `identity.key` なし / 独自 key ありの両方を用意する
-  - 実 `vrt-harness` 側は crater の公開 API だけを使い、 baseline 管理と fixture UX は `vrt-harness` に残す
-  - stable identity contract は `taskId + spec + filter + variant + optional shard`。 upstream issue: `mizchi/flaker#8`
-- [ ] flaker core と crater domain metadata の境界を固定する
-  - core: selection / quarantine / summary / diff
-  - crater: VRT 固有メトリクス (`diffRatio`, `threshold`, `backend`, `viewport`, `snapshotKind`)
-- [ ] VRT 判定は crater に残しつつ、 summary / identity / quarantine 連携だけ共通契約へ寄せる
-- [ ] crater に残った汎用 test management code を削る
-  - task selection / quarantine / batch summary の local wrapper が facade だけになっていないか棚卸しする
-- [ ] flaker issue と crater / `vrt-harness` TODO の相互参照を整え、 drift を防ぐ
-
-### CI / Task Runner
-
-- [ ] `affected pkfire` job の実 CI 結果を見て required check 化するか決める
-  - PR merge-base / push `github.event.before` fallback が GitHub Actions 上で期待どおりか確認する
-  - `.cache/pkfire` と `~/.pkl/cache` の hit 率を summary / timing artifact で追えるようにする
-- [ ] `pkf affected --profile=ci` の対象 gate を CI 実績に合わせて調整する
-  - `check`, `test`, `test-taffy`, `test-wasm`, `test-native-smoke` の required / optional 境界を決める
-  - schedule では full matrix、 PR / push では affected gate という分担で過不足がないか確認する
-
-### WPT / Compatibility (補足)
-
-- [ ] 実 `mizchi/image` が依存に入った時点で smoke test を追加する
-  - JS export と Bytes 入力の shape を固定する
-  - WPT image intrinsic provider の fallback と衝突しないことを確認する
-- [ ] `taffy_compat` の既存 failure 群を baseline 管理対象にするか、 段階的に潰すか方針を決める
-- [ ] `moon coverage analyze` の mixed-target workspace 前提の扱いを決める
+- `painter/paint/raster/paint_raster.mbt` の glyph 周辺責務整理 (bitmap font fallback と glyph path render の境界、 `mizchi/font` / `mizchi/svg` 委譲)
+- `webdriver/server` の WebSocket transport (`bidi_server.mbt`) 移動 — `reset_runtime_js_state` / `reset_paint_provider` を callback 化してから (#71 続き)
+- `scripts/crater_bidi_adapter.py` から transport 以外の実装責務を削る
+- `scripts/wpt-webdriver-runner.ts` / `scripts/wpt-runner.ts` / `scripts/wpt-dom-runner.ts` の責務整理
 
 ### Workspace / Release
 
-- [ ] `benchmarks` / `testing` / adapter module の release note template と changelog 粒度を決める
-- [ ] root facade retirement 後の publish / release note を確認する
-  - publish script / docs / downstream adapter が retired facade を参照しないことを release 前に再確認する
-- [ ] `browser/native` と `wasm` を CI の required check にどこまで含めるか決める
-- [ ] adapter module (`jsbidi`, `browser-native`, `js`, `wasm`) をどこまで公開サポート対象にするか決める
+- 実 `mizchi/image` 依存時の JS export + Bytes 入力 shape 固定 (smoke test)
+- `taffy_compat` failure を baseline 管理にするか段階潰しか方針決定
+- `moon coverage analyze` の mixed-target workspace 扱い決定
+- `benchmarks` / `testing` / adapter module の release note template と changelog 粒度
+- root facade retirement 後の publish / release note 確認 (publish script / docs / downstream が retired facade を参照しないか)
+- `browser/native` / `wasm` を CI required check にどこまで含めるか
+- adapter module (`jsbidi`, `browser-native`, `js`, `wasm`) の公開サポート範囲
+
+### VRT 運用
+
+- low diff ページの pseudo / icon / border-radius 残差は font 差分除外 VRT の budget tighten 後に対応
+- WPT VRT ベースラインを `just wpt-vrt-baseline-update` で随時更新
+- fixture ごとの threshold を artifact を見ながら段階的に tighten
 
 ## External / Blocker
 
-- [ ] `mizchi/kagura`: テキスト色が薄い SVG rasterizer alpha 問題を追う
-- [ ] `mizchi/kagura`: glyph mirror の per-quad UV swap workaround を正しい層で解消する
-- [ ] CI: llvmpipe セットアップを決める
-  - `LIBGL_ALWAYS_SOFTWARE=1`
-  - `mesa-vulkan-drivers`
+- `mizchi/kagura`: SVG rasterizer alpha 問題 (テキスト色が薄い)
+- `mizchi/kagura`: glyph mirror per-quad UV swap workaround の正しい層での解消
+- CI: llvmpipe セットアップ判断 (`LIBGL_ALWAYS_SOFTWARE=1` / `mesa-vulkan-drivers`)
 
 ## Maintenance Rules
 
-- 完了したタスクは必要な要約だけ残し、 長い作業ログは追加しない。
-- 古い計測値を書くときは再計測コマンドと日付を必ず添える。
-- 実装計画は Red / Green / Refactor の次アクションが分かる粒度に保つ。
-- 優先度は UX 影響軸 (Now=P0 → Next=P1 → Backlog) で並べ替え、 release を跨ぐ前にトリアージし直す。
+- pkspec scenario に reify したら、 該当行をこのファイルから削除する
+- scenario の reviewStatus が `approved` になったら、 表の link 列に対応 test を追記する
+- 古い計測値は再計測コマンドと日付を必ず添える
+- 完了済タスクの実装履歴は git history / docs / issue に寄せる

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -1,6 +1,6 @@
 amends "../pkspec/Spec.pkl"
 
-feature = "crater local gates"
+feature = "crater quality contract"
 
 goals {
   new Goal {
@@ -24,29 +24,69 @@ goals {
       "The browser surface is broad enough that prose-only backlog items drift unless the spec index is checked."
   }
   new Goal {
-    id = "goal.browser-compat"
-    name = "browser compatibility work has focused gates"
+    id = "goal.css-compat"
+    name = "CSS compatibility baselines are tracked per WPT module"
     priority = 75
     reviewStatus = "approved"
     description =
-      "DOM, locator, Playwright, and website scenarios have a named local gate distinct from VRT."
+      "Each WPT CSS module Crater opts into has a measured pass-rate baseline and an explicit set of follow-up gaps so layout work has a single coverage ledger."
     rationale =
-      "VRT is expensive and noisy; non-visual compatibility should stay independently runnable."
+      "CSS coverage is the largest UX surface. Without per-module baselines, regressions hide and new modules drift between issues and ad-hoc memos."
   }
   new Goal {
-    id = "goal.visual-regression"
-    name = "visual regressions are reproducible"
+    id = "goal.dom-compat"
+    name = "DOM and Shadow DOM surface is covered"
     priority = 70
     reviewStatus = "approved"
     description =
-      "Paint VRT, WPT VRT, and report-generation tasks are grouped so visual diffs can be regenerated and inspected consistently."
+      "DOM, Shadow DOM, custom elements, and Web Components observation paths are exercised by WPT DOM and component-focused scenarios."
     rationale =
-      "Crater's rendering work needs a repeatable path from changed code to sampled visual evidence."
+      "Preact, Playwright, and downstream consumers depend on a faithful DOM surface; gaps surface as silent shadow-aware bugs."
+  }
+  new Goal {
+    id = "goal.protocol-compat"
+    name = "WebDriver BiDi / Playwright / CDP surfaces match upstream contracts"
+    priority = 65
+    reviewStatus = "approved"
+    description =
+      "Crater's protocol adapters expose the BiDi, Playwright, and CDP commands needed for adapter parity and component-level inspection."
+    rationale =
+      "Protocol drift breaks downstream automation silently; pinning the supported surface in pkspec keeps the contract explicit."
+  }
+  new Goal {
+    id = "goal.paint-accuracy"
+    name = "rendering accuracy is measured and reproducible"
+    priority = 60
+    reviewStatus = "approved"
+    description =
+      "Paint VRT, WPT VRT, Luna component VRT, and report-generation tasks share fixtures, thresholds, and a regeneration path so visual diffs can be reproduced and inspected consistently."
+    rationale =
+      "Crater's rendering work needs a repeatable path from changed code to sampled visual evidence with named accuracy targets."
+  }
+  new Goal {
+    id = "goal.diagnostic-api"
+    name = "Crater exposes rendering diagnostics beyond pixel diffs"
+    priority = 55
+    reviewStatus = "draft"
+    description =
+      "BiDi / CLI surfaces expose paint-tree diffs, computed style queries, selector-scoped renders, and property mutation so VRT tools can detect changes pixels miss."
+    rationale =
+      "VRT benchmarks show pixel-only detection plateaus around 50%; structural diagnostics are Crater's differentiator and should be a tracked contract instead of ad-hoc API surface."
+  }
+  new Goal {
+    id = "goal.ci-efficiency"
+    name = "CI keeps fast feedback at the affected surface"
+    priority = 50
+    reviewStatus = "approved"
+    description =
+      "Affected gating, pkfire cache reuse, and parallelised VRT shards keep PR wall time bounded while schedule runs cover the full matrix."
+    rationale =
+      "Heavy WPT and VRT shards dominate wall time. Without explicit efficiency targets, slow CI silently displaces actual review work."
   }
   new Goal {
     id = "goal.release-safety"
     name = "workspace release order is inspectable"
-    priority = 60
+    priority = 40
     reviewStatus = "approved"
     description = "MoonBit publish order can be checked and printed before any publish operation."
     rationale =
@@ -55,6 +95,10 @@ goals {
 }
 
 scenarios {
+  // ---------------------------------------------------------------------------
+  // Existing approved scenarios — pkfire / pkspec wiring contracts.
+  // contributes blocks updated to reflect the new 9-goal taxonomy.
+  // ---------------------------------------------------------------------------
   new {
     id = "task.default"
     name = "pkfire exposes task inventory"
@@ -113,7 +157,7 @@ scenarios {
     tags { "spec"; "pkfire"; "benchmark" }
     severity = "major"
     reviewStatus = "approved"
-    contributes { "goal.local-gates" }
+    contributes { "goal.local-gates"; "goal.paint-accuracy" }
   }
   new {
     id = "task.affected"
@@ -124,7 +168,7 @@ scenarios {
     severity = "major"
     reviewStatus = "approved"
     dependsOn { "task.default"; "task.check"; "task.bench"; "vrt.report" }
-    contributes { "goal.local-gates" }
+    contributes { "goal.local-gates"; "goal.ci-efficiency" }
   }
   new {
     id = "task.diagnostics"
@@ -146,7 +190,7 @@ scenarios {
     severity = "major"
     reviewStatus = "approved"
     dependsOn { "task.affected"; "task.diagnostics" }
-    contributes { "goal.local-gates" }
+    contributes { "goal.local-gates"; "goal.ci-efficiency" }
   }
   new {
     id = "spec.check"
@@ -177,7 +221,7 @@ scenarios {
     tags { "spec"; "browser"; "playwright" }
     severity = "major"
     reviewStatus = "approved"
-    contributes { "goal.browser-compat" }
+    contributes { "goal.protocol-compat" }
   }
   new {
     id = "browser.preact"
@@ -188,7 +232,7 @@ scenarios {
     severity = "major"
     reviewStatus = "approved"
     dependsOn { "browser.playwright" }
-    contributes { "goal.browser-compat" }
+    contributes { "goal.dom-compat"; "goal.protocol-compat" }
   }
   new {
     id = "wpt.dom"
@@ -198,7 +242,7 @@ scenarios {
     tags { "spec"; "browser"; "wpt"; "dom"; "pkfire" }
     severity = "major"
     reviewStatus = "approved"
-    contributes { "goal.browser-compat" }
+    contributes { "goal.dom-compat" }
   }
   new {
     id = "wpt.webdriver-bidi"
@@ -208,7 +252,7 @@ scenarios {
     tags { "spec"; "browser"; "webdriver"; "bidi"; "pkfire" }
     severity = "major"
     reviewStatus = "approved"
-    contributes { "goal.browser-compat" }
+    contributes { "goal.protocol-compat" }
   }
   new {
     id = "wpt.css"
@@ -218,7 +262,7 @@ scenarios {
     tags { "spec"; "browser"; "wpt"; "css"; "pkfire" }
     severity = "major"
     reviewStatus = "approved"
-    contributes { "goal.browser-compat" }
+    contributes { "goal.css-compat" }
   }
   new {
     id = "wpt.suite"
@@ -229,7 +273,7 @@ scenarios {
     severity = "major"
     reviewStatus = "approved"
     dependsOn { "wpt.css"; "wpt.dom"; "wpt.webdriver-bidi" }
-    contributes { "goal.browser-compat" }
+    contributes { "goal.css-compat"; "goal.dom-compat"; "goal.protocol-compat" }
   }
   new {
     id = "vrt.report"
@@ -239,7 +283,7 @@ scenarios {
     tags { "spec"; "vrt"; "paint" }
     severity = "major"
     reviewStatus = "approved"
-    contributes { "goal.visual-regression" }
+    contributes { "goal.paint-accuracy" }
   }
   new {
     id = "release.publish-order"
@@ -259,7 +303,7 @@ scenarios {
     tags { "spec"; "wpt"; "dom" }
     severity = "major"
     reviewStatus = "draft"
-    contributes { "goal.browser-compat" }
+    contributes { "goal.dom-compat" }
     openQuestions { "Which WPT DOM subset is stable enough to require in every local check?" }
   }
   new {
@@ -270,9 +314,449 @@ scenarios {
     tags { "spec"; "studio"; "e2e" }
     severity = "major"
     reviewStatus = "draft"
-    contributes { "goal.browser-compat"; "goal.visual-regression" }
+    contributes { "goal.paint-accuracy"; "goal.protocol-compat" }
     openQuestions {
       "Which private Studio scenario can be represented by a public reusable contract?"
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // New scenarios (Phase 1 stubs) — all draft, no implementing test required.
+  // Each carries a backlink to the originating issue or TODO bucket.
+  // ---------------------------------------------------------------------------
+
+  // -- CSS compatibility: per-module baselines and follow-up bugs -------------
+  new {
+    id = "compat.css-text-baseline"
+    name = "css-text WPT module baseline is established"
+    description =
+      "Measure and pin a per-module pass-rate baseline for the css-text WPT module, then close gaps as separate scenarios. Source: TODO Now (P0)."
+    tags { "wpt"; "css"; "baseline"; "todo:now" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+    openQuestions {
+      "Which css-text subset is in scope before the first wpt-config rollout?"
+    }
+  }
+  new {
+    id = "compat.css-backgrounds-baseline"
+    name = "css-backgrounds WPT module baseline is established"
+    description =
+      "Measure and pin a per-module pass-rate baseline for the css-backgrounds WPT module. Source: TODO Now (P0)."
+    tags { "wpt"; "css"; "baseline"; "todo:now" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "compat.css-images-baseline"
+    name = "css-images WPT module baseline is enabled"
+    description =
+      "Promote css-images from manual baseline measurement (currently 93% pass) into wpt-config. See GitHub issue #65 for measurement scope and #68 for the gradient-with-border outlier."
+    tags { "wpt"; "css"; "baseline"; "issue:65"; "issue:68" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "compat.css-values-baseline"
+    name = "css-values WPT module baseline is enabled"
+    description =
+      "Promote css-values from manual baseline measurement into wpt-config. See GitHub issue #65 (measurement) and #67 (calc() through table column-width outlier)."
+    tags { "wpt"; "css"; "baseline"; "issue:65"; "issue:67" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "compat.css-inline-baseline"
+    name = "css-inline WPT module baseline is enabled"
+    description =
+      "Promote css-inline from manual baseline measurement into wpt-config. See GitHub issue #65 (measurement) and #66 (empty inline span height outlier)."
+    tags { "wpt"; "css"; "baseline"; "issue:65"; "issue:66" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "compat.css-filter-effects"
+    name = "filter-effects WPT pass rate is closed out"
+    description =
+      "Drive the filter-effects WPT module from 98/106 to full pass. Implementing filter as an abs-pos containing block clears the bulk of failures. See GitHub issue #64."
+    tags { "wpt"; "css"; "filter"; "issue:64"; "todo:now" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+
+  // -- Paint accuracy: text wrap, font weight, glyph metrics -----------------
+  new {
+    id = "paint.text-wrap-layout-parity"
+    name = "painter text wrap matches the layout engine"
+    description =
+      "Close the gap between the painter's word-level wrap and the layout engine's precise wrap so real-world VRT diffs reflect text correctly. Source: TODO Now (P0)."
+    tags { "paint"; "text"; "wrap"; "todo:now" }
+    severity = "critical"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy" }
+  }
+  new {
+    id = "paint.font-weight-numeric"
+    name = "numeric font-weight survives paint"
+    description =
+      "Preserve the resolved numeric font-weight (e.g. 500) through the painter instead of collapsing to is_bold. Required for Luna VRT parity on medium UI labels. See GitHub issue #48."
+    tags { "paint"; "font"; "issue:48"; "todo:now" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy" }
+  }
+  new {
+    id = "paint.text-glyph-metrics"
+    name = "glyph metrics and AA approach Chromium parity"
+    description =
+      "Reduce Luna VRT diffs dominated by glyph rasterization differences (slightly narrower / lighter than Chromium). See GitHub issue #47."
+    tags { "paint"; "font"; "vrt"; "issue:47" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy" }
+  }
+
+  // -- DOM compatibility: Web Components residuals ---------------------------
+  new {
+    id = "compat.web-components-shadow-selectors"
+    name = "Shadow DOM selector surface is complete"
+    description =
+      "Implement remaining shadow-aware selectors: :host compound selectors, ::slotted, :host-context. Source: TODO Next (P1) and browser/TODO.md."
+    tags { "dom"; "shadow"; "selectors"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.dom-compat" }
+  }
+  new {
+    id = "compat.web-components-element-internals"
+    name = "Web Components advanced surface is covered"
+    description =
+      "Close gaps in closed shadow root, declarative shadow DOM, customized built-in, form-associated custom elements, and ElementInternals. Source: TODO Next (P1)."
+    tags { "dom"; "shadow"; "custom-elements"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.dom-compat" }
+  }
+
+  // -- Protocol compatibility: Playwright shadow-aware ----------------------
+  new {
+    id = "protocol.playwright-shadow-aware"
+    name = "Playwright / CDP / jsbidi inspection is shadow-aware"
+    description =
+      "Align the query / action / inspection surface across Playwright, CDP, and jsbidi for shadow DOM. Source: TODO Next (P1)."
+    tags { "protocol"; "playwright"; "shadow"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.protocol-compat"; "goal.dom-compat" }
+  }
+
+  // -- Diagnostic APIs (vrt-harness CSS challenge driven) -------------------
+  new {
+    id = "diagnostic.paint-tree-diff"
+    name = "paint tree diff API is exposed"
+    description =
+      "Expose a structured paint-tree diff API so VRT tools can detect CSS changes that produce no pixel diff. See GitHub issue #23."
+    tags { "diagnostic"; "vrt"; "api"; "issue:23" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.diagnostic-api" }
+  }
+  new {
+    id = "diagnostic.css-property-mutation"
+    name = "CSS property mutation API is exposed"
+    description =
+      "Expose an API that renders a page with specific CSS properties toggled, returning the layout diff. Avoids re-parsing the entire stylesheet for mutation testing. See GitHub issue #24."
+    tags { "diagnostic"; "vrt"; "api"; "issue:24" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.diagnostic-api" }
+  }
+  new {
+    id = "diagnostic.selector-scoped-render"
+    name = "selector-scoped rendering API is exposed"
+    description =
+      "Expose an API to render only the subtree matched by a CSS selector for component-level VRT. See GitHub issue #25."
+    tags { "diagnostic"; "vrt"; "api"; "issue:25" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.diagnostic-api" }
+  }
+  new {
+    id = "protocol.bidi-computed-style"
+    name = "BiDi exposes computed CSS styles"
+    description =
+      "Add a BiDi command equivalent to getComputedStyle() so VRT tools can use computed-style diffs (single most impactful detection signal, +23% over pixel-only in the CSS challenge benchmark). See GitHub issue #26."
+    tags { "protocol"; "bidi"; "diagnostic"; "issue:26" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.diagnostic-api"; "goal.protocol-compat" }
+  }
+
+  // -- CI efficiency --------------------------------------------------------
+  new {
+    id = "ci.parallel-vrt-bottleneck"
+    name = "VRT shards stop dominating CI wall time"
+    description =
+      "Parallelise or shard the remaining VRT bottleneck jobs (playwright-paint-vrt, wpt-vrt display / flexbox / position) below the current ~20m ceiling. See GitHub issue #44."
+    tags { "ci"; "vrt"; "performance"; "issue:44" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.ci-efficiency" }
+  }
+  new {
+    id = "ci.flaker-effectiveness"
+    name = "flaker quarantine and fixtures stay effective"
+    description =
+      "Tighten flaker CI-time effectiveness: quarantine expiry, fixture coverage gaps, duckdb persistence. See GitHub issue #79."
+    tags { "ci"; "flaker"; "issue:79" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.ci-efficiency" }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Phase 2 stubs — remaining TODO buckets and issue-driven bugs reified as
+  // scenarios so TODO.md can collapse to a pkspec index. All draft.
+  // ---------------------------------------------------------------------------
+
+  // -- Additional CSS module baselines (TODO Now) ----------------------------
+  new {
+    id = "compat.css-color-baseline"
+    name = "css-color WPT module baseline is established"
+    description =
+      "Measure and pin a per-module pass-rate baseline for the css-color WPT module. Source: TODO Now (P0)."
+    tags { "wpt"; "css"; "baseline"; "todo:now" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "compat.css-transforms-baseline"
+    name = "css-transforms WPT module baseline is established"
+    description =
+      "Measure and pin a per-module pass-rate baseline for the css-transforms WPT module. Source: TODO Now (P0)."
+    tags { "wpt"; "css"; "baseline"; "todo:now" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "compat.css-pseudo-baseline"
+    name = "css-pseudo WPT module baseline is established"
+    description =
+      "Measure and pin a per-module pass-rate baseline for the css-pseudo WPT module (covers ::before / ::after content sizing residuals). Source: TODO Now (P0)."
+    tags { "wpt"; "css"; "baseline"; "todo:now" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "compat.css-writing-modes-baseline"
+    name = "css-writing-modes WPT module baseline is established"
+    description =
+      "Measure and pin a per-module pass-rate baseline for the css-writing-modes WPT module. Source: TODO Now (P0)."
+    tags { "wpt"; "css"; "baseline"; "todo:now" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "compat.css-ruby-baseline"
+    name = "css-ruby WPT module baseline is established"
+    description =
+      "Measure and pin a per-module pass-rate baseline for the css-ruby WPT module. Source: TODO Now (P0)."
+    tags { "wpt"; "css"; "baseline"; "todo:now" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+
+  // -- Browser shell controls (TODO Next) ------------------------------------
+  new {
+    id = "compat.browser-shell-form-controls"
+    name = "browser shell form control default actions match spec"
+    description =
+      "Close residuals in browser shell control default actions: select popup UI, blur-time change semantics, IME / selection / caret behaviour. Source: TODO Next (P1)."
+    tags { "dom"; "form-controls"; "ime"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.dom-compat" }
+  }
+  new {
+    id = "compat.native-form-control-appearance"
+    name = "native form control appearance is policied"
+    description =
+      "Decide per-control whether select / button native appearance is masked in VRT or implemented as a paint target, then pin the chosen path. Source: TODO Next (P1)."
+    tags { "paint"; "form-controls"; "vrt"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy"; "goal.dom-compat" }
+    openQuestions {
+      "Which native controls (select, button, input[type=...]) become paint targets versus VRT-masked?"
+    }
+  }
+
+  // -- Paint accuracy: fixtures and real-world snapshots (TODO Next) --------
+  new {
+    id = "paint.real-world-snapshots"
+    name = "built-in real-world snapshots cover 3-5 pages"
+    description =
+      "Add 3-5 built-in real-world page snapshots and wire them into CI comparison so paint regressions on representative pages are observable. Source: TODO Next (P1)."
+    tags { "paint"; "vrt"; "fixtures"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy" }
+  }
+  new {
+    id = "paint.github-residual-diff"
+    name = "GitHub real-URL VRT residuals are reduced"
+    description =
+      "Reduce GitHub real-URL VRT residuals that survive --mask-assets: sticky nav, card border, list marker. Source: TODO Next (P1)."
+    tags { "paint"; "vrt"; "github"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy" }
+  }
+  new {
+    id = "compat.css-background-gradient-vrt"
+    name = "CSS gradient VRT fixture coverage is expanded"
+    description =
+      "Expand VRT fixtures for CSS background gradient and repeating-gradient so painter accuracy is measurable. Source: TODO Next (P1)."
+    tags { "css"; "paint"; "vrt"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat"; "goal.paint-accuracy" }
+  }
+  new {
+    id = "paint.svg-logo-intrinsic"
+    name = "SVG logo intrinsic sizing has dedicated fixtures"
+    description =
+      "Separate SVG / logo intrinsic size and paint path from real-URL fixtures into dedicated reproducible fixtures. Source: TODO Next (P1)."
+    tags { "paint"; "svg"; "fixtures"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy" }
+  }
+  new {
+    id = "paint.browser-shell-fixture-expansion"
+    name = "browser shell fixtures grow toward real pages"
+    description =
+      "Expand browser shell fixtures toward real pages (article / dashboard / GitHub snapshot) with DOM mutation + repaint observation pinned. Source: TODO Next (P1)."
+    tags { "paint"; "vrt"; "browser-shell"; "todo:next" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy" }
+  }
+
+  // -- Layout / paint bugs (issue-driven) ------------------------------------
+  new {
+    id = "bug.flexbox-min-width-justify"
+    name = "flexbox min_width with justify-content centers correctly"
+    description =
+      "Fix justify-content: center being a no-op when min_width is used instead of width on flex containers. See GitHub issue #2."
+    tags { "css"; "flexbox"; "bug"; "issue:2" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "bug.inline-abspos-width-ahem"
+    name = "inline abspos text width matches Ahem"
+    description =
+      "Fix inline abspos text width estimation mismatch with Ahem font (position-absolute-in-inline-003/004). See GitHub issue #17."
+    tags { "css"; "inline"; "bug"; "issue:17" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
+    id = "bug.border-radius-paint"
+    name = "border-radius produces a pixel diff"
+    description =
+      "Removing border-radius should produce a pixel diff. Painter must render border-radius accurately for VRT detection. See GitHub issue #19."
+    tags { "paint"; "vrt"; "bug"; "issue:19" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy" }
+  }
+  new {
+    id = "bug.flexbox-align-items"
+    name = "align-items on flex containers is reflected"
+    description =
+      "Removing align-items: center from a flex container must produce a pixel diff. See GitHub issue #22."
+    tags { "css"; "flexbox"; "bug"; "issue:22" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat"; "goal.paint-accuracy" }
+  }
+
+  // -- Diagnostic / Tools (issue-driven) -------------------------------------
+  new {
+    id = "diagnostic.css-rule-usage-tracking"
+    name = "CSS rule usage tracking identifies dead rules"
+    description =
+      "Track which CSS rules are matched and applied during rendering, then report unused or overridden rules. See GitHub issue #27."
+    tags { "diagnostic"; "css"; "api"; "issue:27" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.diagnostic-api" }
+  }
+  new {
+    id = "diagnostic.vrt-prescanner-tracker"
+    name = "VRT prescanner benchmark is tracked"
+    description =
+      "Use mizchi/vrt-harness CSS challenge benchmark as a continuous accuracy + speedup tracker for Crater's rendering work. See GitHub issue #29."
+    tags { "diagnostic"; "vrt"; "benchmark"; "issue:29" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.diagnostic-api"; "goal.paint-accuracy" }
+  }
+  new {
+    id = "tui.raster-image-display"
+    name = "TUI raster image display works for JPEG / PNG / GIF"
+    description =
+      "Make TUI raster image display robust for JPEG / PNG / GIF via kitty graphics or sixel fallback. SVG already works. See GitHub issue #16."
+    tags { "tui"; "paint"; "image"; "issue:16" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.paint-accuracy" }
+  }
+
+  // -- CI efficiency residuals -----------------------------------------------
+  new {
+    id = "ci.dead-module-detection"
+    name = "dead-module detection has documented methodology"
+    description =
+      "Document the dead-module sweep methodology and act on remaining cleanup candidates surfaced during pre-release boundary tightening. See GitHub issue #60."
+    tags { "ci"; "workspace"; "boundary"; "issue:60" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.ci-efficiency" }
+  }
+  new {
+    id = "ci.affected-required-check"
+    name = "affected pkfire gate is promoted or pinned"
+    description =
+      "Decide whether the affected pkfire job becomes a required check on PRs based on observed CI behaviour, and document fallback semantics for missing merge-base or push event.before. Source: TODO Backlog."
+    tags { "ci"; "pkfire"; "affected"; "todo:backlog" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.ci-efficiency" }
+  }
+  new {
+    id = "ci.flaker-vrt-harness-contract"
+    name = "vrt-harness consumer payload is wired to crater"
+    description =
+      "Wire the vrt-harness consumer payload to crater's stable identity contract (taskId + spec + filter + variant + optional shard), keeping VRT decision in crater and identity / summary in the shared contract. Upstream: mizchi/flaker#8."
+    tags { "ci"; "flaker"; "vrt-harness"; "todo:backlog" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.ci-efficiency"; "goal.paint-accuracy" }
   }
 }


### PR DESCRIPTION
## Summary

- Split `goal.browser-compat` into `goal.css-compat` / `goal.dom-compat` / `goal.protocol-compat`, and add `goal.diagnostic-api` and `goal.ci-efficiency`. The 9-goal taxonomy maps work onto explicit quality axes instead of a single \"compat\" bucket.
- Reify 44 draft scenarios in \`specs/crater.pkl\` covering every open issue and every Now/Next/Backlog TODO bucket. Each carries an issue or TODO backlink so coverage is traceable from a single source.
- Collapse \`TODO.md\` to a pkspec scenario index plus the operational and external backlog. Goal coverage is now visible via \`pkspec spec --goals specs/crater.pkl specs/tasks.Test.pkl\`.

Closes #65 (meta tracking issue — decomposed into per-module sub-issues #66/#67/#68 and the corresponding \`compat.css-*-baseline\` scenarios).

## Test plan

- [x] \`pkf run spec-check\` — passes (18 approved scenarios with implementations)
- [x] \`pkf run spec-lint\` — clean
- [x] \`pkspec spec --goals\` renders the new 9-goal taxonomy with per-goal coverage percentages

🤖 Generated with [Claude Code](https://claude.com/claude-code)