### PR TITLE
Carry numeric font-weight through paint to JS face selection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,6 @@ pkf run spec-check                                          # contract が壊れ
 | `compat.css-inline-baseline` | css-inline WPT baseline 有効化 | #65, #66 |
 | `compat.css-filter-effects` | filter-effects 残 failure 潰し | #64 |
 | `paint.text-wrap-layout-parity` | painter / layout の text wrap 一致 | — |
-| `paint.font-weight-numeric` | numeric font-weight 保持 | #48 |
 | `paint.text-glyph-metrics` | glyph metrics / AA Chromium parity | #47 |
 
 ## Next (P1) — pkspec scenarios

--- a/painter/paint/glyph/provider_wbtest.mbt
+++ b/painter/paint/glyph/provider_wbtest.mbt
@@ -1,0 +1,102 @@
+///|
+/// Whitebox tests pinning the numeric font_weight contract on GlyphProvider.
+/// Implements: paint.font-weight-numeric (GitHub issue #48).
+
+///|
+fn recording_provider_by_weight(
+  recorded : Ref[Double],
+) -> GlyphProvider {
+  {
+    get_glyph: fn(_codepoint, _font_size, _is_bold) {
+      (([] : Array[@svg.PathCommand]), 4.0)
+    },
+    get_kern: fn(_left, _right, _font_size, _is_bold) { 0.0 },
+    get_glyph_by_weight: Some(fn(_codepoint, _font_size, font_weight) {
+      recorded.val = font_weight
+      (([] : Array[@svg.PathCommand]), 4.0)
+    }),
+    get_kern_by_weight: None,
+    ascent_ratio: 0.8,
+    get_glyph_for_family: None,
+    get_kern_for_family: None,
+    get_glyph_for_family_by_weight: None,
+    get_kern_for_family_by_weight: None,
+    get_ascent_for_family: None,
+  }
+}
+
+///|
+test "glyph_from_provider forwards numeric font_weight 500 without collapsing" {
+  let recorded : Ref[Double] = { val: 0.0 }
+  let provider = recording_provider_by_weight(recorded)
+  let _ = glyph_from_provider(provider, 'A'.to_int(), 16.0, false, "", 500.0)
+  inspect(recorded.val, content="500")
+}
+
+///|
+test "glyph_from_provider forwards numeric font_weight 600 without collapsing" {
+  let recorded : Ref[Double] = { val: 0.0 }
+  let provider = recording_provider_by_weight(recorded)
+  let _ = glyph_from_provider(provider, 'A'.to_int(), 16.0, false, "", 600.0)
+  inspect(recorded.val, content="600")
+}
+
+///|
+test "glyph_from_provider forwards numeric font_weight 400 distinctly from 700" {
+  let recorded400 : Ref[Double] = { val: 0.0 }
+  let _ = glyph_from_provider(
+    recording_provider_by_weight(recorded400),
+    'A'.to_int(),
+    16.0,
+    false,
+    "",
+    400.0,
+  )
+  let recorded700 : Ref[Double] = { val: 0.0 }
+  let _ = glyph_from_provider(
+    recording_provider_by_weight(recorded700),
+    'A'.to_int(),
+    16.0,
+    false,
+    "",
+    700.0,
+  )
+  inspect(recorded400.val, content="400")
+  inspect(recorded700.val, content="700")
+  inspect(recorded400.val != recorded700.val, content="true")
+}
+
+///|
+fn legacy_bold_provider(
+  recorded_bold : Ref[Bool],
+) -> GlyphProvider {
+  {
+    get_glyph: fn(_codepoint, _font_size, is_bold) {
+      recorded_bold.val = is_bold
+      (([] : Array[@svg.PathCommand]), 4.0)
+    },
+    get_kern: fn(_left, _right, _font_size, _is_bold) { 0.0 },
+    get_glyph_by_weight: None,
+    get_kern_by_weight: None,
+    ascent_ratio: 0.8,
+    get_glyph_for_family: None,
+    get_kern_for_family: None,
+    get_glyph_for_family_by_weight: None,
+    get_kern_for_family_by_weight: None,
+    get_ascent_for_family: None,
+  }
+}
+
+///|
+test "legacy bool-only providers still receive is_bold when no by_weight slot" {
+  let recorded : Ref[Bool] = { val: false }
+  let _ = glyph_from_provider(
+    legacy_bold_provider(recorded),
+    'A'.to_int(),
+    16.0,
+    true,
+    "",
+    700.0,
+  )
+  inspect(recorded.val, content="true")
+}

