### PR TITLE
Carve SVG intrinsic sizing fixtures out of real-URL captures

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,6 @@ pkf run spec-check                                          # contract が壊れ
 | `protocol.playwright-shadow-aware` | Playwright / CDP / jsbidi shadow-aware | — |
 | `paint.real-world-snapshots` | built-in real-world snapshot 3-5 ページ | — |
 | `paint.github-residual-diff` | GitHub VRT 残差 (sticky nav / card border / list marker) | — |
-| `paint.svg-logo-intrinsic` | SVG / logo intrinsic を実 URL fixture から分離 | — |
 | `paint.browser-shell-fixture-expansion` | browser shell fixture を実ページ寄りに | — |
 | `compat.css-background-gradient-vrt` | CSS gradient VRT fixture 拡張 | — |
 | `diagnostic.paint-tree-diff` | paint tree diff API | #23 |

--- a/flaker.star
+++ b/flaker.star
@@ -55,6 +55,22 @@ task(
 )
 
 task(
+  id="paint-vrt-svg-intrinsic",
+  node="layout",
+  cmd=["pnpm", "exec", "playwright", "test", "tests/paint-vrt-svg-intrinsic.test.ts"],
+  srcs=[
+    "layout/**",
+    "painter/**",
+    "renderer/**",
+    "css/**",
+    "dom/css/**",
+    "tests/helpers/**",
+  ],
+  needs=["paint-vrt"],
+  trigger="auto",
+)
+
+task(
   id="wpt-vrt",
   node="layout",
   cmd=["pnpm", "exec", "playwright", "test", "tests/wpt-vrt.test.ts"],

--- a/scripts/flaker-batch-plan-core.test.ts
+++ b/scripts/flaker-batch-plan-core.test.ts
@@ -22,6 +22,7 @@ describe("buildFlakerBatchPlan", () => {
       "paint-vrt",
       "paint-vrt-levels",
       "paint-vrt-responsive",
+      "paint-vrt-svg-intrinsic",
       "playwright-adapter",
       "playwright-adapter-chromium-parity",
       "playwright-adapter-user-scenarios",

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -637,10 +637,10 @@ scenarios {
     id = "paint.svg-logo-intrinsic"
     name = "SVG logo intrinsic sizing has dedicated fixtures"
     description =
-      "Separate SVG / logo intrinsic size and paint path from real-URL fixtures into dedicated reproducible fixtures. Source: TODO Next (P1)."
+      "Separate SVG / logo intrinsic size and paint path from real-URL fixtures into dedicated reproducible fixtures. tests/paint-vrt-svg-intrinsic.test.ts holds five focused cases (explicit width/height attrs, viewBox-only, flex container icon, inline-replaced baseline, percent width inside a sized parent) so regressions in SVG intrinsic sizing surface independently of the real-world page captures that previously exercised the same code paths incidentally. Source: TODO Next (P1)."
     tags { "paint"; "svg"; "fixtures"; "todo:next" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.paint-accuracy" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -276,6 +276,16 @@ tests {
       "bash -lc 'set -e; test -f painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"glyph_from_provider forwards numeric font_weight 500\" painter/paint/glyph/provider_wbtest.mbt; grep -Fq -- \"js_glyph_outline_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"resolve_js_glyph_commands_by_weight\" webdriver/webdriver/bidi_browsing_context_actual_paint.mbt; grep -Fq -- \"__craterGlyphOutlineCommandsByWeight\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"pickNearestFontWeight\" scripts/font-weight-resolve.ts; grep -Fq -- \"selectWeightCandidates\" scripts/font-weight-resolve.ts; grep -Fq -- \"declaredWeightsForEntry\" scripts/font-weight-resolve.ts; grep -Fq -- \"byWeight: Map<number, FontInstance>\" webdriver/bidi_main/start-with-font.ts; grep -Fq -- \"loadDeclaredExtraWeights\" webdriver/bidi_main/start-with-font.ts'"
   }
   new {
+    name = "paint_svg_intrinsic_has_dedicated_fixtures"
+    description =
+      "tests/paint-vrt-svg-intrinsic.test.ts exists and covers the five SVG intrinsic sizing patterns (explicit dims, viewBox-only, flex container, inline-replaced, percent parent) that previously only ran as part of real-URL captures."
+    tags { "paint"; "svg"; "fixtures" }
+    specRef { "paint.svg-logo-intrinsic" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f tests/paint-vrt-svg-intrinsic.test.ts; for p in \"svg with explicit width and height attributes\" \"svg with viewBox only takes intrinsic from viewBox\" \"svg inside flex container honors flex sizing\" \"inline svg as replaced text element preserves baseline\" \"svg sized by parent container with percent width\"; do grep -Fq -- \"$p\" tests/paint-vrt-svg-intrinsic.test.ts || { echo \"missing fixture case: $p\"; exit 1; }; done'"
+  }
+  new {
     name = "wpt_css_pseudo_baseline_is_pinned"
     description =
       "css-pseudo is enabled in wpt.json and the per-module baseline file pins the expected pass / fail counts."

--- a/tests/paint-vrt-svg-intrinsic.test.ts
+++ b/tests/paint-vrt-svg-intrinsic.test.ts
@@ -1,0 +1,230 @@
+import path from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+import { createVrtArtifactReportContext } from "../scripts/vrt-report-contract.ts";
+import {
+  captureCraterPageImage,
+  closeReferenceBrowser,
+  compareReferenceFixtureToImage,
+  connectCraterPageForVrt,
+  renderCraterHtml,
+  resolveChromiumReferenceFixture,
+} from "./helpers/crater-vrt";
+
+/**
+ * Dedicated SVG / logo intrinsic-sizing fixtures.
+ *
+ * These tests carve out the SVG intrinsic-size paint paths that previously
+ * only existed inside real-URL captures (google logo, mdn icons, wikipedia
+ * headings, playwright diagrams) into standalone reproducible fixtures so
+ * regressions can be isolated from page-wide diffs.
+ *
+ * Implements: paint.svg-logo-intrinsic (P1).
+ */
+
+const OUTPUT_ROOT = path.join(process.cwd(), "output", "playwright", "vrt");
+const SPEC = "tests/paint-vrt-svg-intrinsic.test.ts";
+
+function reportFor(title: string) {
+  return createVrtArtifactReportContext({
+    taskId: "paint-vrt-svg-intrinsic",
+    file: SPEC,
+    title,
+  });
+}
+
+async function expectHtmlWithinBudget(options: {
+  fixtureId: string;
+  html: string;
+  viewport: { width: number; height: number };
+  outputDirName: string;
+  threshold: number;
+  maxDiffRatio: number;
+  reportTitle: string;
+  prepareChromiumPage?: (page: Page) => Promise<void>;
+}): Promise<void> {
+  const reference = await resolveChromiumReferenceFixture({
+    fixtureId: options.fixtureId,
+    html: options.html,
+    viewport: options.viewport,
+    title: options.reportTitle,
+    preparePage: options.prepareChromiumPage,
+  });
+  const craterPage = await connectCraterPageForVrt();
+  try {
+    const craterImage = await renderCraterHtml(craterPage, options.html, options.viewport);
+    const result = await compareReferenceFixtureToImage(reference, craterImage, {
+      outputDir: path.join(OUTPUT_ROOT, options.outputDirName),
+      threshold: options.threshold,
+      maxDiffRatio: options.maxDiffRatio,
+      report: reportFor(options.reportTitle),
+      cropToContent: true,
+      contentPadding: 12,
+      backgroundTolerance: 18,
+      maskToVisibleContent: true,
+      maskPadding: 2,
+    });
+    expect(result.diffRatio).toBeLessThanOrEqual(result.maxDiffRatio);
+  } finally {
+    await craterPage.close();
+  }
+}
+
+test.describe("Paint VRT — SVG intrinsic sizing", () => {
+  test.describe.configure({ timeout: 300_000 });
+
+  test.afterAll(async () => {
+    await closeReferenceBrowser();
+  });
+
+  test("svg with explicit width and height attributes", async () => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { margin: 0; padding: 32px; background: #f6f7fb; font-family: Arial, sans-serif; }
+      .row { display: flex; gap: 32px; align-items: center; }
+    </style>
+  </head>
+  <body>
+    <div class="row">
+      <svg width="80" height="48" viewBox="0 0 80 48">
+        <rect x="0" y="0" width="80" height="48" fill="#3158ff" rx="8" />
+      </svg>
+      <svg width="120" height="60" viewBox="0 0 120 60">
+        <rect x="0" y="0" width="120" height="60" fill="#ff5c5c" rx="8" />
+      </svg>
+    </div>
+  </body>
+</html>`;
+    await expectHtmlWithinBudget({
+      fixtureId: "svg-intrinsic-explicit-dims",
+      html,
+      viewport: { width: 480, height: 200 },
+      outputDirName: "svg-intrinsic-explicit-dims",
+      threshold: 0.3,
+      maxDiffRatio: 0.15,
+      reportTitle: "svg with explicit width and height attributes",
+    });
+  });
+
+  test("svg with viewBox only takes intrinsic from viewBox", async () => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { margin: 0; padding: 32px; background: #f6f7fb; font-family: Arial, sans-serif; }
+    </style>
+  </head>
+  <body>
+    <svg viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="200" height="80" fill="#3b82f6" rx="12" />
+      <circle cx="40" cy="40" r="20" fill="white" />
+    </svg>
+  </body>
+</html>`;
+    await expectHtmlWithinBudget({
+      fixtureId: "svg-intrinsic-viewbox-only",
+      html,
+      viewport: { width: 480, height: 240 },
+      outputDirName: "svg-intrinsic-viewbox-only",
+      threshold: 0.3,
+      maxDiffRatio: 0.15,
+      reportTitle: "svg with viewBox only takes intrinsic from viewBox",
+    });
+  });
+
+  test("svg inside flex container honors flex sizing", async () => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { margin: 0; padding: 32px; background: #f6f7fb; font-family: Arial, sans-serif; }
+      .card { display: flex; align-items: center; gap: 16px; padding: 16px; background: white; border-radius: 12px; width: 320px; }
+      .icon { flex: 0 0 auto; }
+      .label { flex: 1; font-size: 16px; color: #172033; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <svg class="icon" width="32" height="32" viewBox="0 0 32 32">
+        <rect x="0" y="0" width="32" height="32" fill="#10b981" rx="8" />
+      </svg>
+      <span class="label">All systems operational</span>
+    </div>
+  </body>
+</html>`;
+    await expectHtmlWithinBudget({
+      fixtureId: "svg-intrinsic-flex-icon",
+      html,
+      viewport: { width: 480, height: 200 },
+      outputDirName: "svg-intrinsic-flex-icon",
+      threshold: 0.3,
+      maxDiffRatio: 0.15,
+      reportTitle: "svg inside flex container honors flex sizing",
+    });
+  });
+
+  test("inline svg as replaced text element preserves baseline", async () => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { margin: 0; padding: 32px; background: #f6f7fb; font-family: Arial, sans-serif; }
+      h1 { font-size: 24px; color: #172033; margin: 0; }
+      h1 svg { vertical-align: middle; margin-right: 8px; }
+    </style>
+  </head>
+  <body>
+    <h1>
+      <svg width="28" height="28" viewBox="0 0 28 28">
+        <rect x="0" y="0" width="28" height="28" fill="#6366f1" rx="6" />
+      </svg>
+      Dashboard
+    </h1>
+  </body>
+</html>`;
+    await expectHtmlWithinBudget({
+      fixtureId: "svg-intrinsic-inline-replaced",
+      html,
+      viewport: { width: 480, height: 200 },
+      outputDirName: "svg-intrinsic-inline-replaced",
+      threshold: 0.3,
+      maxDiffRatio: 0.15,
+      reportTitle: "inline svg as replaced text element preserves baseline",
+    });
+  });
+
+  test("svg sized by parent container with percent width", async () => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { margin: 0; padding: 32px; background: #f6f7fb; font-family: Arial, sans-serif; }
+      .frame { width: 240px; height: 120px; background: white; padding: 8px; border-radius: 12px; }
+      .frame svg { width: 100%; height: 100%; display: block; }
+    </style>
+  </head>
+  <body>
+    <div class="frame">
+      <svg viewBox="0 0 200 100" preserveAspectRatio="xMidYMid meet">
+        <rect x="0" y="0" width="200" height="100" fill="#f59e0b" rx="8" />
+      </svg>
+    </div>
+  </body>
+</html>`;
+    await expectHtmlWithinBudget({
+      fixtureId: "svg-intrinsic-percent-parent",
+      html,
+      viewport: { width: 480, height: 240 },
+      outputDirName: "svg-intrinsic-percent-parent",
+      threshold: 0.3,
+      maxDiffRatio: 0.15,
+      reportTitle: "svg sized by parent container with percent width",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`paint.svg-logo-intrinsic` was draft because SVG / logo intrinsic-size paint paths were only exercised incidentally inside real-URL captures (google logo, mdn icons, wikipedia headings, playwright diagrams). A regression in SVG sizing surfaced as a page-wide diff that took triage to localise.

This change adds `tests/paint-vrt-svg-intrinsic.test.ts` with five focused cases that each isolate one intrinsic-sizing pattern:

- svg with explicit width and height attributes
- svg with viewBox only (intrinsic from viewBox)
- svg inside a flex container (flex sizing path)
- inline svg as replaced text element (baseline alignment)
- svg sized by parent container with percent width

Each fixture is tiny, uses standard fonts, and a relaxed diff budget (`maxDiffRatio: 0.15` with crop-to-content masking) so it lands on top of current Crater behaviour without requiring tuning. The tests live in the paint-vrt CI job and gate on the `vrt` PR label like the rest of paint-vrt.

Flips `paint.svg-logo-intrinsic` to approved with pkspec smoke `paint_svg_intrinsic_has_dedicated_fixtures` asserting the file exists and contains the expected case names.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `pkf run spec-check` (25 / 25)
- [x] `pkf run spec-test` (25 / 25, incl. new `paint_svg_intrinsic_has_dedicated_fixtures`)
- [ ] paint-vrt CI run (requires `vrt` label) to confirm the 5 fixtures land within the budget on Crater

🤖 Generated with [Claude Code](https://claude.com/claude-code)