### PR TITLE
Enable css-backgrounds WPT module and lock its baseline at 74/80

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,6 @@ pkf run spec-check                                          # contract が壊れ
 | scenario id | 概要 | link |
 |---|---|---|
 | `compat.css-text-baseline` | css-text WPT baseline | — |
-| `compat.css-backgrounds-baseline` | css-backgrounds WPT baseline | — |
 | `compat.css-transforms-baseline` | css-transforms WPT baseline | — |
 | `compat.css-pseudo-baseline` | css-pseudo WPT baseline | — |
 | `compat.css-writing-modes-baseline` | css-writing-modes WPT baseline | — |

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -343,10 +343,10 @@ scenarios {
     id = "compat.css-backgrounds-baseline"
     name = "css-backgrounds WPT module baseline is established"
     description =
-      "Measure and pin a per-module pass-rate baseline for the css-backgrounds WPT module. Source: TODO Now (P0)."
+      "Measure and pin a per-module pass-rate baseline for the css-backgrounds WPT module. css-backgrounds is enabled in wpt.json, the test count (80) and pass count (74) are pinned in tests/wpt-baselines/css-backgrounds.env, and scripts/test-wpt-module-baseline.sh fails CI when the count regresses. The 6 baseline failures are table-cell background-local positioning cases. Source: TODO Now (P0)."
     tags { "wpt"; "css"; "baseline"; "todo:now" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.css-compat" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -276,6 +276,16 @@ tests {
       "bash -lc 'set -e; test -f painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"glyph_from_provider forwards numeric font_weight 500\" painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"js_glyph_outline_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"resolve_js_glyph_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"__craterGlyphOutlineCommandsByWeight\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"pickNearestFontWeight\" scripts/font-weight-resolve.ts; grep -Fq -- \"selectWeightCandidates\" scripts/font-weight-resolve.ts; grep -Fq -- \"declaredWeightsForEntry\" scripts/font-weight-resolve.ts; grep -Fq -- \"byWeight: Map<number, FontInstance>\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"loadDeclaredExtraWeights\" webdriver/bidi_main/start-with-font.ts'"
   }
   new {
+    name = "wpt_css_backgrounds_baseline_is_pinned"
+    description =
+      "css-backgrounds is enabled in wpt.json and the per-module baseline file pins the expected pass / fail counts."
+    tags { "wpt"; "css"; "baseline" }
+    specRef { "compat.css-backgrounds-baseline" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"\\\"css-backgrounds\\\"\" wpt.json; test -f tests/wpt-baselines/css-backgrounds.env; grep -Fq -- \"MODULE=css-backgrounds\" tests/wpt-baselines/css-backgrounds.env; grep -Fq -- \"BASELINE_PASSED=74\" tests/wpt-baselines/css-backgrounds.env; grep -Fq -- \"BASELINE_FAILED=6\" tests/wpt-baselines/css-backgrounds.env'"
+  }
+  new {
     name = "wpt_css_color_baseline_is_pinned"
     description =
       "css-color is enabled in wpt.json, the per-module baseline file exists with the expected fields, and scripts/test-wpt-module-baseline.sh is wired to enforce no-regression on it."

--- a/tests/wpt-baselines/css-backgrounds.env
+++ b/tests/wpt-baselines/css-backgrounds.env
@@ -1,0 +1,6 @@
+MODULE=css-backgrounds
+BASELINE_TOTAL=80
+BASELINE_PASSED=74
+BASELINE_FAILED=6
+BASELINE_UPDATED_AT=2026-05-17T00:00:00Z
+NOTE="Layout-tree compare runner ignores most paint properties. The 6 baseline failures are table-cell background-local positioning cases that depend on collapsed border / cell layout details."

--- a/wpt.json
+++ b/wpt.json
@@ -20,11 +20,12 @@
     "css-multicol",
     "css-break",
 
-    // Paint-leaning module enabled as a per-module baseline anchor. The
+    // Paint-leaning modules enabled as per-module baseline anchors. The
     // layout-tree compare runner mostly ignores color / paint properties,
-    // so the pass rate measures layout robustness on the css-color suite.
-    // See pkspec compat.css-color-baseline.
-    "css-color"
+    // so the pass rate measures layout robustness on these suites.
+    // See pkspec compat.css-color-baseline and compat.css-backgrounds-baseline.
+    "css-color",
+    "css-backgrounds"
 
     // Later: meaningful, but deferred for now.
     // "css-ruby",           // JP-oriented value is high, but general UI/layout wins come first.
@@ -32,7 +33,6 @@
     // "css-pseudo",         // first-line / first-letter need a wider inline model pass.
     // "css-text",           // broad text shaping / wrapping surface; current text model is still approximate.
     // "css-transforms",     // current support is translate-only.
-    // "css-backgrounds",    // mostly paint-oriented for the current layout-tree runner.
   ],
   "recursiveModules": [
     "css-align",


### PR DESCRIPTION
## Summary

Same per-module baseline mechanism as #121 (css-color). The layout-tree compare runner mostly ignores paint properties, so the css-backgrounds suite mostly exercises layout robustness on background-positioned fixtures.

- `wpt.json`: uncomment `css-backgrounds` in `modules`.
- `tests/wpt-baselines/css-backgrounds.env`: pin `TOTAL=80`, `PASSED=74`, `FAILED=6`. The 6 failures are `table-cell background-local` positioning cases that depend on collapsed-border / cell-layout details Crater doesn't match yet.
- `specs/crater.pkl`: flip `compat.css-backgrounds-baseline` to `approved`.
- `specs/tasks.Test.pkl`: pkspec smoke `wpt_css_backgrounds_baseline_is_pinned` asserts the module is enabled and the baseline file pins the expected counts.

Remaining deferred P0 modules: `css-text`, `css-transforms`, `css-pseudo`, `css-writing-modes`, `css-ruby` — likely all require implementation work to score meaningful baselines, unlike the two paint-leaning modules.

## Test plan

- [x] `npx tsx scripts/wpt-runner.ts css-backgrounds` → 74 / 80
- [x] `bash scripts/test-wpt-module-baseline.sh css-backgrounds` → baseline check passes
- [x] `pkf run spec-check` (21 / 21)
- [x] `pkf run spec-test` (21 / 21, incl. new `wpt_css_backgrounds_baseline_is_pinned`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)