--- a/scripts/font-weight-resolve.test.ts
+++ b/scripts/font-weight-resolve.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { pickNearestFontWeight } from "./font-weight-resolve";
+
+describe("pickNearestFontWeight (CSS Fonts L4 §5.2)", () => {
+  test("returns null when no weights are available", () => {
+    expect(pickNearestFontWeight([], 500)).toBeNull();
+  });
+
+  test("requested 500 with only 400 and 700 falls to 400 per CSS L4 §5.2 (lighter before heavier)", () => {
+    expect(pickNearestFontWeight([400, 700], 500)).toBe(400);
+  });
+
+  test("requested 500 picks 500 exactly when available", () => {
+    expect(pickNearestFontWeight([400, 500, 700], 500)).toBe(500);
+  });
+
+  test("requested 500 picks 500 when only regular/medium loaded", () => {
+    expect(pickNearestFontWeight([400, 500], 500)).toBe(500);
+  });
+
+  test("requested 400 picks 500 in 400..500 ascending before falling lower or higher", () => {
+    expect(pickNearestFontWeight([300, 500, 700], 400)).toBe(500);
+  });
+
+  test("requested 400 with only lighter weights picks the heaviest below requested", () => {
+    expect(pickNearestFontWeight([100, 200, 300], 400)).toBe(300);
+  });
+
+  test("requested 400 with only weights above 500 picks the lightest above", () => {
+    expect(pickNearestFontWeight([600, 700, 900], 400)).toBe(600);
+  });
+
+  test("requested 300 picks the heaviest weight at or below requested", () => {
+    expect(pickNearestFontWeight([100, 300, 400, 700], 300)).toBe(300);
+  });
+
+  test("requested 300 with only heavier weights picks the lightest above", () => {
+    expect(pickNearestFontWeight([400, 500, 700], 300)).toBe(400);
+  });
+
+  test("requested 700 picks the lightest weight at or above requested", () => {
+    expect(pickNearestFontWeight([400, 500, 700, 900], 700)).toBe(700);
+  });
+
+  test("requested 700 with only lighter weights picks the heaviest below", () => {
+    expect(pickNearestFontWeight([300, 400, 500], 700)).toBe(500);
+  });
+
+  test("requested 900 picks 900 when present, else heaviest below", () => {
+    expect(pickNearestFontWeight([400, 700, 900], 900)).toBe(900);
+    expect(pickNearestFontWeight([400, 700], 900)).toBe(700);
+  });
+
+  test("requested 600 (bold-ish) picks 700 over 500", () => {
+    expect(pickNearestFontWeight([400, 500, 700], 600)).toBe(700);
+  });
+
+  test("requested 500 with only 400 falls to 400 (no medium, no heavier)", () => {
+    expect(pickNearestFontWeight([400], 500)).toBe(400);
+  });
+
+  test("duplicate weights are deduplicated before selection", () => {
+    expect(pickNearestFontWeight([400, 400, 700, 700], 500)).toBe(400);
+  });
+});

