### PR TITLE
Enable css-borders WPT module and lock its baseline at 4/5

### DIFF
--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -350,6 +350,16 @@ scenarios {
     contributes { "goal.css-compat" }
   }
   new {
+    id = "compat.css-borders-baseline"
+    name = "css-borders WPT module baseline is established"
+    description =
+      "Measure and pin a per-module pass-rate baseline for the css-borders WPT module. css-borders is enabled in wpt.json, the test count (5) and pass count (4) are pinned in tests/wpt-baselines/css-borders.env, and scripts/test-wpt-module-baseline.sh fails CI when the count regresses. The single baseline failure is border-shape-absolute-coords-shape-ref.tentative.html, where the layout-tree compare runner cannot reconcile a top-level <polygon> SVG element against Crater's current SVG geometry output."
+    tags { "wpt"; "css"; "baseline" }
+    severity = "major"
+    reviewStatus = "approved"
+    contributes { "goal.css-compat" }
+  }
+  new {
     id = "compat.css-images-baseline"
     name = "css-images WPT module baseline is enabled"
     description =

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -336,6 +336,16 @@ tests {
       "bash -lc 'set -e; grep -Fq -- \"\\\"css-backgrounds\\\"\" wpt.json; test -f tests/wpt-baselines/css-backgrounds.env; grep -Fq -- \"MODULE=css-backgrounds\" tests/wpt-baselines/css-backgrounds.env; grep -Fq -- \"BASELINE_PASSED=74\" tests/wpt-baselines/css-backgrounds.env; grep -Fq -- \"BASELINE_FAILED=6\" tests/wpt-baselines/css-backgrounds.env'"
   }
   new {
+    name = "wpt_css_borders_baseline_is_pinned"
+    description =
+      "css-borders is enabled in wpt.json and the per-module baseline file pins the expected pass / fail counts."
+    tags { "wpt"; "css"; "baseline" }
+    specRef { "compat.css-borders-baseline" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"\\\"css-borders\\\"\" wpt.json; test -f tests/wpt-baselines/css-borders.env; grep -Fq -- \"MODULE=css-borders\" tests/wpt-baselines/css-borders.env; grep -Fq -- \"BASELINE_PASSED=4\" tests/wpt-baselines/css-borders.env; grep -Fq -- \"BASELINE_FAILED=1\" tests/wpt-baselines/css-borders.env'"
+  }
+  new {
     name = "wpt_css_color_baseline_is_pinned"
     description =
       "css-color is enabled in wpt.json, the per-module baseline file exists with the expected fields, and scripts/test-wpt-module-baseline.sh is wired to enforce no-regression on it."

--- a/tests/wpt-baselines/css-borders.env
+++ b/tests/wpt-baselines/css-borders.env
@@ -1,0 +1,6 @@
+MODULE=css-borders
+BASELINE_TOTAL=5
+BASELINE_PASSED=4
+BASELINE_FAILED=1
+BASELINE_UPDATED_AT=2026-05-17T00:00:00Z
+NOTE="One baseline failure is border-shape-absolute-coords-shape-ref.tentative.html, which uses a top-level <polygon> SVG element that the layout-tree compare runner cannot reconcile against Crater's current SVG geometry output."

--- a/wpt.json
+++ b/wpt.json
@@ -37,7 +37,12 @@
     // Pseudo-elements; only 1 fixture matches the current
     // includePrefixes filter. Widening the filter requires the broader
     // inline-model pass. See pkspec compat.css-pseudo-baseline.
-    "css-pseudo"
+    "css-pseudo",
+
+    // Borders. The includePrefixes filter exposes a small set of
+    // border-radius / border-shape / border-image fixtures (5 layout
+    // comparable). See pkspec compat.css-borders-baseline.
+    "css-borders"
 
     // Later: meaningful, but deferred for now.
     // "css-ruby",           // No fixtures match includePrefixes; needs filter widening.


### PR DESCRIPTION
## Summary

- Adds `css-borders` to `wpt.json` and pins the per-module pass-rate baseline at 4 passed / 1 failed / 5 total in `tests/wpt-baselines/css-borders.env`.
- The single baseline failure is `border-shape-absolute-coords-shape-ref.tentative.html`, where the layout-tree compare runner cannot reconcile a top-level `<polygon>` SVG element against Crater's current SVG geometry output. The other 4 fixtures pass cleanly.
- Implements `compat.css-borders-baseline` (P0). Scenario flips from draft to approved; pkspec smoke test `wpt_css_borders_baseline_is_pinned` verifies the wpt.json entry and the baseline env file's expected fields.

## Test plan

- [x] `scripts/test-wpt-module-baseline.sh css-borders` → "WPT css-borders baseline check passed"
- [x] `pkf run spec-check` (27 declared specs implemented)
- [x] `pkf run spec-lint` (clean)
- [x] `pkf run spec-test` (27 passed)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)