### PR TITLE
Enable css-writing-modes WPT module and lock its baseline at 17/27

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,6 @@ pkf run spec-check                                          # contract が壊れ
 |---|---|---|
 | `compat.css-text-baseline` | css-text WPT baseline | — |
 | `compat.css-pseudo-baseline` | css-pseudo WPT baseline | — |
-| `compat.css-writing-modes-baseline` | css-writing-modes WPT baseline | — |
 | `compat.css-ruby-baseline` | css-ruby WPT baseline | — |
 | `compat.css-images-baseline` | css-images WPT baseline 有効化 | #65, #68 |
 | `compat.css-values-baseline` | css-values WPT baseline 有効化 | #65, #67 |

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -560,10 +560,10 @@ scenarios {
     id = "compat.css-writing-modes-baseline"
     name = "css-writing-modes WPT module baseline is established"
     description =
-      "Measure and pin a per-module pass-rate baseline for the css-writing-modes WPT module. Source: TODO Now (P0)."
+      "Measure and pin a per-module pass-rate baseline for the css-writing-modes WPT module. css-writing-modes is enabled in wpt.json with the existing includePrefixes filter, the test count (27), pass count (17), and failure count (10) are pinned in tests/wpt-baselines/css-writing-modes.env, and scripts/test-wpt-module-baseline.sh enforces no regression. The 10 failures cluster on table-cell layout under vertical writing modes. Widening includePrefixes is a follow-up after logical-property support stabilises. Source: TODO Now (P0)."
     tags { "wpt"; "css"; "baseline"; "todo:now" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.css-compat" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -276,6 +276,16 @@ tests {
       "bash -lc 'set -e; test -f painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"glyph_from_provider forwards numeric font_weight 500\" painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"js_glyph_outline_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"resolve_js_glyph_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"__craterGlyphOutlineCommandsByWeight\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"pickNearestFontWeight\" scripts/font-weight-resolve.ts; grep -Fq -- \"selectWeightCandidates\" scripts/font-weight-resolve.ts; grep -Fq -- \"declaredWeightsForEntry\" scripts/font-weight-resolve.ts; grep -Fq -- \"byWeight: Map<number, FontInstance>\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"loadDeclaredExtraWeights\" webdriver/bidi_main/start-with-font.ts'"
   }
   new {
+    name = "wpt_css_writing_modes_baseline_is_pinned"
+    description =
+      "css-writing-modes is enabled in wpt.json and the per-module baseline file pins the expected pass / fail counts."
+    tags { "wpt"; "css"; "baseline" }
+    specRef { "compat.css-writing-modes-baseline" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"\\\"css-writing-modes\\\"\" wpt.json; test -f tests/wpt-baselines/css-writing-modes.env; grep -Fq -- \"MODULE=css-writing-modes\" tests/wpt-baselines/css-writing-modes.env; grep -Fq -- \"BASELINE_PASSED=17\" tests/wpt-baselines/css-writing-modes.env; grep -Fq -- \"BASELINE_FAILED=10\" tests/wpt-baselines/css-writing-modes.env'"
+  }
+  new {
     name = "wpt_css_transforms_baseline_is_pinned"
     description =
       "css-transforms is enabled in wpt.json and the per-module baseline file pins the expected pass / fail counts."

--- a/tests/wpt-baselines/css-writing-modes.env
+++ b/tests/wpt-baselines/css-writing-modes.env
@@ -1,0 +1,6 @@
+MODULE=css-writing-modes
+BASELINE_TOTAL=27
+BASELINE_PASSED=17
+BASELINE_FAILED=10
+BASELINE_UPDATED_AT=2026-05-17T00:00:00Z
+NOTE="The 10 baseline failures concentrate on table-cell layout under vertical writing modes. Logical-property support is still in flight; widening includePrefixes for more css-writing-modes fixtures is a follow-up once logical properties settle."

--- a/wpt.json
+++ b/wpt.json
@@ -27,13 +27,17 @@
     // and compat.css-transforms-baseline.
     "css-color",
     "css-backgrounds",
-    "css-transforms"
+    "css-transforms",
+
+    // Logical-flow module. The wpt.json includePrefixes filter exposes
+    // about 27 fixtures that the layout-tree compare runner can grade.
+    // See pkspec compat.css-writing-modes-baseline.
+    "css-writing-modes"
 
     // Later: meaningful, but deferred for now.
-    // "css-ruby",           // JP-oriented value is high, but general UI/layout wins come first.
-    // "css-writing-modes",  // Broader orthogonal flow matrix after logical properties settle.
+    // "css-ruby",           // No fixtures match includePrefixes; needs filter widening.
     // "css-pseudo",         // first-line / first-letter need a wider inline model pass.
-    // "css-text",           // broad text shaping / wrapping surface; current text model is still approximate.
+    // "css-text",           // No fixtures match includePrefixes; needs filter widening.
   ],
   "recursiveModules": [
     "css-align",


### PR DESCRIPTION
## Summary

Fourth per-module baseline PR after #121 (color), #122 (backgrounds), #123 (transforms). The `wpt.json` `includePrefixes` filter exposes 27 fixtures the layout-tree compare runner can grade; 17 pass, 10 fail.

- `wpt.json`: uncomment `css-writing-modes` in `modules`. Leave `css-text`, `css-pseudo`, and `css-ruby` on the deferred list: `css-text` and `css-ruby` filter to zero tests under current `includePrefixes`, `css-pseudo` needs the wider inline-model pass.
- `tests/wpt-baselines/css-writing-modes.env`: pin `TOTAL=27`, `PASSED=17`, `FAILED=10`. The 10 failures cluster on table-cell layout under vertical writing modes — logical-property support is still in flight.
- `specs/crater.pkl`: flip `compat.css-writing-modes-baseline` to `approved`.
- `specs/tasks.Test.pkl`: pkspec smoke `wpt_css_writing_modes_baseline_is_pinned` asserts the wiring.

Remaining deferred P0 modules: `css-text`, `css-pseudo`, `css-ruby` — each will need either a widened `includePrefixes` or a chunk of implementation work before they can score a meaningful baseline.

## Test plan

- [x] `npx tsx scripts/wpt-runner.ts css-writing-modes` → 17 / 27
- [x] `bash scripts/test-wpt-module-baseline.sh css-writing-modes` → baseline check passes
- [x] `pkf run spec-check` (23 / 23)
- [x] `pkf run spec-test` (23 / 23, incl. new `wpt_css_writing_modes_baseline_is_pinned`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)