--- a/scripts/font-weight-resolve.ts
+++ b/scripts/font-weight-resolve.ts
@@ -1,0 +1,46 @@
+/**
+ * Implements the CSS Fonts Level 4 §5.2 font weight matching algorithm.
+ *
+ * Given the set of weights actually loaded for a family, pick the one nearest
+ * to the requested weight using the spec's tie-breaking rules.
+ *
+ * Used by start-with-font.ts to route numeric font-weight (e.g. 500) to the
+ * loaded face that best matches, instead of collapsing to a regular/bold bool.
+ *
+ * Implements: paint.font-weight-numeric (GitHub issue #48).
+ */
+
+export function pickNearestFontWeight(
+  available: readonly number[],
+  requested: number,
+): number | null {
+  if (available.length === 0) return null;
+
+  const sorted = [...new Set(available)].sort((a, b) => a - b);
+
+  if (requested >= 400 && requested <= 500) {
+    const inRangeAscending = sorted.filter(
+      (w) => w >= requested && w <= 500,
+    );
+    if (inRangeAscending.length > 0) return inRangeAscending[0];
+    const belowRequested = sorted.filter((w) => w < requested);
+    if (belowRequested.length > 0) return belowRequested[belowRequested.length - 1];
+    const above500 = sorted.filter((w) => w > 500);
+    if (above500.length > 0) return above500[0];
+    return null;
+  }
+
+  if (requested < 400) {
+    const atOrBelow = sorted.filter((w) => w <= requested);
+    if (atOrBelow.length > 0) return atOrBelow[atOrBelow.length - 1];
+    const above = sorted.filter((w) => w > requested);
+    if (above.length > 0) return above[0];
+    return null;
+  }
+
+  const atOrAbove = sorted.filter((w) => w >= requested);
+  if (atOrAbove.length > 0) return atOrAbove[0];
+  const below = sorted.filter((w) => w < requested);
+  if (below.length > 0) return below[below.length - 1];
+  return null;
+}

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -405,10 +405,10 @@ scenarios {
     id = "paint.font-weight-numeric"
     name = "numeric font-weight survives paint"
     description =
-      "Preserve the resolved numeric font-weight (e.g. 500) through the painter instead of collapsing to is_bold. Required for Luna VRT parity on medium UI labels. See GitHub issue #48."
+      "Preserve the resolved numeric font-weight (e.g. 500) through the painter instead of collapsing to is_bold. The MoonBit glyph provider keeps a by_weight slot, the JS FFI bridge passes the numeric weight (not a boolean), the JS side installs __craterGlyph*ByWeight hooks, and per-family face selection uses the CSS Fonts L4 §5.2 nearest-weight algorithm. Layer A: contract end-to-end. Layer B (separate PR): load medium / semibold faces so Luna VRT visibly improves. See GitHub issue #48."
     tags { "paint"; "font"; "issue:48"; "todo:now" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.paint-accuracy" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -266,6 +266,16 @@ tests {
     }
   }
   new {
+    name = "paint_preserves_numeric_font_weight"
+    description =
+      "The paint contract preserves numeric font-weight end-to-end. The MoonBit glyph provider has a by_weight slot, the JS FFI bridge passes the numeric weight (not a boolean) into JS, the JS side installs __craterGlyph*ByWeight hooks, and the per-family lookup uses the CSS Fonts L4 §5.2 nearest-weight resolver."
+    tags { "paint"; "font"; "issue:48" }
+    specRef { "paint.font-weight-numeric" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"glyph_from_provider forwards numeric font_weight 500\" painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"js_glyph_outline_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"resolve_js_glyph_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"__craterGlyphOutlineCommandsByWeight\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"pickNearestFontWeight\" scripts/font-weight-resolve.ts'"
+  }
+  new {
     name = "ci_wires_pkfire_affected_with_cache"
     description =
       "The GitHub Actions CI should restore pkfire/Pkl caches and execute affected core gates against the resolved base."

--- a/webdriver/bidi_main/start-with-font.ts
+++ b/webdriver/bidi_main/start-with-font.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_TEXT_FONT_FAMILY,
   resolveEffectiveFontFamily,
 } from "../../scripts/font-family-defaults.ts";
+import { pickNearestFontWeight } from "../../scripts/font-weight-resolve.ts";
 import {
   listBundledWptFonts,
   resolveBundledWptFontUrl,
@@ -244,6 +245,39 @@ function getFontInstance(fontFamily: string, isBold: boolean): FontInstance | nu
   return isBold && fallback.bold ? fallback.bold : fallback.regular || null;
 }
 
+function entryFacesByWeight(
+  entry: { regular?: FontInstance; bold?: FontInstance },
+): Map<number, FontInstance> {
+  const faces = new Map<number, FontInstance>();
+  if (entry.regular) faces.set(400, entry.regular);
+  if (entry.bold) faces.set(700, entry.bold);
+  return faces;
+}
+
+function getFontInstanceByWeight(
+  fontFamily: string,
+  weight: number,
+): FontInstance | null {
+  const families = resolveEffectiveFontFamily(fontFamily)
+    .split(",")
+    .map((f) => f.trim().replace(/['"]/g, "").toLowerCase());
+  for (const f of families) {
+    const norm = ALIASES[f] || f;
+    const entry = fontCache.get(norm);
+    if (!entry) continue;
+    const faces = entryFacesByWeight(entry);
+    if (faces.size === 0) continue;
+    const picked = pickNearestFontWeight([...faces.keys()], weight);
+    if (picked !== null) return faces.get(picked) ?? null;
+  }
+  const fallback = fontCache.get("arial") || fontCache.values().next().value;
+  if (!fallback) return null;
+  const faces = entryFacesByWeight(fallback);
+  if (faces.size === 0) return null;
+  const picked = pickNearestFontWeight([...faces.keys()], weight);
+  return picked !== null ? faces.get(picked) ?? null : null;
+}
+
 // ============================================================
 // Install global providers
 // ============================================================
@@ -368,6 +402,89 @@ if (!defaultFont) {
   (globalThis as any).__craterAscentForFamily = (ff: string) => {
     const font = getFontInstance(ff, false);
     return font ? font.ascentRatio : 0.8;
+  };
+
+  // Numeric-weight-aware providers. Crater's paint pipeline preserves the
+  // resolved numeric font-weight; these hooks route it through the CSS Fonts
+  // L4 §5.2 nearest-weight algorithm so adding a medium / semibold face later
+  // is a font-loading change, not a code change. See GitHub issue #48.
+  (globalThis as any).__craterGlyphOutlineCommandsByWeight = (
+    cp: number,
+    fs: number,
+    weight: number,
+  ) => {
+    const font = getFontInstanceByWeight(DEFAULT_TEXT_FONT_FAMILY, weight);
+    if (!font || !font.glyphOutlineCommands) return "";
+    return font.glyphOutlineCommands(cp, fs);
+  };
+  (globalThis as any).__craterGlyphToSvgPathByWeight = (
+    cp: number,
+    fs: number,
+    weight: number,
+  ) => {
+    const font = getFontInstanceByWeight(DEFAULT_TEXT_FONT_FAMILY, weight);
+    if (!font || !font.glyphToSvgPath) return "";
+    return font.glyphToSvgPath(cp, fs);
+  };
+  (globalThis as any).__craterGlyphAdvanceByWeight = (
+    cp: number,
+    fs: number,
+    weight: number,
+  ) => {
+    const font = getFontInstanceByWeight(DEFAULT_TEXT_FONT_FAMILY, weight);
+    if (!font || !font.glyphAdvance) return fs * 0.5;
+    return font.glyphAdvance(cp, fs);
+  };
+  (globalThis as any).__craterKernAdvanceByWeight = (
+    cp1: number,
+    cp2: number,
+    fs: number,
+    weight: number,
+  ) => {
+    const font = getFontInstanceByWeight(DEFAULT_TEXT_FONT_FAMILY, weight);
+    if (!font || !font.kernAdvance) return 0;
+    return font.kernAdvance(cp1, cp2, fs);
+  };
+  (globalThis as any).__craterOutlineCommandsForFamilyByWeight = (
+    cp: number,
+    fs: number,
+    weight: number,
+    ff: string,
+  ) => {
+    const font = getFontInstanceByWeight(ff, weight);
+    if (!font || !font.glyphOutlineCommands) return "";
+    return font.glyphOutlineCommands(cp, fs);
+  };
+  (globalThis as any).__craterGlyphForFamilyByWeight = (
+    cp: number,
+    fs: number,
+    weight: number,
+    ff: string,
+  ) => {
+    const font = getFontInstanceByWeight(ff, weight);
+    if (!font || !font.glyphToSvgPath) return "";
+    return font.glyphToSvgPath(cp, fs);
+  };
+  (globalThis as any).__craterAdvanceForFamilyByWeight = (
+    cp: number,
+    fs: number,
+    weight: number,
+    ff: string,
+  ) => {
+    const font = getFontInstanceByWeight(ff, weight);
+    if (!font || !font.glyphAdvance) return fs * 0.5;
+    return font.glyphAdvance(cp, fs);
+  };
+  (globalThis as any).__craterKernForFamilyByWeight = (
+    cp1: number,
+    cp2: number,
+    fs: number,
+    weight: number,
+    ff: string,
+  ) => {
+    const font = getFontInstanceByWeight(ff, weight);
+    if (!font || !font.kernAdvance) return 0;
+    return font.kernAdvance(cp1, cp2, fs);
   };
 }
 

--- a/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
+++ b/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
@@ -216,6 +216,147 @@ extern "js" fn js_ascent_for_family(font_family : String) -> Double =
   #|}
 
 ///|
+/// Numeric-weight-aware glyph outline JSON. Falls back to the boolean-bold
+/// dispatch when no by-weight hook is installed, so legacy JS providers keep
+/// working.
+extern "js" fn js_glyph_outline_commands_by_weight(
+  codepoint : Int,
+  font_size : Double,
+  font_weight : Double,
+) -> String =
+  #|(cp, fs, weight) => {
+  #|  const byWeight = globalThis.__craterGlyphOutlineCommandsByWeight;
+  #|  if (typeof byWeight === "function") {
+  #|    try { return String(byWeight(cp, fs, weight) || ""); } catch { return ""; }
+  #|  }
+  #|  const bold = weight >= 600;
+  #|  const fn = bold ? (globalThis.__craterGlyphOutlineCommandsBold || globalThis.__craterGlyphOutlineCommands) : globalThis.__craterGlyphOutlineCommands;
+  #|  if (typeof fn !== "function") return "";
+  #|  try { return String(fn(cp, fs) || ""); } catch { return ""; }
+  #|}
+
+///|
+extern "js" fn js_glyph_to_svg_path_by_weight(
+  codepoint : Int,
+  font_size : Double,
+  font_weight : Double,
+) -> String =
+  #|(cp, fs, weight) => {
+  #|  const byWeight = globalThis.__craterGlyphToSvgPathByWeight;
+  #|  if (typeof byWeight === "function") {
+  #|    try { return String(byWeight(cp, fs, weight) || ""); } catch { return ""; }
+  #|  }
+  #|  const bold = weight >= 600;
+  #|  const fn = bold ? (globalThis.__craterGlyphToSvgPathBold || globalThis.__craterGlyphToSvgPath) : globalThis.__craterGlyphToSvgPath;
+  #|  if (typeof fn !== "function") return "";
+  #|  try { return String(fn(cp, fs) || ""); } catch { return ""; }
+  #|}
+
+///|
+extern "js" fn js_glyph_advance_by_weight(
+  codepoint : Int,
+  font_size : Double,
+  font_weight : Double,
+) -> Double =
+  #|(cp, fs, weight) => {
+  #|  const byWeight = globalThis.__craterGlyphAdvanceByWeight;
+  #|  if (typeof byWeight === "function") {
+  #|    try { const v = Number(byWeight(cp, fs, weight)); return Number.isFinite(v) ? v : fs * 0.5; } catch { return fs * 0.5; }
+  #|  }
+  #|  const bold = weight >= 600;
+  #|  const fn = bold ? (globalThis.__craterGlyphAdvanceBold || globalThis.__craterGlyphAdvance) : globalThis.__craterGlyphAdvance;
+  #|  if (typeof fn !== "function") return fs * 0.5;
+  #|  try { const v = Number(fn(cp, fs)); return Number.isFinite(v) ? v : fs * 0.5; } catch { return fs * 0.5; }
+  #|}
+
+///|
+extern "js" fn js_kern_advance_by_weight(
+  cp1 : Int,
+  cp2 : Int,
+  font_size : Double,
+  font_weight : Double,
+) -> Double =
+  #|(cp1, cp2, fs, weight) => {
+  #|  const byWeight = globalThis.__craterKernAdvanceByWeight;
+  #|  if (typeof byWeight === "function") {
+  #|    try { const v = Number(byWeight(cp1, cp2, fs, weight)); return Number.isFinite(v) ? v : 0; } catch { return 0; }
+  #|  }
+  #|  const bold = weight >= 600;
+  #|  const fn = bold ? (globalThis.__craterKernAdvanceBold || globalThis.__craterKernAdvance) : globalThis.__craterKernAdvance;
+  #|  if (typeof fn !== "function") return 0;
+  #|  try { const v = Number(fn(cp1, cp2, fs)); return Number.isFinite(v) ? v : 0; } catch { return 0; }
+  #|}
+
+///|
+extern "js" fn js_outline_commands_for_family_by_weight(
+  codepoint : Int,
+  font_size : Double,
+  font_weight : Double,
+  font_family : String,
+) -> String =
+  #|(cp, fs, weight, ff) => {
+  #|  const byWeight = globalThis.__craterOutlineCommandsForFamilyByWeight;
+  #|  if (typeof byWeight === "function") {
+  #|    try { return String(byWeight(cp, fs, weight, ff) || ""); } catch { return ""; }
+  #|  }
+  #|  const fn = globalThis.__craterOutlineCommandsForFamily;
+  #|  if (typeof fn !== "function") return "";
+  #|  try { return String(fn(cp, fs, weight >= 600, ff) || ""); } catch { return ""; }
+  #|}
+
+///|
+extern "js" fn js_glyph_for_family_by_weight(
+  codepoint : Int,
+  font_size : Double,
+  font_weight : Double,
+  font_family : String,
+) -> String =
+  #|(cp, fs, weight, ff) => {
+  #|  const byWeight = globalThis.__craterGlyphForFamilyByWeight;
+  #|  if (typeof byWeight === "function") {
+  #|    try { return String(byWeight(cp, fs, weight, ff) || ""); } catch { return ""; }
+  #|  }
+  #|  const fn = globalThis.__craterGlyphForFamily;
+  #|  if (typeof fn !== "function") return "";
+  #|  try { return String(fn(cp, fs, weight >= 600, ff) || ""); } catch { return ""; }
+  #|}
+
+///|
+extern "js" fn js_advance_for_family_by_weight(
+  codepoint : Int,
+  font_size : Double,
+  font_weight : Double,
+  font_family : String,
+) -> Double =
+  #|(cp, fs, weight, ff) => {
+  #|  const byWeight = globalThis.__craterAdvanceForFamilyByWeight;
+  #|  if (typeof byWeight === "function") {
+  #|    try { const v = Number(byWeight(cp, fs, weight, ff)); return Number.isFinite(v) ? v : fs * 0.5; } catch { return fs * 0.5; }
+  #|  }
+  #|  const fn = globalThis.__craterAdvanceForFamily;
+  #|  if (typeof fn !== "function") return fs * 0.5;
+  #|  try { const v = Number(fn(cp, fs, weight >= 600, ff)); return Number.isFinite(v) ? v : fs * 0.5; } catch { return fs * 0.5; }
+  #|}
+
+///|
+extern "js" fn js_kern_for_family_by_weight(
+  cp1 : Int,
+  cp2 : Int,
+  font_size : Double,
+  font_weight : Double,
+  font_family : String,
+) -> Double =
+  #|(cp1, cp2, fs, weight, ff) => {
+  #|  const byWeight = globalThis.__craterKernForFamilyByWeight;
+  #|  if (typeof byWeight === "function") {
+  #|    try { const v = Number(byWeight(cp1, cp2, fs, weight, ff)); return Number.isFinite(v) ? v : 0; } catch { return 0; }
+  #|  }
+  #|  const fn = globalThis.__craterKernForFamily;
+  #|  if (typeof fn !== "function") return 0;
+  #|  try { const v = Number(fn(cp1, cp2, fs, weight >= 600, ff)); return Number.isFinite(v) ? v : 0; } catch { return 0; }
+  #|}
+
+///|
 extern "js" fn has_bold_text_provider() -> Bool =
   #|() => typeof globalThis.__craterMeasureTextIntrinsicBold === "function"
 
@@ -364,13 +505,12 @@ fn ensure_paint_provider_initialized() -> Unit {
         )
       },
       get_glyph_by_weight: Some(fn(codepoint, font_size, font_weight) {
-        let is_bold = font_weight >= 600.0
-        resolve_js_glyph_commands(
-          use_outline_commands, codepoint, font_size, is_bold,
+        resolve_js_glyph_commands_by_weight(
+          use_outline_commands, codepoint, font_size, font_weight,
         )
       }),
       get_kern_by_weight: Some(fn(cp1, cp2, font_size, font_weight) {
-        js_kern_advance(cp1, cp2, font_size, font_weight >= 600.0)
+        js_kern_advance_by_weight(cp1, cp2, font_size, font_weight)
       }),
       get_glyph_for_family: Some(fn(
         codepoint,
@@ -391,9 +531,8 @@ fn ensure_paint_provider_initialized() -> Unit {
         font_weight,
         font_family,
       ) {
-        let is_bold = font_weight >= 600.0
-        resolve_js_family_glyph_commands(
-          use_outline_commands, codepoint, font_size, is_bold, font_family,
+        resolve_js_family_glyph_commands_by_weight(
+          use_outline_commands, codepoint, font_size, font_weight, font_family,
         )
       }),
       get_kern_for_family_by_weight: Some(fn(
@@ -403,11 +542,11 @@ fn ensure_paint_provider_initialized() -> Unit {
         font_weight,
         font_family,
       ) {
-        js_kern_for_family(
+        js_kern_for_family_by_weight(
           cp1,
           cp2,
           font_size,
-          font_weight >= 600.0,
+          font_weight,
           font_family,
         )
       }),
@@ -441,6 +580,67 @@ fn resolve_js_glyph_commands(
     }
     let commands = @svg.parse_path(svg_path)
     (commands, advance)
+  }
+}
+
+///|
+fn resolve_js_glyph_commands_by_weight(
+  use_outline_commands : Bool,
+  codepoint : Int,
+  font_size : Double,
+  font_weight : Double,
+) -> (Array[@svg.PathCommand], Double) {
+  let advance = js_glyph_advance_by_weight(codepoint, font_size, font_weight)
+  if use_outline_commands {
+    let json = js_glyph_outline_commands_by_weight(
+      codepoint, font_size, font_weight,
+    )
+    if json.length() == 0 || json == "[]" {
+      return ([], advance)
+    }
+    let commands = @rendering.parse_glyph_outline_commands_json(json)
+    (commands, advance)
+  } else {
+    let svg_path = js_glyph_to_svg_path_by_weight(
+      codepoint, font_size, font_weight,
+    )
+    if svg_path.length() == 0 {
+      return ([], advance)
+    }
+    let commands = @svg.parse_path(svg_path)
+    (commands, advance)
+  }
+}
+
+///|
+fn resolve_js_family_glyph_commands_by_weight(
+  use_outline_commands : Bool,
+  codepoint : Int,
+  font_size : Double,
+  font_weight : Double,
+  font_family : String,
+) -> (Array[@svg.PathCommand], Double)? {
+  let advance = js_advance_for_family_by_weight(
+    codepoint, font_size, font_weight, font_family,
+  )
+  if use_outline_commands {
+    let json = js_outline_commands_for_family_by_weight(
+      codepoint, font_size, font_weight, font_family,
+    )
+    if json.length() == 0 || json == "[]" {
+      return None
+    }
+    let commands = @rendering.parse_glyph_outline_commands_json(json)
+    Some((commands, advance))
+  } else {
+    let svg_path = js_glyph_for_family_by_weight(
+      codepoint, font_size, font_weight, font_family,
+    )
+    if svg_path.length() == 0 {
+      return None
+    }
+    let commands = @svg.parse_path(svg_path)
+    Some((commands, advance))
   }
 }
 


### PR DESCRIPTION
## Summary

Layer A of GitHub issue #48. Wires the resolved numeric `font-weight` end-to-end through the paint pipeline so the JS side can route faces with the CSS Fonts Level 4 §5.2 nearest-weight algorithm instead of collapsing every weight to a boolean before the FFI call.

- `painter/paint/glyph`: whitebox tests pin `get_glyph_by_weight` is called with the raw weight (400 / 500 / 600 / 700) and legacy bool-only providers still receive `is_bold`.
- `webdriver/webdriver/bidi_browsing_context_actual_paint.mbt`: new `js_*_by_weight` FFI bindings that prefer `__craterGlyph*ByWeight` JS hooks when installed and fall back to the existing `weight >= 600` collapse otherwise. The `get_*_by_weight` slots on `GlyphProvider` now route through them.
- `webdriver/bidi_main/start-with-font.ts`: installs `__craterGlyph*ByWeight` hooks backed by `pickNearestFontWeight` (`scripts/font-weight-resolve.ts`), so adding a medium / semibold face later is a font-loading change, not a code change.
- `specs/crater.pkl` + `specs/tasks.Test.pkl`: `paint.font-weight-numeric` flips from `draft` to `approved` with a binding pkspec smoke test.

Layer B (separate PR) will load medium / semibold faces so Luna VRT diffs on `font-weight: 500` labels visibly shrink. Until then this PR is behaviour-preserving for fonts with only regular / bold variants and keeps semantic `<b>` / `<strong>` intact.

Closes part of #48 (Layer A; Layer B remains open until medium faces are loaded).

## Test plan

- [x] `moon test -p mizchi/crater-painter/paint/glyph --target js` (5 / 5)
- [x] `npx vitest run scripts/font-weight-resolve.test.ts` (15 / 15)
- [x] `pkf run spec-check`
- [x] `pkf run spec-test` (19 / 19 incl. new `paint_preserves_numeric_font_weight`)
- [x] `pkf run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)