### PR TITLE
Load declared medium / semibold faces in BiDi font loader

### DIFF
--- a/scripts/font-weight-resolve.test.ts
+++ b/scripts/font-weight-resolve.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { pickNearestFontWeight } from "./font-weight-resolve";
+import {
+  declaredWeightsForEntry,
+  type FontFileMapEntry,
+  pickNearestFontWeight,
+  selectWeightCandidates,
+} from "./font-weight-resolve";
 
 describe("pickNearestFontWeight (CSS Fonts L4 §5.2)", () => {
   test("returns null when no weights are available", () => {
@@ -61,5 +66,70 @@ describe("pickNearestFontWeight (CSS Fonts L4 §5.2)", () => {
 
   test("duplicate weights are deduplicated before selection", () => {
     expect(pickNearestFontWeight([400, 400, 700, 700], 500)).toBe(400);
+  });
+});
+
+describe("selectWeightCandidates / declaredWeightsForEntry", () => {
+  const sansLikeEntry: FontFileMapEntry = {
+    regular: ["NotoSans-Regular.ttf"],
+    bold: ["NotoSans-Bold.ttf"],
+    byWeight: {
+      300: ["NotoSans-Light.ttf"],
+      500: ["NotoSans-Medium.ttf"],
+      600: ["NotoSans-SemiBold.ttf"],
+    },
+  };
+
+  const minimalEntry: FontFileMapEntry = {
+    regular: ["Arial.ttf"],
+    bold: ["Arial Bold.ttf"],
+  };
+
+  test("selectWeightCandidates returns regular slot for 400 even without byWeight key", () => {
+    expect(selectWeightCandidates(sansLikeEntry, 400)).toEqual(["NotoSans-Regular.ttf"]);
+    expect(selectWeightCandidates(minimalEntry, 400)).toEqual(["Arial.ttf"]);
+  });
+
+  test("selectWeightCandidates returns bold slot for 700 even without byWeight key", () => {
+    expect(selectWeightCandidates(sansLikeEntry, 700)).toEqual(["NotoSans-Bold.ttf"]);
+    expect(selectWeightCandidates(minimalEntry, 700)).toEqual(["Arial Bold.ttf"]);
+  });
+
+  test("selectWeightCandidates returns byWeight slot for declared non-default weights", () => {
+    expect(selectWeightCandidates(sansLikeEntry, 500)).toEqual(["NotoSans-Medium.ttf"]);
+    expect(selectWeightCandidates(sansLikeEntry, 600)).toEqual(["NotoSans-SemiBold.ttf"]);
+    expect(selectWeightCandidates(sansLikeEntry, 300)).toEqual(["NotoSans-Light.ttf"]);
+  });
+
+  test("selectWeightCandidates returns [] for undeclared weights", () => {
+    expect(selectWeightCandidates(sansLikeEntry, 100)).toEqual([]);
+    expect(selectWeightCandidates(minimalEntry, 500)).toEqual([]);
+    expect(selectWeightCandidates(minimalEntry, 900)).toEqual([]);
+  });
+
+  test("declaredWeightsForEntry includes regular and bold implicitly", () => {
+    expect(declaredWeightsForEntry(minimalEntry)).toEqual([400, 700]);
+  });
+
+  test("declaredWeightsForEntry merges byWeight with implicit 400 / 700", () => {
+    expect(declaredWeightsForEntry(sansLikeEntry)).toEqual([300, 400, 500, 600, 700]);
+  });
+
+  test("declaredWeightsForEntry skips empty regular / bold slots", () => {
+    const onlyByWeight: FontFileMapEntry = {
+      regular: [],
+      bold: [],
+      byWeight: { 500: ["Foo-Medium.ttf"] },
+    };
+    expect(declaredWeightsForEntry(onlyByWeight)).toEqual([500]);
+  });
+
+  test("declaredWeightsForEntry ignores byWeight slots that have no candidates", () => {
+    const sparse: FontFileMapEntry = {
+      regular: ["a.ttf"],
+      bold: ["b.ttf"],
+      byWeight: { 500: [], 600: ["x.ttf"] },
+    };
+    expect(declaredWeightsForEntry(sparse)).toEqual([400, 600, 700]);
   });
 });

--- a/scripts/font-weight-resolve.ts
+++ b/scripts/font-weight-resolve.ts
@@ -1,14 +1,54 @@
 /**
- * Implements the CSS Fonts Level 4 §5.2 font weight matching algorithm.
- *
- * Given the set of weights actually loaded for a family, pick the one nearest
- * to the requested weight using the spec's tie-breaking rules.
+ * Implements the CSS Fonts Level 4 §5.2 font weight matching algorithm
+ * plus the pure FONT_FILE_MAP helpers that surface declared weight slots
+ * before any filesystem lookup.
  *
  * Used by start-with-font.ts to route numeric font-weight (e.g. 500) to the
  * loaded face that best matches, instead of collapsing to a regular/bold bool.
  *
- * Implements: paint.font-weight-numeric (GitHub issue #48).
+ * Implements: paint.font-weight-numeric (GitHub issue #48), Layer B.
  */
+
+export interface FontFileMapEntry {
+  regular: string[];
+  bold: string[];
+  byWeight?: Record<number, string[]>;
+}
+
+/**
+ * Returns the candidate file names for a given CSS weight from a FONT_FILE_MAP
+ * entry. Weights 400 and 700 fall back to the regular / bold slots so the
+ * declared byWeight map can omit them. Returns an empty array when no
+ * candidates are declared.
+ */
+export function selectWeightCandidates(
+  entry: FontFileMapEntry,
+  weight: number,
+): readonly string[] {
+  if (weight === 400) return entry.regular;
+  if (weight === 700) return entry.bold;
+  return entry.byWeight?.[weight] ?? [];
+}
+
+/**
+ * Returns the set of weights a FONT_FILE_MAP entry declares candidates for,
+ * including the implicit 400 / 700 slots when the regular / bold lists are
+ * non-empty. Sorted ascending.
+ */
+export function declaredWeightsForEntry(entry: FontFileMapEntry): number[] {
+  const weights = new Set<number>();
+  if (entry.regular.length > 0) weights.add(400);
+  if (entry.bold.length > 0) weights.add(700);
+  if (entry.byWeight) {
+    for (const key of Object.keys(entry.byWeight)) {
+      const n = Number(key);
+      if (Number.isFinite(n) && (entry.byWeight[n] ?? []).length > 0) {
+        weights.add(n);
+      }
+    }
+  }
+  return [...weights].sort((a, b) => a - b);
+}
 
 export function pickNearestFontWeight(
   available: readonly number[],

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -405,7 +405,7 @@ scenarios {
     id = "paint.font-weight-numeric"
     name = "numeric font-weight survives paint"
     description =
-      "Preserve the resolved numeric font-weight (e.g. 500) through the painter instead of collapsing to is_bold. The MoonBit glyph provider keeps a by_weight slot, the JS FFI bridge passes the numeric weight (not a boolean), the JS side installs __craterGlyph*ByWeight hooks, and per-family face selection uses the CSS Fonts L4 §5.2 nearest-weight algorithm. Layer A: contract end-to-end. Layer B (separate PR): load medium / semibold faces so Luna VRT visibly improves. See GitHub issue #48."
+      "Preserve the resolved numeric font-weight (e.g. 500) through the painter instead of collapsing to is_bold. Layer A: contract end-to-end - the MoonBit glyph provider keeps a by_weight slot, the JS FFI bridge passes the numeric weight (not a boolean), the JS side installs __craterGlyph*ByWeight hooks, and per-family face selection uses the CSS Fonts L4 §5.2 nearest-weight algorithm. Layer B: the BiDi font loader populates FontEntry.byWeight from declared medium / semibold / light candidates in FONT_FILE_MAP, so installing fonts-noto-core or similar lets sans-serif font-weight: 500 render with NotoSans-Medium instead of falling back to regular. See GitHub issue #48."
     tags { "paint"; "font"; "issue:48"; "todo:now" }
     severity = "major"
     reviewStatus = "approved"

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -273,7 +273,7 @@ tests {
     specRef { "paint.font-weight-numeric" }
     workdir = ".."
     cmd =
-      "bash -lc 'set -e; test -f painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"glyph_from_provider forwards numeric font_weight 500\" painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"js_glyph_outline_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"resolve_js_glyph_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"__craterGlyphOutlineCommandsByWeight\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"pickNearestFontWeight\" scripts/font-weight-resolve.ts'"
+      "bash -lc 'set -e; test -f painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"glyph_from_provider forwards numeric font_weight 500\" painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"js_glyph_outline_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"resolve_js_glyph_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"__craterGlyphOutlineCommandsByWeight\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"pickNearestFontWeight\" scripts/font-weight-resolve.ts; grep -Fq -- \"selectWeightCandidates\" scripts/font-weight-resolve.ts; grep -Fq -- \"declaredWeightsForEntry\" scripts/font-weight-resolve.ts; grep -Fq -- \"byWeight: Map<number, FontInstance>\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"loadDeclaredExtraWeights\" webdriver/bidi_main/start-with-font.ts'"
   }
   new {
     name = "ci_wires_pkfire_affected_with_cache"

--- a/webdriver/bidi_main/start-with-font.ts
+++ b/webdriver/bidi_main/start-with-font.ts
@@ -11,7 +11,11 @@ import {
   DEFAULT_TEXT_FONT_FAMILY,
   resolveEffectiveFontFamily,
 } from "../../scripts/font-family-defaults.ts";
-import { pickNearestFontWeight } from "../../scripts/font-weight-resolve.ts";
+import {
+  declaredWeightsForEntry,
+  pickNearestFontWeight,
+  selectWeightCandidates,
+} from "../../scripts/font-weight-resolve.ts";
 import {
   listBundledWptFonts,
   resolveBundledWptFontUrl,
@@ -39,7 +43,18 @@ const LINUX_FONT_DIRS = [
 ];
 const FONT_DIRS = Deno.build.os === "darwin" ? MAC_FONT_DIRS : LINUX_FONT_DIRS;
 
-const FONT_FILE_MAP: Record<string, { regular: string[]; bold: string[] }> = {
+type FontFileMapEntry = {
+  regular: string[];
+  bold: string[];
+  // Optional non-400 / non-700 weight candidates. Looked up by
+  // getFontInstanceByWeight via FontEntry.byWeight when a request for e.g.
+  // font-weight: 500 lands. Empty / missing on systems where no Medium /
+  // SemiBold / Light variant is installed; the CSS Fonts L4 nearest-weight
+  // resolver picks regular or bold in that case.
+  byWeight?: Record<number, string[]>;
+};
+
+const FONT_FILE_MAP: Record<string, FontFileMapEntry> = {
   arial: {
     regular: ["Arial.ttf", "LiberationSans-Regular.ttf", "DejaVuSans.ttf"],
     bold: ["Arial Bold.ttf", "Arial_Bold.ttf", "arialbd.ttf", "LiberationSans-Bold.ttf", "DejaVuSans-Bold.ttf"],
@@ -61,8 +76,33 @@ const FONT_FILE_MAP: Record<string, { regular: string[]; bold: string[] }> = {
     bold: ["Courier New Bold.ttf", "Courier_New_Bold.ttf", "courbd.ttf", "LiberationMono-Bold.ttf", "DejaVuSansMono-Bold.ttf"],
   },
   "sans-serif": {
-    regular: ["Arial.ttf", "LiberationSans-Regular.ttf", "DejaVuSans.ttf", "FreeSans.ttf"],
-    bold: ["Arial Bold.ttf", "LiberationSans-Bold.ttf", "DejaVuSans-Bold.ttf", "FreeSansBold.ttf"],
+    regular: ["Arial.ttf", "LiberationSans-Regular.ttf", "DejaVuSans.ttf", "FreeSans.ttf", "NotoSans-Regular.ttf", "Roboto-Regular.ttf"],
+    bold: ["Arial Bold.ttf", "LiberationSans-Bold.ttf", "DejaVuSans-Bold.ttf", "FreeSansBold.ttf", "NotoSans-Bold.ttf", "Roboto-Bold.ttf"],
+    byWeight: {
+      300: ["NotoSans-Light.ttf", "Roboto-Light.ttf"],
+      500: ["NotoSans-Medium.ttf", "Roboto-Medium.ttf"],
+      600: ["NotoSans-SemiBold.ttf", "Roboto-SemiBold.ttf"],
+    },
+  },
+  roboto: {
+    regular: ["Roboto-Regular.ttf", "Arial.ttf", "LiberationSans-Regular.ttf"],
+    bold: ["Roboto-Bold.ttf", "Arial Bold.ttf", "LiberationSans-Bold.ttf"],
+    byWeight: {
+      300: ["Roboto-Light.ttf"],
+      500: ["Roboto-Medium.ttf"],
+      600: ["Roboto-SemiBold.ttf"],
+      900: ["Roboto-Black.ttf"],
+    },
+  },
+  "noto sans": {
+    regular: ["NotoSans-Regular.ttf", "Arial.ttf", "LiberationSans-Regular.ttf"],
+    bold: ["NotoSans-Bold.ttf", "Arial Bold.ttf", "LiberationSans-Bold.ttf"],
+    byWeight: {
+      300: ["NotoSans-Light.ttf"],
+      500: ["NotoSans-Medium.ttf"],
+      600: ["NotoSans-SemiBold.ttf"],
+      900: ["NotoSans-Black.ttf"],
+    },
   },
 };
 const ALIASES: Record<string, string> = {
@@ -115,6 +155,20 @@ function resolveFont(family: string, weight: "regular" | "bold"): string | null 
   return null;
 }
 
+function resolveFontByDeclaredWeight(
+  family: string,
+  weight: number,
+): string | null {
+  const norm = ALIASES[family] || family;
+  const map = FONT_FILE_MAP[norm];
+  if (!map) return null;
+  for (const fileName of selectWeightCandidates(map, weight)) {
+    const found = findFont(fileName);
+    if (found) return found;
+  }
+  return null;
+}
+
 // ============================================================
 // Font module loading with multi-font support
 // ============================================================
@@ -127,8 +181,17 @@ interface FontInstance {
   ascentRatio: number;
 }
 
-// Cache of loaded font instances: family -> { regular, bold }
-const fontCache = new Map<string, { regular?: FontInstance; bold?: FontInstance }>();
+// Cache of loaded font instances. `byWeight` always contains 400 (= regular)
+// and 700 (= bold) when those are loaded, plus any extras declared in
+// FONT_FILE_MAP.byWeight that resolved to a file on disk. The dedicated
+// `regular` / `bold` slots stay populated for backward compatibility with the
+// boolean-isBold dispatch path.
+interface FontEntry {
+  regular?: FontInstance;
+  bold?: FontInstance;
+  byWeight: Map<number, FontInstance>;
+}
+const fontCache = new Map<string, FontEntry>();
 
 function fontPathLabel(fontPath: string | URL): string {
   return fontPath instanceof URL ? fontPath.pathname : fontPath;
@@ -172,8 +235,38 @@ async function loadFontInstance(fontPath: string | URL): Promise<FontInstance | 
   }
 }
 
-// Pre-load common fonts
-const PRELOAD_FAMILIES = ["arial", "verdana", "georgia", "times new roman", "courier new"];
+// Pre-load common fonts. "sans-serif" is its own entry so any installed
+// Noto / Roboto Medium / SemiBold files declared in FONT_FILE_MAP.sans-serif
+// reach FontEntry.byWeight without being shadowed by the arial alias below.
+const PRELOAD_FAMILIES = [
+  "arial",
+  "verdana",
+  "georgia",
+  "times new roman",
+  "courier new",
+  "sans-serif",
+  "roboto",
+  "noto sans",
+];
+
+async function loadDeclaredExtraWeights(
+  family: string,
+): Promise<Map<number, FontInstance>> {
+  const extras = new Map<number, FontInstance>();
+  const norm = ALIASES[family] || family;
+  const map = FONT_FILE_MAP[norm];
+  if (!map) return extras;
+  for (const weight of declaredWeightsForEntry(map)) {
+    if (weight === 400 || weight === 700) continue;
+    const path = resolveFontByDeclaredWeight(norm, weight);
+    if (!path) continue;
+    const instance = await loadFontInstance(path);
+    if (!instance) continue;
+    extras.set(weight, instance);
+    console.error(`[font] ${family} weight ${weight}: ${path}`);
+  }
+  return extras;
+}
 
 async function preloadFonts() {
   for (const family of PRELOAD_FAMILIES) {
@@ -191,17 +284,33 @@ async function preloadFonts() {
       if (bold) console.error(`[font] ${family} bold: ${boldPath}`);
     }
 
-    fontCache.set(family, { regular: regular || undefined, bold: bold || undefined });
+    const byWeight = new Map<number, FontInstance>();
+    if (regular) byWeight.set(400, regular);
+    if (bold) byWeight.set(700, bold);
+    for (const [weight, instance] of await loadDeclaredExtraWeights(family)) {
+      byWeight.set(weight, instance);
+    }
+
+    fontCache.set(family, {
+      regular: regular || undefined,
+      bold: bold || undefined,
+      byWeight,
+    });
   }
-  // Set sans-serif = arial
-  if (fontCache.has("arial")) {
+  // Fallback aliases: only set when the alias target hasn't loaded its own
+  // entry. This preserves sans-serif's independent byWeight set when its own
+  // preload succeeded, but still gives "sans-serif" -> arial coverage if
+  // FONT_FILE_MAP["sans-serif"] failed to resolve.
+  if (!fontCache.has("sans-serif") && fontCache.has("arial")) {
     fontCache.set("sans-serif", fontCache.get("arial")!);
+  }
+  if (!fontCache.has("helvetica") && fontCache.has("arial")) {
     fontCache.set("helvetica", fontCache.get("arial")!);
   }
-  if (fontCache.has("times new roman")) {
+  if (!fontCache.has("serif") && fontCache.has("times new roman")) {
     fontCache.set("serif", fontCache.get("times new roman")!);
   }
-  if (fontCache.has("courier new")) {
+  if (!fontCache.has("monospace") && fontCache.has("courier new")) {
     fontCache.set("monospace", fontCache.get("courier new")!);
   }
 }
@@ -218,7 +327,9 @@ async function preloadBundledWptFonts() {
     const regular = await loadFontInstance(fontUrl);
     if (!regular) continue;
 
-    const entry = { regular };
+    const byWeight = new Map<number, FontInstance>();
+    byWeight.set(400, regular);
+    const entry: FontEntry = { regular, byWeight };
     fontCache.set(font.family, entry);
     for (const alias of font.aliases ?? []) {
       fontCache.set(alias.toLowerCase(), entry);
@@ -245,9 +356,11 @@ function getFontInstance(fontFamily: string, isBold: boolean): FontInstance | nu
   return isBold && fallback.bold ? fallback.bold : fallback.regular || null;
 }
 
-function entryFacesByWeight(
-  entry: { regular?: FontInstance; bold?: FontInstance },
-): Map<number, FontInstance> {
+function entryFacesByWeight(entry: FontEntry): Map<number, FontInstance> {
+  // entry.byWeight already includes 400 (regular) and 700 (bold) when those
+  // were loaded, plus any extras populated by loadDeclaredExtraWeights.
+  // Fall back to a minimal map for older entry shapes (defensive).
+  if (entry.byWeight && entry.byWeight.size > 0) return entry.byWeight;
   const faces = new Map<number, FontInstance>();
   if (entry.regular) faces.set(400, entry.regular);
   if (entry.bold) faces.set(700, entry.bold);


### PR DESCRIPTION
## Summary

Layer B of GitHub issue #48. Layer A (#118) wired numeric `font-weight` end-to-end through paint → JS, but the loader still only populated `regular` + `bold` per family, so weights 500 / 600 fell back to regular under the CSS Fonts L4 §5.2 resolver.

- `scripts/font-weight-resolve.ts`: expose `FontFileMapEntry`, `selectWeightCandidates(entry, weight)`, `declaredWeightsForEntry(entry)` as pure helpers (testable outside Deno).
- `webdriver/bidi_main/start-with-font.ts`:
  - `FONT_FILE_MAP` entries can carry an optional `byWeight: Record<number, string[]>`. `sans-serif`, `roboto`, `noto sans` declare NotoSans / Roboto Light / Medium / SemiBold / Black candidates.
  - `FontEntry` holds an explicit `byWeight: Map<number, FontInstance>` seeded with 400 / 700 plus any declared extras that resolved on disk.
  - `PRELOAD_FAMILIES` includes `sans-serif` / `roboto` / `noto sans` as their own entries; the fallback aliases (`sans-serif -> arial`, etc.) only fire when the alias target hasn't loaded its own entry, so an independently-loaded `sans-serif` keeps its medium / semibold faces.
- `specs/crater.pkl` + `specs/tasks.Test.pkl`: `paint.font-weight-numeric` description updated for Layer B, smoke test extended with `selectWeightCandidates` / `declaredWeightsForEntry` / `FontEntry.byWeight` / `loadDeclaredExtraWeights` grep pins.

The visible Luna VRT improvement requires the host to actually have one of the declared medium files installed. On a stock CI runner with only liberation + msttcorefonts that's still false today — behaviour for those hosts is unchanged. Installing `fonts-noto-core` (or similar) and exposing the resolved paths is a separate CI / packaging change, not part of this PR.

Closes the loader-side portion of #48 (Layer B). Issue stays open until CI fonts are installed.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run scripts/font-weight-resolve.test.ts` (23 / 23, incl. 8 new for the pure helpers)
- [x] `pkf run spec-test` (19 / 19, incl. extended `paint_preserves_numeric_font_weight`)
- [x] `pkf run check` (8 / 8)
- [x] `(cd webdriver && moon build --target js)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)