### PR TITLE
Enable css-transforms WPT module and lock its baseline at 2/2

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,6 @@ pkf run spec-check                                          # contract が壊れ
 | scenario id | 概要 | link |
 |---|---|---|
 | `compat.css-text-baseline` | css-text WPT baseline | — |
-| `compat.css-transforms-baseline` | css-transforms WPT baseline | — |
 | `compat.css-pseudo-baseline` | css-pseudo WPT baseline | — |
 | `compat.css-writing-modes-baseline` | css-writing-modes WPT baseline | — |
 | `compat.css-ruby-baseline` | css-ruby WPT baseline | — |

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -540,10 +540,10 @@ scenarios {
     id = "compat.css-transforms-baseline"
     name = "css-transforms WPT module baseline is established"
     description =
-      "Measure and pin a per-module pass-rate baseline for the css-transforms WPT module. Source: TODO Now (P0)."
+      "Measure and pin a per-module pass-rate baseline for the css-transforms WPT module. css-transforms is enabled in wpt.json with the existing includePrefixes filter, the test count (2) and pass count (2) are pinned in tests/wpt-baselines/css-transforms.env, and scripts/test-wpt-module-baseline.sh enforces no regression. The filter currently exposes only the scrollable-* fixtures because Crater supports translate transforms but not the broader matrix / 3D suite; widening includePrefixes to cover more transform fixtures would be a follow-up after matrix / 3D support lands. Source: TODO Now (P0)."
     tags { "wpt"; "css"; "baseline"; "todo:now" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.css-compat" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -276,6 +276,16 @@ tests {
       "bash -lc 'set -e; test -f painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"glyph_from_provider forwards numeric font_weight 500\" painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"js_glyph_outline_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"resolve_js_glyph_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"__craterGlyphOutlineCommandsByWeight\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"pickNearestFontWeight\" scripts/font-weight-resolve.ts; grep -Fq -- \"selectWeightCandidates\" scripts/font-weight-resolve.ts; grep -Fq -- \"declaredWeightsForEntry\" scripts/font-weight-resolve.ts; grep -Fq -- \"byWeight: Map<number, FontInstance>\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"loadDeclaredExtraWeights\" webdriver/bidi_main/start-with-font.ts'"
   }
   new {
+    name = "wpt_css_transforms_baseline_is_pinned"
+    description =
+      "css-transforms is enabled in wpt.json and the per-module baseline file pins the expected pass / fail counts."
+    tags { "wpt"; "css"; "baseline" }
+    specRef { "compat.css-transforms-baseline" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"\\\"css-transforms\\\"\" wpt.json; test -f tests/wpt-baselines/css-transforms.env; grep -Fq -- \"MODULE=css-transforms\" tests/wpt-baselines/css-transforms.env; grep -Fq -- \"BASELINE_PASSED=2\" tests/wpt-baselines/css-transforms.env; grep -Fq -- \"BASELINE_FAILED=0\" tests/wpt-baselines/css-transforms.env'"
+  }
+  new {
     name = "wpt_css_backgrounds_baseline_is_pinned"
     description =
       "css-backgrounds is enabled in wpt.json and the per-module baseline file pins the expected pass / fail counts."

--- a/tests/wpt-baselines/css-transforms.env
+++ b/tests/wpt-baselines/css-transforms.env
@@ -1,0 +1,6 @@
+MODULE=css-transforms
+BASELINE_TOTAL=2
+BASELINE_PASSED=2
+BASELINE_FAILED=0
+BASELINE_UPDATED_AT=2026-05-17T00:00:00Z
+NOTE="The wpt.json includePrefixes filter restricts css-transforms to scrollable-* fixtures. Crater currently only supports translate; broader matrix / 3D transform support would unlock the rest of the suite (see scenario description)."

--- a/wpt.json
+++ b/wpt.json
@@ -23,16 +23,17 @@
     // Paint-leaning modules enabled as per-module baseline anchors. The
     // layout-tree compare runner mostly ignores color / paint properties,
     // so the pass rate measures layout robustness on these suites.
-    // See pkspec compat.css-color-baseline and compat.css-backgrounds-baseline.
+    // See pkspec compat.css-color-baseline, compat.css-backgrounds-baseline,
+    // and compat.css-transforms-baseline.
     "css-color",
-    "css-backgrounds"
+    "css-backgrounds",
+    "css-transforms"
 
     // Later: meaningful, but deferred for now.
     // "css-ruby",           // JP-oriented value is high, but general UI/layout wins come first.
     // "css-writing-modes",  // Broader orthogonal flow matrix after logical properties settle.
     // "css-pseudo",         // first-line / first-letter need a wider inline model pass.
     // "css-text",           // broad text shaping / wrapping surface; current text model is still approximate.
-    // "css-transforms",     // current support is translate-only.
   ],
   "recursiveModules": [
     "css-align",


### PR DESCRIPTION
## Summary

Third per-module baseline PR after #121 (css-color) and #122 (css-backgrounds). The `wpt.json` `includePrefixes` filter currently exposes only the `scrollable-*` fixtures because Crater supports translate transforms but not the broader matrix / 3D suite. Both `scrollable-3d-transform-z` tests pass against the layout-tree compare runner, so 2/2 is the honest baseline.

- `wpt.json`: uncomment `css-transforms` in `modules`.
- `tests/wpt-baselines/css-transforms.env`: pin `TOTAL=2`, `PASSED=2`, `FAILED=0`, with a note that widening `includePrefixes` is a follow-up after matrix / 3D support lands.
- `specs/crater.pkl`: flip `compat.css-transforms-baseline` to `approved`.
- `specs/tasks.Test.pkl`: pkspec smoke `wpt_css_transforms_baseline_is_pinned` asserts the wiring.

Remaining deferred P0 modules: `css-text`, `css-pseudo`, `css-writing-modes`, `css-ruby` — all require implementation work to score meaningful baselines.

## Test plan

- [x] `npx tsx scripts/wpt-runner.ts css-transforms` → 2 / 2
- [x] `bash scripts/test-wpt-module-baseline.sh css-transforms` → baseline check passes
- [x] `pkf run spec-check` (22 / 22)
- [x] `pkf run spec-test` (22 / 22, incl. new `wpt_css_transforms_baseline_is_pinned`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)