### PR TITLE
Bust pkfire task cache to clear poisoned glob-output entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,20 @@ jobs:
       - name: Restore pkfire task cache
         uses: actions/cache@v4
         with:
+          # NOTE: bumped to v2 to invalidate cache entries poisoned by
+          # the glob-outputs bug fixed in mizchi/pkfire#15. Entries
+          # written by pkfire <= v0.10.0 archive an empty payload for
+          # outputs declared with glob patterns (e.g. `js/dist/**`),
+          # which caused affected pkfire runs to hit cache, restore
+          # nothing, and fail downstream node:test imports with
+          # ERR_MODULE_NOT_FOUND. Drop the v2 suffix once the affected
+          # tasks have re-stored against a fixed pkfire build.
           path: .cache/pkfire
-          key: pkfire-task-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}
+          key: pkfire-task-v2-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}
           restore-keys: |
-            pkfire-task-${{ runner.os }}-${{ github.ref_name }}-
-            pkfire-task-${{ runner.os }}-main-
-            pkfire-task-${{ runner.os }}-
+            pkfire-task-v2-${{ runner.os }}-${{ github.ref_name }}-
+            pkfire-task-v2-${{ runner.os }}-main-
+            pkfire-task-v2-${{ runner.os }}-
 
       - name: Warm Pkl package cache
         run: pkf pkl-cache warm


### PR DESCRIPTION
## Summary

`affected pkfire` has been failing on `main` since #126 with `ERR_MODULE_NOT_FOUND: Cannot find module '/home/runner/work/crater/crater/js/dist/index.js'` (run [25989323177](https://github.com/mizchi/crater/actions/runs/25989323177), [25989573561](https://github.com/mizchi/crater/actions/runs/25989573561)).

Root cause is a pkfire v0.10.0 bug where `writeArchive` treats output glob patterns like `js/dist/**` as literal paths. `os.Lstat` then fails with `ErrNotExist`, the entry is silently skipped, and the cache archive is stored empty. The next run hits the cache, restores nothing, and `node --test` can't import `js/dist/index.js`. Upstream fix at mizchi/pkfire#15.

This PR bumps the actions/cache key from `pkfire-task-*` to `pkfire-task-v2-*` so the poisoned `build-js-package` entry is no longer restored on the next run. Once pkfire ships the fix and the affected tasks have re-stored against a non-buggy build, the `v2` suffix can be dropped.

## Test plan

- [ ] CI green on this PR (affected pkfire stays green because the empty-archive entry is no longer restored and the task re-executes)
- [ ] Subsequent main run also green

🤖 Generated with [Claude Code](https://claude.com/claude-code)