### PR TITLE
Enable css-pseudo WPT module and lock its baseline at 1/1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,6 @@ pkf run spec-check                                          # contract が壊れ
 | scenario id | 概要 | link |
 |---|---|---|
 | `compat.css-text-baseline` | css-text WPT baseline | — |
-| `compat.css-pseudo-baseline` | css-pseudo WPT baseline | — |
 | `compat.css-ruby-baseline` | css-ruby WPT baseline | — |
 | `compat.css-images-baseline` | css-images WPT baseline 有効化 | #65, #68 |
 | `compat.css-values-baseline` | css-values WPT baseline 有効化 | #65, #67 |

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -550,10 +550,10 @@ scenarios {
     id = "compat.css-pseudo-baseline"
     name = "css-pseudo WPT module baseline is established"
     description =
-      "Measure and pin a per-module pass-rate baseline for the css-pseudo WPT module (covers ::before / ::after content sizing residuals). Source: TODO Now (P0)."
+      "Measure and pin a per-module pass-rate baseline for the css-pseudo WPT module. css-pseudo is enabled in wpt.json with the existing includePrefixes filter, the test count (1) and pass count (1) are pinned in tests/wpt-baselines/css-pseudo.env, and scripts/test-wpt-module-baseline.sh enforces no regression. Only relative-box-order-of-pseudo-elements matches the current filter; widening to cover ::first-line / ::first-letter is a follow-up after the broader inline-model pass lands. Source: TODO Now (P0)."
     tags { "wpt"; "css"; "baseline"; "todo:now" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.css-compat" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -276,6 +276,16 @@ tests {
       "bash -lc 'set -e; test -f painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"glyph_from_provider forwards numeric font_weight 500\" painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"js_glyph_outline_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"resolve_js_glyph_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"__craterGlyphOutlineCommandsByWeight\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"pickNearestFontWeight\" scripts/font-weight-resolve.ts; grep -Fq -- \"selectWeightCandidates\" scripts/font-weight-resolve.ts; grep -Fq -- \"declaredWeightsForEntry\" scripts/font-weight-resolve.ts; grep -Fq -- \"byWeight: Map<number, FontInstance>\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"loadDeclaredExtraWeights\" webdriver/bidi_main/start-with-font.ts'"
   }
   new {
+    name = "wpt_css_pseudo_baseline_is_pinned"
+    description =
+      "css-pseudo is enabled in wpt.json and the per-module baseline file pins the expected pass / fail counts."
+    tags { "wpt"; "css"; "baseline" }
+    specRef { "compat.css-pseudo-baseline" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"\\\"css-pseudo\\\"\" wpt.json; test -f tests/wpt-baselines/css-pseudo.env; grep -Fq -- \"MODULE=css-pseudo\" tests/wpt-baselines/css-pseudo.env; grep -Fq -- \"BASELINE_PASSED=1\" tests/wpt-baselines/css-pseudo.env; grep -Fq -- \"BASELINE_FAILED=0\" tests/wpt-baselines/css-pseudo.env'"
+  }
+  new {
     name = "wpt_css_writing_modes_baseline_is_pinned"
     description =
       "css-writing-modes is enabled in wpt.json and the per-module baseline file pins the expected pass / fail counts."

--- a/tests/wpt-baselines/css-pseudo.env
+++ b/tests/wpt-baselines/css-pseudo.env
@@ -1,0 +1,6 @@
+MODULE=css-pseudo
+BASELINE_TOTAL=1
+BASELINE_PASSED=1
+BASELINE_FAILED=0
+BASELINE_UPDATED_AT=2026-05-17T00:00:00Z
+NOTE="The wpt.json includePrefixes filter exposes only relative-box-order-of-pseudo-elements; widening to cover ::first-line / ::first-letter requires the broader inline-model pass mentioned in the scenario description."

--- a/wpt.json
+++ b/wpt.json
@@ -32,11 +32,15 @@
     // Logical-flow module. The wpt.json includePrefixes filter exposes
     // about 27 fixtures that the layout-tree compare runner can grade.
     // See pkspec compat.css-writing-modes-baseline.
-    "css-writing-modes"
+    "css-writing-modes",
+
+    // Pseudo-elements; only 1 fixture matches the current
+    // includePrefixes filter. Widening the filter requires the broader
+    // inline-model pass. See pkspec compat.css-pseudo-baseline.
+    "css-pseudo"
 
     // Later: meaningful, but deferred for now.
     // "css-ruby",           // No fixtures match includePrefixes; needs filter widening.
-    // "css-pseudo",         // first-line / first-letter need a wider inline model pass.
     // "css-text",           // No fixtures match includePrefixes; needs filter widening.
   ],
   "recursiveModules": [


### PR DESCRIPTION
## Summary

Fifth per-module baseline PR after #121-#124. Only `relative-box-order-of-pseudo-elements` matches the current `includePrefixes` filter; that single fixture passes against the layout-tree compare runner.

- `wpt.json`: uncomment `css-pseudo` in `modules`. Leave `css-text` and `css-ruby` on the deferred list — both still filter to zero fixtures under current `includePrefixes`.
- `tests/wpt-baselines/css-pseudo.env`: pin `TOTAL=1`, `PASSED=1`, `FAILED=0` with a note that widening to cover `::first-line` / `::first-letter` is a follow-up after the broader inline-model pass lands.
- `specs/crater.pkl`: flip `compat.css-pseudo-baseline` to `approved`.
- `specs/tasks.Test.pkl`: pkspec smoke `wpt_css_pseudo_baseline_is_pinned` asserts the wiring.

Remaining deferred P0 modules: `css-text`, `css-ruby` — each needs widened `includePrefixes` (or implementation work) before they can score a meaningful baseline.

## Test plan

- [x] `npx tsx scripts/wpt-runner.ts css-pseudo` → 1 / 1
- [x] `bash scripts/test-wpt-module-baseline.sh css-pseudo` → baseline check passes
- [x] `pkf run spec-check` (24 / 24)
- [x] `pkf run spec-test` (24 / 24, incl. new `wpt_css_pseudo_baseline_is_pinned`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)