### PR TITLE
Install fonts-roboto and fonts-noto-core on CI VRT runners

### DIFF
--- a/scripts/ci-font-compat.test.ts
+++ b/scripts/ci-font-compat.test.ts
@@ -62,6 +62,17 @@ describe("CI compatible font setup", () => {
     expect(script).toContain("sudo apt-get install -y --reinstall --no-install-recommends ttf-mscorefonts-installer || true");
   });
 
+  test("font install script pulls in medium-weight faces for paint.font-weight-numeric Layer C", () => {
+    const script = readRepoFile("scripts/ci/install-compatible-fonts.sh");
+
+    expect(script).toContain("fonts-roboto");
+    expect(script).toContain("fonts-noto-core");
+    expect(script).toContain("medium_weight_files=(");
+    expect(script).toContain("Roboto-Medium.ttf");
+    expect(script).toContain("NotoSans-Medium.ttf");
+    expect(script).toContain("No medium-weight font found");
+  });
+
   test("font resolvers include msttcorefonts file variants", () => {
     const bidiSource = readRepoFile("webdriver/bidi_main/start-with-font.ts");
     const resolverSource = readRepoFile("scripts/system-font-resolver.ts");

--- a/scripts/ci/install-compatible-fonts.sh
+++ b/scripts/ci/install-compatible-fonts.sh
@@ -39,6 +39,8 @@ sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
   fontconfig \
   fonts-liberation2 \
+  fonts-roboto \
+  fonts-noto-core \
   cabextract \
   xfonts-utils
 
@@ -54,6 +56,18 @@ required_files=(
   "Georgia.ttf"
   "Times_New_Roman.ttf"
   "Courier_New.ttf"
+)
+
+# Medium / non-default weight files supplied by fonts-roboto and
+# fonts-noto-core. paint.font-weight-numeric (GitHub issue #48) needs at
+# least one of these on disk so FONT_FILE_MAP.byWeight in
+# webdriver/bidi_main/start-with-font.ts can populate FontEntry.byWeight
+# with a real medium face. Required at least one in the list, not all.
+medium_weight_files=(
+  "Roboto-Medium.ttf"
+  "Roboto-Light.ttf"
+  "NotoSans-Medium.ttf"
+  "NotoSans-SemiBold.ttf"
 )
 
 for attempt in 1 2 3; do
@@ -79,3 +93,16 @@ done
 for family in "Arial" "Verdana" "Georgia" "Times New Roman" "Courier New"; do
   echo "[font-ci] ${family} => $(fc-match -f '%{file}\n' "${family}" || true)"
 done
+
+# Verify at least one medium-weight face landed so paint.font-weight-numeric
+# Layer B has something to dispatch to.
+found_medium=0
+for file_name in "${medium_weight_files[@]}"; do
+  if has_font_file "${file_name}"; then
+    echo "[font-ci] medium-weight font available: ${file_name}"
+    found_medium=1
+  fi
+done
+if [ "${found_medium}" -eq 0 ]; then
+  echo "::warning title=No medium-weight font found::None of ${medium_weight_files[*]} are installed; font-weight: 500 will fall back to regular"
+fi

--- a/webdriver/bidi_main/start-with-font.ts
+++ b/webdriver/bidi_main/start-with-font.ts
@@ -120,22 +120,30 @@ const ALIASES: Record<string, string> = {
   "book antiqua": "georgia",
 };
 
+function findFontIn(root: string, fileName: string, depth: number): string | null {
+  try {
+    const direct = `${root}/${fileName}`;
+    Deno.statSync(direct);
+    return direct;
+  } catch {}
+  if (depth <= 0) return null;
+  try {
+    for (const entry of Deno.readDirSync(root)) {
+      if (!entry.isDirectory) continue;
+      const found = findFontIn(`${root}/${entry.name}`, fileName, depth - 1);
+      if (found) return found;
+    }
+  } catch {}
+  return null;
+}
+
 function findFont(fileName: string): string | null {
+  // depth = 4 catches packages like fonts-roboto-unhinted that nest files at
+  // <font_dir>/roboto/unhinted/RobotoTTF/Roboto-Medium.ttf — too deep for the
+  // original one-level scan.
   for (const dir of FONT_DIRS) {
-    try {
-      const p = `${dir}/${fileName}`;
-      Deno.statSync(p);
-      return p;
-    } catch {}
-    // One level deep
-    try {
-      for (const entry of Deno.readDirSync(dir)) {
-        if (entry.isDirectory) {
-          const p = `${dir}/${entry.name}/${fileName}`;
-          try { Deno.statSync(p); return p; } catch {}
-        }
-      }
-    } catch {}
+    const found = findFontIn(dir, fileName, 4);
+    if (found) return found;
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Layer C of GitHub issue #48. Layers A (#118) and B (#119) wired numeric `font-weight` through paint and gave the BiDi font loader a `byWeight` Map, but the GitHub Actions runners only had liberation + msttcorefonts on disk, so `FONT_FILE_MAP.byWeight` entries for `Roboto-Medium` / `NotoSans-Medium` never resolved and `font-weight: 500` still fell back to regular in the Luna VRT job.

- `scripts/ci/install-compatible-fonts.sh`: add `fonts-roboto` + `fonts-noto-core` to the apt install line. Both packages are small, don't go through the flaky msttcorefonts retry path, and provide `Roboto-{Light,Medium,Bold,Black}.ttf` and `NotoSans-{Regular,Medium,SemiBold,Bold,...}.ttf` files that the Layer B `FONT_FILE_MAP.byWeight` declarations expect.
- Post-install check verifies at least one declared medium-weight file landed and emits a `::warning` when none did, so a future package rename surfaces in the job log instead of silently regressing to Layer A behaviour.
- `scripts/ci-font-compat.test.ts`: pins the new install line, medium-weight file list, and the warning string.

After this lands, the next Luna VRT run should pick up `NotoSans-Medium` / `Roboto-Medium` for `font-weight: 500` labels and produce a smaller diff on the `switch` fixture. If the diff actually shrinks meaningfully, issue #48 can be closed.

## Test plan

- [x] `npx vitest run scripts/ci-font-compat.test.ts` (8 / 8)
- [x] `bash -n scripts/ci/install-compatible-fonts.sh`
- [x] `pkf run spec-test` (19 / 19)
- [ ] Observe Luna VRT diff change on this PR's CI run (the install script only runs in jobs that use `install-compatible-fonts.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)