### PR TITLE
Browser auth + CORS Phase 1-4: Profile / SameSite / CORS / BiDi errorText

### DIFF
--- a/browser/http/cors_reexport_test.mbt
+++ b/browser/http/cors_reexport_test.mbt
@@ -1,0 +1,11 @@
+///|
+test "browser/http re-exports CORS surface" {
+  let d = @http.classify_request(
+    url="https://example.com/x",
+    origin="https://example.com",
+    mode=@http.RequestMode::Cors,
+    method="GET",
+    headers={},
+  )
+  inspect(d, content="Allow")
+}

--- a/browser/http/moon.pkg
+++ b/browser/http/moon.pkg
@@ -2,6 +2,7 @@ import {
   "mizchi/crater-browser-http" @http_impl,
   "mizchi/crater-browser-http/cache" @cache,
   "mizchi/crater-browser-http/cookie_jar" @cookie_jar,
+  "mizchi/crater-browser-http/cors" @cors,
   "mizchi/crater-browser-http/profile" @profile,
   "mizchi/crater-browser-http/samesite" @samesite,
 }

--- a/browser/http/moon.pkg
+++ b/browser/http/moon.pkg
@@ -2,6 +2,7 @@ import {
   "mizchi/crater-browser-http" @http_impl,
   "mizchi/crater-browser-http/cache" @cache,
   "mizchi/crater-browser-http/cookie_jar" @cookie_jar,
+  "mizchi/crater-browser-http/profile" @profile,
 }
 
 supported_targets = "js+native+wasm+wasm-gc"

--- a/browser/http/moon.pkg
+++ b/browser/http/moon.pkg
@@ -3,6 +3,7 @@ import {
   "mizchi/crater-browser-http/cache" @cache,
   "mizchi/crater-browser-http/cookie_jar" @cookie_jar,
   "mizchi/crater-browser-http/profile" @profile,
+  "mizchi/crater-browser-http/samesite" @samesite,
 }
 
 supported_targets = "js+native+wasm+wasm-gc"

--- a/browser/http/pkg.generated.mbti
+++ b/browser/http/pkg.generated.mbti
@@ -5,6 +5,7 @@ import {
   "mizchi/crater-browser-http",
   "mizchi/crater-browser-http/cache",
   "mizchi/crater-browser-http/cookie_jar",
+  "mizchi/crater-browser-http/profile",
 }
 
 // Values
@@ -31,6 +32,8 @@ pub fn parse_set_cookie(String, String, String) -> @cookie_jar.ParsedCookie?
 // Types and methods
 
 // Type aliases
+pub using @profile {type AuthState}
+
 pub using @cache {type CacheDirectives}
 
 pub using @cache {type CacheEntry}
@@ -48,6 +51,8 @@ pub using @crater-browser-http {type HttpResponse}
 pub using @cache {type MemoryCacheBackend}
 
 pub using @cookie_jar {type ParsedCookie}
+
+pub using @profile {type Profile}
 
 pub using @crater-browser-http {type RequestMode}
 

--- a/browser/http/pkg.generated.mbti
+++ b/browser/http/pkg.generated.mbti
@@ -6,12 +6,15 @@ import {
   "mizchi/crater-browser-http/cache",
   "mizchi/crater-browser-http/cookie_jar",
   "mizchi/crater-browser-http/profile",
+  "mizchi/crater-browser-http/samesite",
 }
 
 // Values
 pub fn[CacheBackend : @cache.HttpCacheBackend] cached_fetch(url~ : String, options~ : @crater-browser-http.FetchOptions, cache~ : CacheBackend, fetcher~ : (String, @crater-browser-http.FetchOptions) -> @crater-browser-http.HttpResponse raise @crater-browser-http.HttpError) -> @crater-browser-http.HttpResponse raise @crater-browser-http.HttpError
 
 pub async fn[CacheBackend : @cache.HttpCacheBackend] cached_fetch_async(url~ : String, options~ : @crater-browser-http.FetchOptions, cache~ : CacheBackend, fetcher~ : async (String, @crater-browser-http.FetchOptions) -> @crater-browser-http.HttpResponse raise @crater-browser-http.HttpError) -> @crater-browser-http.HttpResponse raise @crater-browser-http.HttpError
+
+pub fn classify_site_context(String, String) -> @samesite.SiteContext
 
 pub async fn fetch(String, options? : @crater-browser-http.FetchOptions) -> @crater-browser-http.HttpResponse raise @crater-browser-http.HttpError
 
@@ -26,6 +29,8 @@ pub fn now_seconds() -> Double
 pub fn parse_cache_control(String) -> @cache.CacheDirectives
 
 pub fn parse_set_cookie(String, String, String) -> @cookie_jar.ParsedCookie?
+
+pub fn should_attach_cookie(@cookie_jar.ParsedCookie, @samesite.SiteContext, Bool) -> Bool
 
 // Errors
 
@@ -57,6 +62,8 @@ pub using @profile {type Profile}
 pub using @crater-browser-http {type RequestMode}
 
 pub using @crater-browser-http {type RequestSandbox}
+
+pub using @samesite {type SiteContext}
 
 pub using @cache {trait HttpCacheBackend}
 

--- a/browser/http/pkg.generated.mbti
+++ b/browser/http/pkg.generated.mbti
@@ -5,6 +5,7 @@ import {
   "mizchi/crater-browser-http",
   "mizchi/crater-browser-http/cache",
   "mizchi/crater-browser-http/cookie_jar",
+  "mizchi/crater-browser-http/cors",
   "mizchi/crater-browser-http/profile",
   "mizchi/crater-browser-http/samesite",
 }
@@ -13,6 +14,8 @@ import {
 pub fn[CacheBackend : @cache.HttpCacheBackend] cached_fetch(url~ : String, options~ : @crater-browser-http.FetchOptions, cache~ : CacheBackend, fetcher~ : (String, @crater-browser-http.FetchOptions) -> @crater-browser-http.HttpResponse raise @crater-browser-http.HttpError) -> @crater-browser-http.HttpResponse raise @crater-browser-http.HttpError
 
 pub async fn[CacheBackend : @cache.HttpCacheBackend] cached_fetch_async(url~ : String, options~ : @crater-browser-http.FetchOptions, cache~ : CacheBackend, fetcher~ : async (String, @crater-browser-http.FetchOptions) -> @crater-browser-http.HttpResponse raise @crater-browser-http.HttpError) -> @crater-browser-http.HttpResponse raise @crater-browser-http.HttpError
+
+pub fn classify_request(url~ : String, origin~ : String, mode~ : @crater-browser-http.RequestMode, method~ : String, headers~ : Map[String, String]) -> @cors.CorsDecision
 
 pub fn classify_site_context(String, String) -> @samesite.SiteContext
 
@@ -32,6 +35,10 @@ pub fn parse_set_cookie(String, String, String) -> @cookie_jar.ParsedCookie?
 
 pub fn should_attach_cookie(@cookie_jar.ParsedCookie, @samesite.SiteContext, Bool) -> Bool
 
+pub fn validate_actual_response(request_url~ : String, origin~ : String, credentials~ : @crater-browser-http.CredentialsMode, response~ : @crater-browser-http.HttpResponse) -> Result[Unit, String]
+
+pub fn validate_preflight_response(@cors.PreflightRequest, @crater-browser-http.HttpResponse) -> Result[Unit, String]
+
 // Errors
 
 // Types and methods
@@ -45,6 +52,8 @@ pub using @cache {type CacheEntry}
 
 pub using @cookie_jar {type CookieJar}
 
+pub using @cors {type CorsDecision}
+
 pub using @crater-browser-http {type CredentialsMode}
 
 pub using @crater-browser-http {type FetchOptions}
@@ -56,6 +65,12 @@ pub using @crater-browser-http {type HttpResponse}
 pub using @cache {type MemoryCacheBackend}
 
 pub using @cookie_jar {type ParsedCookie}
+
+pub using @cors {type PreflightCache}
+
+pub using @cors {type PreflightEntry}
+
+pub using @cors {type PreflightRequest}
 
 pub using @profile {type Profile}
 

--- a/browser/http/profile_reexport_test.mbt
+++ b/browser/http/profile_reexport_test.mbt
@@ -1,0 +1,5 @@
+///|
+test "browser/http re-exports Profile" {
+  let _ : @http.Profile = @http.Profile::default()
+  inspect(true, content="true")
+}

--- a/browser/http/samesite_reexport_test.mbt
+++ b/browser/http/samesite_reexport_test.mbt
@@ -1,0 +1,5 @@
+///|
+test "browser/http re-exports SameSite types" {
+  let s : @http.SiteContext = @http.SiteContext::SameSite
+  inspect(s, content="SameSite")
+}

--- a/browser/http/top.mbt
+++ b/browser/http/top.mbt
@@ -26,6 +26,43 @@ pub using @profile {type Profile, type AuthState}
 pub using @samesite {type SiteContext}
 
 ///|
+pub using @cors {
+  type CorsDecision,
+  type PreflightRequest,
+  type PreflightEntry,
+  type PreflightCache,
+}
+
+///|
+pub fn classify_request(
+  url~ : String,
+  origin~ : String,
+  mode~ : RequestMode,
+  method~ : String,
+  headers~ : Map[String, String],
+) -> CorsDecision {
+  @cors.classify_request(url~, origin~, mode~, method~, headers~)
+}
+
+///|
+pub fn validate_preflight_response(
+  request : PreflightRequest,
+  response : HttpResponse,
+) -> Result[Unit, String] {
+  @cors.validate_preflight_response(request, response)
+}
+
+///|
+pub fn validate_actual_response(
+  request_url~ : String,
+  origin~ : String,
+  credentials~ : CredentialsMode,
+  response~ : HttpResponse,
+) -> Result[Unit, String] {
+  @cors.validate_actual_response(request_url~, origin~, credentials~, response~)
+}
+
+///|
 pub fn classify_site_context(
   request_origin : String,
   cookie_domain : String,

--- a/browser/http/top.mbt
+++ b/browser/http/top.mbt
@@ -23,6 +23,26 @@ pub using @cookie_jar {type CookieJar, type ParsedCookie}
 pub using @profile {type Profile, type AuthState}
 
 ///|
+pub using @samesite {type SiteContext}
+
+///|
+pub fn classify_site_context(
+  request_origin : String,
+  cookie_domain : String,
+) -> SiteContext {
+  @samesite.classify_site_context(request_origin, cookie_domain)
+}
+
+///|
+pub fn should_attach_cookie(
+  cookie : @cookie_jar.ParsedCookie,
+  site_context : SiteContext,
+  is_top_level_navigation : Bool,
+) -> Bool {
+  @samesite.should_attach_cookie(cookie, site_context, is_top_level_navigation)
+}
+
+///|
 pub fn[CacheBackend : HttpCacheBackend] cached_fetch(
   url~ : String,
   options~ : FetchOptions,

--- a/browser/http/top.mbt
+++ b/browser/http/top.mbt
@@ -20,6 +20,9 @@ pub using @cache {
 pub using @cookie_jar {type CookieJar, type ParsedCookie}
 
 ///|
+pub using @profile {type Profile, type AuthState}
+
+///|
 pub fn[CacheBackend : HttpCacheBackend] cached_fetch(
   url~ : String,
   options~ : FetchOptions,

--- a/browser/shell/browser_options.mbt
+++ b/browser/shell/browser_options.mbt
@@ -8,9 +8,10 @@ pub fn Browser::set_enable_js(self : Browser, enable : Bool) -> Unit {
 
 ///|
 /// Enable or disable cookie jar.
-/// Cookies are disabled by default for security.
+/// Swaps only the jar on the existing profile, preserving http_cache,
+/// user_agent, and auth_state.
 pub fn Browser::set_enable_cookies(self : Browser, enable : Bool) -> Unit {
-  self.cookie_jar = @http_cookie_jar.CookieJar::new(enabled=enable)
+  self.profile.cookie_jar = @http_cookie_jar.CookieJar::new(enabled=enable)
 }
 
 ///|

--- a/browser/shell/cors_enforcement_wbtest.mbt
+++ b/browser/shell/cors_enforcement_wbtest.mbt
@@ -1,0 +1,281 @@
+///|
+/// Tests for the CORS gate seam (`script_fetch_with_cors`).
+///
+/// These exercise the gate directly via captured fetcher closures so
+/// the path stays unit-testable without a stub HTTP layer:
+///   - classify_request → Allow / PreflightRequired / Blocked decision
+///   - PreflightCache::get_or_validate invocation count
+///   - validate_actual_response wiring (CorsBlocked on missing ACA-Origin)
+///   - NoCors short-circuit (skips validate_actual_response per spec)
+///
+/// The actual `Browser::fetch_external_script_source` wiring is
+/// covered indirectly: every call site uses the same gate, and the
+/// gate's behaviour is locked down by these seam tests.
+
+///|
+/// Build a synthetic HttpResponse with the given status and headers.
+/// Header names are written lowercased so the gate's lookup (which
+/// uses `get_header` semantics) matches regardless of case.
+fn cors_test_response(
+  status~ : Int,
+  aca_origin? : String,
+  body? : String = "/*js*/",
+) -> @http.HttpResponse {
+  let h : Map[String, String] = {}
+  if aca_origin is Some(v) {
+    h["access-control-allow-origin"] = v
+  }
+  { status, headers: h, body }
+}
+
+///|
+/// Build a Cors-mode FetchOptions for a cross-origin GET. `origin` is
+/// the initiating page; the target URL goes to a different origin so
+/// classify_request takes the cross-origin branch.
+fn cors_test_options(
+  method? : String = "GET",
+  origin~ : String,
+  mode? : @http.RequestMode = Cors,
+  credentials? : @http.CredentialsMode = Omit,
+  headers? : Map[String, String] = {},
+) -> @http.FetchOptions {
+  {
+    ..@http.FetchOptions::default(),
+    http_method: method,
+    headers,
+    mode,
+    credentials,
+    origin,
+  }
+}
+
+///|
+async test "script_fetch_with_cors: cross-origin GET Allow + ACA-Origin echo → Ok" {
+  let preflight_cache = @http_cors.PreflightCache::new()
+  let preflight_calls : Array[Int] = [0]
+  let fetcher_calls : Array[Int] = [0]
+  let preflight_fetcher = fn(
+    _req : @http_cors.PreflightRequest,
+  ) -> @http.HttpResponse {
+    preflight_calls[0] = preflight_calls[0] + 1
+    cors_test_response(status=0)
+  }
+  let fetcher = async fn(
+    _u : String,
+    _o : @http.FetchOptions,
+  ) -> @http.HttpResponse raise @http.HttpError {
+    fetcher_calls[0] = fetcher_calls[0] + 1
+    cors_test_response(status=200, aca_origin="https://example.com")
+  }
+  let response = script_fetch_with_cors(
+    url="https://api.other.com/x.js",
+    options=cors_test_options(origin="https://example.com"),
+    preflight_cache~,
+    now=fn() { 1000.0 },
+    preflight_fetcher~,
+    fetcher~,
+  )
+  inspect(response.status, content="200")
+  // Allow path: no preflight, one actual fetch.
+  inspect(preflight_calls[0], content="0")
+  inspect(fetcher_calls[0], content="1")
+}
+
+///|
+async test "script_fetch_with_cors: cross-origin GET Allow but missing ACA-Origin → CorsBlocked" {
+  let preflight_cache = @http_cors.PreflightCache::new()
+  let preflight_fetcher = fn(
+    _req : @http_cors.PreflightRequest,
+  ) -> @http.HttpResponse {
+    cors_test_response(status=0)
+  }
+  let fetcher = async fn(
+    _u : String,
+    _o : @http.FetchOptions,
+  ) -> @http.HttpResponse raise @http.HttpError {
+    // No ACA-Origin header → validate_actual_response should refuse.
+    cors_test_response(status=200)
+  }
+  let outcome : Result[Int, String] = try {
+    let r = script_fetch_with_cors(
+      url="https://api.other.com/x.js",
+      options=cors_test_options(origin="https://example.com"),
+      preflight_cache~,
+      now=fn() { 1000.0 },
+      preflight_fetcher~,
+      fetcher~,
+    )
+    Ok(r.status)
+  } catch {
+    @http.HttpError::CorsBlocked(_) => Err("CorsBlocked")
+    e => Err("other:" + e.to_string())
+  }
+  inspect(
+    outcome,
+    content=(
+      #|Err(CorsBlocked)
+    ),
+  )
+}
+
+///|
+async test "script_fetch_with_cors: PreflightRequired path invokes preflight fetcher once on first call" {
+  let preflight_cache = @http_cors.PreflightCache::new()
+  let preflight_calls : Array[Int] = [0]
+  let fetcher_calls : Array[Int] = [0]
+  let preflight_fetcher = fn(
+    _req : @http_cors.PreflightRequest,
+  ) -> @http.HttpResponse {
+    preflight_calls[0] = preflight_calls[0] + 1
+    // Successful preflight that grants the custom method + header for
+    // the cache's documented Max-Age (parsed as Double seconds).
+    let h : Map[String, String] = {
+      "access-control-allow-origin": "https://example.com",
+      "access-control-allow-methods": "POST",
+      "access-control-allow-headers": "x-csrf",
+      "access-control-max-age": "600",
+    }
+    { status: 204, headers: h, body: "" }
+  }
+  let fetcher = async fn(
+    _u : String,
+    _o : @http.FetchOptions,
+  ) -> @http.HttpResponse raise @http.HttpError {
+    fetcher_calls[0] = fetcher_calls[0] + 1
+    cors_test_response(status=200, aca_origin="https://example.com")
+  }
+  // POST with a custom header → classify_request returns PreflightRequired.
+  let opts = cors_test_options(method="POST", origin="https://example.com", headers={
+    "X-Csrf": "tok",
+  })
+  let response = script_fetch_with_cors(
+    url="https://api.other.com/upload",
+    options=opts,
+    preflight_cache~,
+    now=fn() { 1000.0 },
+    preflight_fetcher~,
+    fetcher~,
+  )
+  inspect(response.status, content="200")
+  inspect(preflight_calls[0], content="1")
+  inspect(fetcher_calls[0], content="1")
+}
+
+///|
+async test "script_fetch_with_cors: cached preflight skips preflight fetcher on second request" {
+  let preflight_cache = @http_cors.PreflightCache::new()
+  let preflight_calls : Array[Int] = [0]
+  let fetcher_calls : Array[Int] = [0]
+  let preflight_fetcher = fn(
+    _req : @http_cors.PreflightRequest,
+  ) -> @http.HttpResponse {
+    preflight_calls[0] = preflight_calls[0] + 1
+    let h : Map[String, String] = {
+      "access-control-allow-origin": "https://example.com",
+      "access-control-allow-methods": "POST",
+      "access-control-allow-headers": "x-csrf",
+      "access-control-max-age": "600",
+    }
+    { status: 204, headers: h, body: "" }
+  }
+  let fetcher = async fn(
+    _u : String,
+    _o : @http.FetchOptions,
+  ) -> @http.HttpResponse raise @http.HttpError {
+    fetcher_calls[0] = fetcher_calls[0] + 1
+    cors_test_response(status=200, aca_origin="https://example.com")
+  }
+  let opts = cors_test_options(method="POST", origin="https://example.com", headers={
+    "X-Csrf": "tok",
+  })
+  // Frozen clock under Max-Age: second call must hit the cache.
+  let now = fn() -> Double { 1000.0 }
+  // First request → cache miss, preflight fetcher called once.
+  let _ = script_fetch_with_cors(
+    url="https://api.other.com/upload",
+    options=opts,
+    preflight_cache~,
+    now~,
+    preflight_fetcher~,
+    fetcher~,
+  )
+  // Second request with the same descriptor → cache hit.
+  let _ = script_fetch_with_cors(
+    url="https://api.other.com/upload",
+    options=opts,
+    preflight_cache~,
+    now~,
+    preflight_fetcher~,
+    fetcher~,
+  )
+  inspect(preflight_calls[0], content="1")
+  inspect(fetcher_calls[0], content="2")
+}
+
+///|
+async test "script_fetch_with_cors: NoCors cross-origin skips validate_actual_response" {
+  let preflight_cache = @http_cors.PreflightCache::new()
+  let preflight_fetcher = fn(
+    _req : @http_cors.PreflightRequest,
+  ) -> @http.HttpResponse {
+    cors_test_response(status=0)
+  }
+  let fetcher = async fn(
+    _u : String,
+    _o : @http.FetchOptions,
+  ) -> @http.HttpResponse raise @http.HttpError {
+    // No ACA-Origin header. With NoCors mode the gate must NOT call
+    // validate_actual_response — the script tag treats the response
+    // as opaque-but-loadable per spec.
+    cors_test_response(status=200)
+  }
+  let response = script_fetch_with_cors(
+    url="https://cdn.other.com/lib.js",
+    options=cors_test_options(origin="https://example.com", mode=NoCors),
+    preflight_cache~,
+    now=fn() { 1000.0 },
+    preflight_fetcher~,
+    fetcher~,
+  )
+  inspect(response.status, content="200")
+}
+
+///|
+async test "script_fetch_with_cors: NoCors + non-simple method → Blocked classification surfaces as CorsBlocked" {
+  let preflight_cache = @http_cors.PreflightCache::new()
+  let preflight_fetcher = fn(
+    _req : @http_cors.PreflightRequest,
+  ) -> @http.HttpResponse {
+    cors_test_response(status=0)
+  }
+  let fetcher = async fn(
+    _u : String,
+    _o : @http.FetchOptions,
+  ) -> @http.HttpResponse raise @http.HttpError {
+    cors_test_response(status=200, aca_origin="https://example.com")
+  }
+  let outcome : Result[Int, String] = try {
+    let r = script_fetch_with_cors(
+      url="https://api.other.com/x.js",
+      options=cors_test_options(
+        method="PUT",
+        origin="https://example.com",
+        mode=NoCors,
+      ),
+      preflight_cache~,
+      now=fn() { 1000.0 },
+      preflight_fetcher~,
+      fetcher~,
+    )
+    Ok(r.status)
+  } catch {
+    @http.HttpError::CorsBlocked(_) => Err("CorsBlocked")
+    e => Err("other:" + e.to_string())
+  }
+  inspect(
+    outcome,
+    content=(
+      #|Err(CorsBlocked)
+    ),
+  )
+}

--- a/browser/shell/external_css_fetch.mbt
+++ b/browser/shell/external_css_fetch.mbt
@@ -9,6 +9,28 @@ async fn http_fetch_adapter(
 }
 
 ///|
+/// Build the FetchOptions for an external <link rel="stylesheet"> load.
+///
+/// Invariant: `mode == NoCors`. External stylesheets are loaded as
+/// no-cors subresources per the Fetch spec — the page can't read the
+/// rules cross-origin without an `<link crossorigin>` attribute, but
+/// the request itself must NOT trigger a CORS preflight. Flipping this
+/// to `Cors` would break the common pattern of pulling a stylesheet
+/// from a CDN that doesn't echo `Access-Control-Allow-Origin`.
+/// Locked by `external_css_fetch_mode_wbtest.mbt`.
+fn build_external_css_options(
+  base_url : String,
+  sandbox : @http.RequestSandbox,
+) -> @http.FetchOptions {
+  {
+    ..@http.FetchOptions::default(),
+    mode: @http.RequestMode::NoCors,
+    origin: base_url,
+    sandbox,
+  }
+}
+
+///|
 /// Fetch external stylesheets and return CSS array
 async fn fetch_external_css(
   html : String,
@@ -30,12 +52,7 @@ async fn fetch_external_css(
     println("Fetching CSS: " + css_url)
     // Try to fetch CSS with cache, ignore errors
     try {
-      let options = {
-        ..@http.FetchOptions::default(),
-        mode: @http.RequestMode::NoCors,
-        origin: base_url,
-        sandbox,
-      }
+      let options = build_external_css_options(base_url, sandbox)
       let response = @http_cache.cached_fetch_async(
         url=css_url,
         options~,

--- a/browser/shell/external_css_fetch_mode_wbtest.mbt
+++ b/browser/shell/external_css_fetch_mode_wbtest.mbt
@@ -1,0 +1,60 @@
+///|
+/// Regression lock for the `external_css_fetch` mode invariant.
+///
+/// External `<link rel="stylesheet">` loads MUST use
+/// `RequestMode::NoCors` so they don't trigger a CORS preflight on a
+/// CDN that has no `Access-Control-Allow-Origin` echo. The Fetch spec
+/// treats the response as opaque (the page can't read the rules
+/// cross-origin without `<link crossorigin>`), but the request itself
+/// must still go through.
+///
+/// We test the builder seam `build_external_css_options` rather than
+/// running the full `fetch_external_css` pipeline because the builder
+/// is the only knob that decides the mode. A future "make it Cors so
+/// we can read the stylesheet text" refactor would have to flip this
+/// line and trip this test.
+
+///|
+test "build_external_css_options uses NoCors mode" {
+  let opts = build_external_css_options(
+    "https://example.com/",
+    @http.RequestSandbox::Open,
+  )
+  // RequestMode derives Eq but not Show, so we compare against the
+  // expected variant directly rather than relying on inspect.
+  let is_nocors = opts.mode == @http.RequestMode::NoCors
+  inspect(is_nocors, content="true")
+  // Sanity: it must NOT be Cors (which would force a preflight on
+  // most CDN-hosted stylesheets).
+  let is_cors = opts.mode == @http.RequestMode::Cors
+  inspect(is_cors, content="false")
+}
+
+///|
+test "build_external_css_options preserves origin and sandbox" {
+  let opts = build_external_css_options(
+    "https://example.com/page",
+    @http.RequestSandbox::SameOrigin,
+  )
+  inspect(opts.origin, content="https://example.com/page")
+  // sandbox round-trip — Allowlist would also round-trip but SameOrigin
+  // is enough to confirm the field isn't dropped.
+  let sandbox_is_same_origin = match opts.sandbox {
+    @http.RequestSandbox::SameOrigin => true
+    _ => false
+  }
+  inspect(sandbox_is_same_origin, content="true")
+}
+
+///|
+test "build_external_css_options defaults to GET" {
+  let opts = build_external_css_options(
+    "https://example.com/",
+    @http.RequestSandbox::Open,
+  )
+  // GET + NoCors is a "simple" request per the CORS classifier, so
+  // classify_request returns Allow — no preflight needed. If either
+  // the method or the mode changes, the gate would start asking for
+  // an OPTIONS roundtrip.
+  inspect(opts.http_method, content="GET")
+}

--- a/browser/shell/moon.pkg
+++ b/browser/shell/moon.pkg
@@ -13,6 +13,7 @@ import {
   "mizchi/crater-browser-http" @http,
   "mizchi/crater-browser-http/cache" @http_cache,
   "mizchi/crater-browser-http/cookie_jar" @http_cookie_jar,
+  "mizchi/crater-browser-http/cors" @http_cors,
   "mizchi/crater-browser-http/profile" @http_profile,
   "mizchi/crater-html-assets" @html_assets,
   "mizchi/crater-browser/interaction_policy",

--- a/browser/shell/moon.pkg
+++ b/browser/shell/moon.pkg
@@ -13,6 +13,7 @@ import {
   "mizchi/crater-browser-http" @http,
   "mizchi/crater-browser-http/cache" @http_cache,
   "mizchi/crater-browser-http/cookie_jar" @http_cookie_jar,
+  "mizchi/crater-browser-http/profile" @http_profile,
   "mizchi/crater-html-assets" @html_assets,
   "mizchi/crater-browser/interaction_policy",
   "mizchi/crater-browser/tui",

--- a/browser/shell/navigation.mbt
+++ b/browser/shell/navigation.mbt
@@ -113,7 +113,7 @@ async fn Browser::load_url_request(
       self.html_content,
       url,
       self.request_sandbox,
-      self.http_cache,
+      self.profile.http_cache,
     ) catch {
       _ => [] // Fallback to no external CSS on error
     },

--- a/browser/shell/navigation_fetch.mbt
+++ b/browser/shell/navigation_fetch.mbt
@@ -8,7 +8,7 @@ async fn Browser::fetch_navigation_document(
   let page_headers : Map[String, String] = {}
   let is_secure = url.has_prefix("https://")
   match
-    self.cookie_jar.get_cookie_header(
+    self.profile.cookie_jar.get_cookie_header(
       url,
       is_secure,
       true,
@@ -32,7 +32,7 @@ async fn Browser::fetch_navigation_document(
   }
   let response = @http.fetch(url, options=page_options)
   match response.headers.get("set-cookie") {
-    Some(sc) => self.cookie_jar.store_from_header(sc, url, is_secure)
+    Some(sc) => self.profile.cookie_jar.store_from_header(sc, url, is_secure)
     None => ()
   }
   response

--- a/browser/shell/navigation_fetch.mbt
+++ b/browser/shell/navigation_fetch.mbt
@@ -1,4 +1,31 @@
 ///|
+/// Compute the `Cookie` header for a top-level navigation request,
+/// filtering each candidate cookie through the SameSite policy
+/// (`is_top_level_navigation=true`, matching
+/// `@http.should_attach_cookie`'s top-level branch). `source_url` is the
+/// origin of the page initiating the navigation; an empty string means
+/// "same-site" and disables cross-site enforcement.
+///
+/// This is the single seam that the navigation path uses to decide
+/// cookie attach. Subresource fetches (script_fetch / external_css_fetch)
+/// have their own helper (TBD in later tasks) so the two contexts can
+/// differ in `is_top_level_navigation` independently.
+fn navigation_cookie_header(
+  jar : @http_cookie_jar.CookieJar,
+  source_url : String,
+  target_url : String,
+) -> String? {
+  let is_secure = target_url.has_prefix("https://")
+  jar.get_cookie_header(
+    target_url,
+    is_secure,
+    true,
+    site_origin=source_url,
+    is_top_level_navigation=true,
+  )
+}
+
+///|
 async fn Browser::fetch_navigation_document(
   self : Browser,
   source_url : String,
@@ -7,14 +34,7 @@ async fn Browser::fetch_navigation_document(
   let url = request.url
   let page_headers : Map[String, String] = {}
   let is_secure = url.has_prefix("https://")
-  match
-    self.profile.cookie_jar.get_cookie_header(
-      url,
-      is_secure,
-      true,
-      site_origin=source_url,
-      is_top_level_navigation=true,
-    ) {
+  match navigation_cookie_header(self.profile.cookie_jar, source_url, url) {
     Some(cookie_header) => page_headers["Cookie"] = cookie_header
     None => ()
   }

--- a/browser/shell/navigation_samesite_wbtest.mbt
+++ b/browser/shell/navigation_samesite_wbtest.mbt
@@ -1,0 +1,68 @@
+///|
+/// Top-level navigation cookie attach is filtered by SameSite policy.
+/// These tests pin the wiring contract: `fetch_navigation_document`
+/// must classify the call as a top-level navigation and pass the
+/// initiating page's origin so cross-site Strict cookies are dropped
+/// while cross-site Lax cookies still ride along.
+
+///|
+test "navigation: Strict cookie attaches on same-site top-level nav" {
+  let jar = @http_cookie_jar.CookieJar::new(enabled=true)
+  jar.store_from_header(
+    "session=abc; SameSite=Strict; Secure", "https://example.com/", true,
+  )
+  // Same-site top-level nav: Strict cookie should attach.
+  debug_inspect(
+    navigation_cookie_header(
+      jar, "https://example.com/login", "https://example.com/dashboard",
+    ),
+    content="Some(\"session=abc\")",
+  )
+}
+
+///|
+test "navigation: Strict cookie blocked on cross-site top-level nav" {
+  let jar = @http_cookie_jar.CookieJar::new(enabled=true)
+  jar.store_from_header(
+    "session=abc; SameSite=Strict; Secure", "https://example.com/", true,
+  )
+  // Cross-site top-level nav: Strict cookie must NOT attach.
+  debug_inspect(
+    navigation_cookie_header(
+      jar, "https://other.com/landing", "https://example.com/dashboard",
+    ),
+    content="None",
+  )
+}
+
+///|
+test "navigation: Lax cookie attaches on cross-site top-level nav" {
+  let jar = @http_cookie_jar.CookieJar::new(enabled=true)
+  jar.store_from_header(
+    "session=abc; SameSite=Lax; Secure", "https://example.com/", true,
+  )
+  // Cross-site top-level nav: Lax cookie attaches (key Lax behavior).
+  // If navigation_fetch ever stops passing is_top_level_navigation=true,
+  // this assertion flips to None and the test fails — that is the wiring
+  // we want to lock down.
+  debug_inspect(
+    navigation_cookie_header(
+      jar, "https://other.com/landing", "https://example.com/dashboard",
+    ),
+    content="Some(\"session=abc\")",
+  )
+}
+
+///|
+test "navigation: empty source_url treated as same-site (no cross-site enforcement)" {
+  let jar = @http_cookie_jar.CookieJar::new(enabled=true)
+  jar.store_from_header(
+    "session=abc; SameSite=Strict; Secure", "https://example.com/", true,
+  )
+  // No initiating page (typed URL / initial load): treat as same-site
+  // so Strict cookies attach. Matches cookie_jar's site_origin="" semantics.
+  debug_inspect(
+    navigation_cookie_header(jar, "", "https://example.com/dashboard"),
+    content="Some(\"session=abc\")",
+  )
+}

--- a/browser/shell/pkg.generated.mbti
+++ b/browser/shell/pkg.generated.mbti
@@ -3,6 +3,8 @@ package "mizchi/crater-browser/shell"
 
 import {
   "mizchi/crater-browser-http",
+  "mizchi/crater-browser-http/cache",
+  "mizchi/crater-browser-http/cookie_jar",
   "mizchi/crater-browser-runtime",
   "mizchi/crater-dom/dom",
   "moonbitlang/async/io",
@@ -17,6 +19,7 @@ type Browser
 pub async fn Browser::activate_at(Self, Int, Int) -> Bool raise @crater-browser-http.HttpError
 pub async fn Browser::activate_focused_link(Self) -> Bool raise @crater-browser-http.HttpError
 pub async fn Browser::activate_link_at(Self, Int, Int) -> Bool raise @crater-browser-http.HttpError
+pub fn Browser::cookie_jar(Self) -> @cookie_jar.CookieJar
 pub fn Browser::debug_layout(Self) -> Unit
 pub fn Browser::enter_hint_mode(Self) -> Unit
 pub async fn Browser::execute_inline_js_async(Self, String) -> String? raise @crater-browser-http.HttpError
@@ -34,6 +37,7 @@ pub async fn Browser::go_back(Self) -> String? raise @crater-browser-http.HttpEr
 pub async fn Browser::go_forward(Self) -> String? raise @crater-browser-http.HttpError
 pub async fn Browser::handle_focused_key(Self, String) -> Bool raise @crater-browser-http.HttpError
 pub fn Browser::hover_at(Self, Int, Int) -> Bool
+pub fn Browser::http_cache(Self) -> @cache.MemoryCacheBackend
 pub fn Browser::is_hint_mode(Self) -> Bool
 pub async fn Browser::navigate(Self, String) -> String raise @crater-browser-http.HttpError
 pub async fn Browser::navigate_lightweight(Self, String) -> String raise @crater-browser-http.HttpError

--- a/browser/shell/profile_state_wbtest.mbt
+++ b/browser/shell/profile_state_wbtest.mbt
@@ -1,0 +1,10 @@
+///|
+test "Browser.profile owns cookie_jar and http_cache" {
+  let state = Browser::new(100, 100)
+  // Store one cookie via the profile.
+  state.profile.cookie_jar.store_from_header(
+    "marker=v; Path=/; SameSite=Lax", "https://example.com", true,
+  )
+  // Accessor sees the SAME jar — exact count proves it's not a copy.
+  inspect(state.cookie_jar().size(), content="1")
+}

--- a/browser/shell/script_fetch.mbt
+++ b/browser/shell/script_fetch.mbt
@@ -19,7 +19,7 @@ async fn Browser::fetch_external_script_source(
     let response = @http_cache.cached_fetch_async(
       url=script_url,
       options=script_options,
-      cache=self.http_cache,
+      cache=self.profile.http_cache,
       fetcher=http_fetch_adapter,
     )
     println("    -> OK (" + response.body.length().to_string() + " bytes)")

--- a/browser/shell/script_fetch.mbt
+++ b/browser/shell/script_fetch.mbt
@@ -1,4 +1,106 @@
 ///|
+/// Async fetcher signature used by the CORS gate. The actual network
+/// roundtrip is driven by the caller-supplied closure, which may
+/// either dispatch a real fetch (in the live path) or return a canned
+/// response (in wbtests).
+type ResponseFetcher = async (String, @http.FetchOptions) -> @http.HttpResponse raise @http.HttpError
+
+///|
+/// Sync OPTIONS preflight fetcher. The PreflightCache invokes this on
+/// cache miss / expiry, never on a fresh hit. The cache contract is
+/// sync (see `@http_cors.PreflightCache::get_or_validate`), so the
+/// live wiring captures a `now`-bounded sync surface: a real network
+/// preflight runs as an `async` call that the closure awaits before
+/// returning the synthetic response.
+type PreflightFetcher = (@http_cors.PreflightRequest) -> @http.HttpResponse
+
+///|
+/// Read-only peek into a PreflightCache: returns `true` when an entry
+/// exists for `req` and `now < expires_at_seconds`. Mirrors the cache's
+/// own `cache_key` formula (`origin|url|method|headers.join(",")`)
+/// which is documented + tested in http/cors/. We keep the formula
+/// local rather than exporting `cache_key` to avoid leaking an
+/// implementation detail.
+fn preflight_cache_has_fresh(
+  cache : @http_cors.PreflightCache,
+  req : @http_cors.PreflightRequest,
+  now : Double,
+) -> Bool {
+  let key = req.origin +
+    "|" +
+    req.url +
+    "|" +
+    req.method +
+    "|" +
+    req.request_headers.join(",")
+  match cache.entries.get(key) {
+    Some(entry) => entry.expires_at_seconds > now
+    None => false
+  }
+}
+
+///|
+/// Run a subresource fetch through the CORS gate:
+///
+/// 1. `@http_cors.classify_request` → Allow / PreflightRequired / Blocked.
+/// 2. If `Blocked`, raise `CorsBlocked` without touching the network.
+/// 3. If `PreflightRequired`, ask `cache.get_or_validate` to either
+///    reuse a fresh entry or invoke `preflight_fetcher` once. A
+///    preflight validation failure raises `PreflightFailed`.
+/// 4. Dispatch the actual request via `fetcher`.
+/// 5. Run `@http_cors.validate_actual_response` on the response and
+///    raise `CorsBlocked` on Err. Same-origin responses skip the check
+///    (the validator returns Ok early in that case).
+///
+/// Tests drive this seam directly by passing closures that return
+/// canned `HttpResponse` values — no real network I/O required.
+async fn script_fetch_with_cors(
+  url~ : String,
+  options~ : @http.FetchOptions,
+  preflight_cache~ : @http_cors.PreflightCache,
+  now~ : () -> Double,
+  preflight_fetcher~ : PreflightFetcher,
+  fetcher~ : ResponseFetcher,
+) -> @http.HttpResponse raise @http.HttpError {
+  let decision = @http_cors.classify_request(
+    url~,
+    origin=options.origin,
+    mode=options.mode,
+    method=options.http_method,
+    headers=options.headers,
+  )
+  match decision {
+    Blocked(reason) => raise @http.HttpError::CorsBlocked(reason)
+    PreflightRequired(preflight_req) =>
+      match
+        preflight_cache.get_or_validate(preflight_req, now, preflight_fetcher) {
+        Err(msg) => raise @http.HttpError::PreflightFailed(msg)
+        Ok(_) => ()
+      }
+    Allow => ()
+  }
+  let response = fetcher(url, options)
+  // NoCors responses are opaque per Fetch spec: the script tag can
+  // still execute the body, but the page can't read it. We skip
+  // validate_actual_response in that mode — the validator assumes a
+  // CORS-mode request and would otherwise block every cross-origin
+  // <script src> that doesn't echo ACA-Origin (which is the majority).
+  if options.mode == @http.RequestMode::NoCors {
+    return response
+  }
+  match
+    @http_cors.validate_actual_response(
+      request_url=url,
+      origin=options.origin,
+      credentials=options.credentials,
+      response~,
+    ) {
+    Err(msg) => raise @http.HttpError::CorsBlocked(msg)
+    Ok(_) => response
+  }
+}
+
+///|
 async fn Browser::fetch_external_script_source(
   self : Browser,
   src : String,
@@ -9,18 +111,102 @@ async fn Browser::fetch_external_script_source(
     return None
   }
   println("  [FETCH] External script: " + script_url)
-  try {
-    let script_options = {
-      ..@http.FetchOptions::default(),
-      mode: @http.RequestMode::NoCors,
-      origin: self.current_url,
-      sandbox: self.request_sandbox,
+  let script_options = {
+    ..@http.FetchOptions::default(),
+    mode: @http.RequestMode::NoCors,
+    origin: self.current_url,
+    sandbox: self.request_sandbox,
+  }
+  // Stash the cache and preflight cache up front so the closures below
+  // can reference them without re-resolving through `self`.
+  let cache = self.profile.http_cache
+  let preflight_cache = self.profile.preflight_cache
+  // The actual fetcher wires the response path through the HTTP cache.
+  // The async hop is inside this closure; the gate calls it exactly
+  // once after the preflight step decides the request can proceed.
+  let fetcher = async fn(
+    u : String,
+    o : @http.FetchOptions,
+  ) -> @http.HttpResponse raise @http.HttpError {
+    @http_cache.cached_fetch_async(
+      url=u,
+      options=o,
+      cache~,
+      fetcher=http_fetch_adapter,
+    )
+  }
+  // PreflightCache::get_or_validate wants a sync fetcher, but the live
+  // OPTIONS roundtrip is async. So we pre-fetch the preflight response
+  // up front (only when classify_request asks for one — see below) and
+  // hand the cache a closure that returns the captured response. The
+  // mutable slot lets the closure see whatever the async hop produced.
+  let captured_preflight : Ref[@http.HttpResponse?] = { val: None }
+  let preflight_fetcher = fn(
+    _req : @http_cors.PreflightRequest,
+  ) -> @http.HttpResponse {
+    match captured_preflight.val {
+      Some(resp) => resp
+      // Defensive: this path runs only when caller forgot to pre-fetch.
+      // 0-status forces the validator to raise PreflightFailed with a
+      // "missing ACA-Origin" message rather than silently allowing.
+      None => { status: 0, headers: {}, body: "" }
     }
-    let response = @http_cache.cached_fetch_async(
+  }
+  // Mirror classify_request's decision once to decide whether to
+  // dispatch the OPTIONS preflight before script_fetch_with_cors
+  // consults the cache. classify_request is pure / cheap, so doing it
+  // twice (here and inside the gate) is fine; the alternative would be
+  // pushing async into the cache contract, which lives in http/cors/.
+  // We pre-fetch only when the cache lookup misses, so a cached entry
+  // skips the redundant OPTIONS roundtrip.
+  let pre_decision = @http_cors.classify_request(
+    url=script_url,
+    origin=script_options.origin,
+    mode=script_options.mode,
+    method=script_options.http_method,
+    headers=script_options.headers,
+  )
+  match pre_decision {
+    PreflightRequired(preflight_req) =>
+      if !preflight_cache_has_fresh(
+          preflight_cache,
+          preflight_req,
+          @http_cache.now_seconds(),
+        ) {
+        let headers : Map[String, String] = {
+          "Access-Control-Request-Method": preflight_req.method,
+        }
+        if !preflight_req.request_headers.is_empty() {
+          headers["Access-Control-Request-Headers"] = preflight_req.request_headers.join(
+            ",",
+          )
+        }
+        let opts = {
+          ..@http.FetchOptions::default(),
+          http_method: "OPTIONS",
+          headers,
+          mode: @http.RequestMode::Cors,
+          origin: preflight_req.origin,
+        }
+        try {
+          captured_preflight.val = Some(
+            @http.fetch(preflight_req.url, options=opts),
+          )
+        } catch {
+          _ =>
+            captured_preflight.val = Some({ status: 0, headers: {}, body: "" })
+        }
+      }
+    _ => ()
+  }
+  try {
+    let response = script_fetch_with_cors(
       url=script_url,
       options=script_options,
-      cache=self.profile.http_cache,
-      fetcher=http_fetch_adapter,
+      preflight_cache~,
+      now=@http_cache.now_seconds,
+      preflight_fetcher~,
+      fetcher~,
     )
     println("    -> OK (" + response.body.length().to_string() + " bytes)")
     Some(response.body)

--- a/browser/shell/state.mbt
+++ b/browser/shell/state.mbt
@@ -192,10 +192,9 @@ struct Browser {
   kitty_uploaded_image_ids : Map[Int, Bool]
   /// Visible kitty placements from the previous text render
   mut kitty_visible_placements : Map[String, KittyPlacement]
-  /// HTTP cache for static assets (CSS, images, scripts, fonts)
-  http_cache : @http_cache.MemoryCacheBackend
-  /// Cookie jar (disabled by default for security)
-  mut cookie_jar : @http_cookie_jar.CookieJar
+  /// Per-session profile bundling user-agent override, cookie jar,
+  /// HTTP cache, and auth state.
+  profile : @http_profile.Profile
 }
 
 ///|
@@ -264,7 +263,21 @@ pub fn Browser::new(
     image_cache: @terminal_image_cache.ImageCache::new(),
     kitty_uploaded_image_ids: {},
     kitty_visible_placements: {},
-    http_cache: @http_cache.MemoryCacheBackend::new(max_entries=1000),
-    cookie_jar: @http_cookie_jar.CookieJar::new(), // disabled by default
+    profile: @http_profile.Profile::default(),
   }
+}
+
+///|
+/// Backward-compatible accessor for the per-session cookie jar.
+/// Prefer reading `state.profile.cookie_jar` directly in new code;
+/// this method keeps existing call sites working through the migration.
+pub fn Browser::cookie_jar(self : Browser) -> @http_cookie_jar.CookieJar {
+  self.profile.cookie_jar
+}
+
+///|
+/// Backward-compatible accessor for the per-session HTTP cache.
+/// Prefer reading `state.profile.http_cache` directly in new code.
+pub fn Browser::http_cache(self : Browser) -> @http_cache.MemoryCacheBackend {
+  self.profile.http_cache
 }

--- a/browser/shell/terminal_image.mbt
+++ b/browser/shell/terminal_image.mbt
@@ -155,7 +155,7 @@ async fn Browser::prefetch_images(self : Browser) -> Unit {
       let response = @http_cache.cached_fetch_async(
         url=abs_url,
         options~,
-        cache=self.http_cache,
+        cache=self.profile.http_cache,
         fetcher=http_fetch_adapter,
       )
       response.body

--- a/http/cookie_jar/cookie_jar.mbt
+++ b/http/cookie_jar/cookie_jar.mbt
@@ -316,7 +316,11 @@ pub fn CookieJar::get_cookie_header(
           if !cookie.secure {
             continue
           }
-        _ => continue // Unknown value → treat as Strict (safe default)
+        _ =>
+          // Unknown value → treat as Lax per WHATWG RFC 6265bis
+          if !is_top_level_navigation {
+            continue
+          }
       }
     }
     if !first {

--- a/http/cookie_jar/cookie_jar_wbtest.mbt
+++ b/http/cookie_jar/cookie_jar_wbtest.mbt
@@ -1099,10 +1099,10 @@ test "samesite: default (no attribute) treated as Lax" {
 }
 
 ///|
-test "samesite: unknown value treated as Strict (safe default)" {
+test "samesite: unknown value treated as Lax (WHATWG default)" {
   let jar = CookieJar::new(enabled=true)
   jar.store_from_header("x=1; SameSite=bogus", "https://example.com/", true)
-  // Cross-site → blocked (unknown value → Strict)
+  // Cross-site subresource → blocked (unknown → Lax, non-top-level nav blocked)
   debug_inspect(
     jar.get_cookie_header(
       "https://example.com/",

--- a/http/cors/cors.mbt
+++ b/http/cors/cors.mbt
@@ -1,0 +1,194 @@
+///|
+/// Outcome of CORS classification for an outgoing fetch.
+///
+/// - `Allow`: request can proceed; cross-origin responses still need
+///   header validation via http enforce_cors_response.
+/// - `PreflightRequired(req)`: an OPTIONS preflight must be sent and
+///   succeed before the actual request runs. `req` carries the URL,
+///   origin, method, and (lowercased, sorted) custom request headers
+///   that go on the Access-Control-Request-* lines.
+/// - `Blocked(reason)`: SOP itself refuses the request (currently
+///   NoCors with a non-simple method or a custom header).
+pub(all) enum CorsDecision {
+  Allow
+  PreflightRequired(PreflightRequest)
+  Blocked(String)
+}
+
+///|
+pub impl Show for CorsDecision with output(self, logger) {
+  match self {
+    Allow => logger.write_string("Allow")
+    PreflightRequired(req) => {
+      logger.write_string("PreflightRequired(")
+      req.output(logger)
+      logger.write_string(")")
+    }
+    Blocked(reason) => {
+      logger.write_string("Blocked(")
+      reason.output(logger)
+      logger.write_string(")")
+    }
+  }
+}
+
+///|
+/// Descriptor for the OPTIONS preflight that classify_request demands
+/// when the actual request is not a simple CORS request.
+///
+/// `request_headers` is lowercased and sorted so a downstream cache
+/// can use it as part of a stable key.
+pub(all) struct PreflightRequest {
+  url : String
+  origin : String
+  method : String
+  request_headers : Array[String]
+}
+
+///|
+pub impl Show for PreflightRequest with output(self, logger) {
+  logger.write_string("{url: ")
+  self.url.output(logger)
+  logger.write_string(", origin: ")
+  self.origin.output(logger)
+  logger.write_string(", method: ")
+  self.method.output(logger)
+  logger.write_string(", request_headers: ")
+  self.request_headers.output(logger)
+  logger.write_string("}")
+}
+
+///|
+/// Cached result of a successful preflight. `expires_at_seconds` is a
+/// monotonic clock value (Unix seconds as Double for sub-second
+/// granularity); when the cache asks "is this entry still valid?" it
+/// compares against the current clock.
+pub(all) struct PreflightEntry {
+  allowed_methods : Array[String]
+  allowed_headers : Array[String]
+  allow_credentials : Bool
+  expires_at_seconds : Double
+}
+
+///|
+/// In-memory preflight cache. Key is built by the caller (typically
+/// `origin + "|" + url + "|" + method + "|" + headers.join(",")`); the
+/// CorsDecision module itself is intentionally key-agnostic for now.
+pub struct PreflightCache {
+  entries : Map[String, PreflightEntry]
+}
+
+///|
+pub fn PreflightCache::new() -> PreflightCache {
+  PreflightCache::{ entries: Map::new() }
+}
+
+///|
+/// Classify a pending fetch into Allow / PreflightRequired / Blocked
+/// per the Fetch spec's CORS protocol. Does not perform any I/O;
+/// callers feed the result into the http fetch driver.
+///
+/// - Same-origin requests always pass (regardless of mode).
+/// - `NoCors` cross-origin: rejects non-simple methods or custom
+///   request headers up front (Blocked).
+/// - `Cors` / `SameOrigin` cross-origin: simple GET/HEAD/POST with
+///   only safelisted request headers → Allow. Anything else returns
+///   PreflightRequired with a descriptor for the OPTIONS request.
+pub fn classify_request(
+  url~ : String,
+  origin~ : String,
+  mode~ : @http_impl.RequestMode,
+  method~ : String,
+  headers~ : Map[String, String],
+) -> CorsDecision {
+  let target_origin = origin_of(url)
+  if target_origin == origin {
+    return Allow
+  }
+
+  // Build the lowercased custom-header list once; both NoCors and
+  // Cors branches consume it.
+  let custom : Array[String] = []
+  for k, _ in headers {
+    let lower = k.to_lower()
+    if !is_safelisted_header(lower) {
+      custom.push(lower)
+    }
+  }
+  custom.sort()
+
+  // SOP guard for NoCors: must stay simple.
+  if mode == @http_impl.RequestMode::NoCors {
+    if !is_simple_method(method) {
+      return Blocked("NoCors disallows non-simple method " + method)
+    }
+    if !custom.is_empty() {
+      return Blocked("NoCors disallows custom header(s): " + custom.join(", "))
+    }
+    return Allow
+  }
+
+  // Cors / SameOrigin / Navigate: preflight if non-simple.
+  if is_simple_method(method) && custom.is_empty() {
+    return Allow
+  }
+  PreflightRequired(PreflightRequest::{
+    url,
+    origin,
+    method,
+    request_headers: custom,
+  })
+}
+
+///|
+/// CORS "simple" method set: GET / HEAD / POST. Anything else
+/// (PUT/DELETE/PATCH/...) triggers a preflight in CORS mode and is
+/// blocked outright in NoCors mode.
+pub fn is_simple_method(method : String) -> Bool {
+  method == "GET" || method == "HEAD" || method == "POST"
+}
+
+///|
+/// CORS "safelisted" request-header set (lowercased name only —
+/// content-type value restrictions are not enforced here; the
+/// preflight will surface them at the OPTIONS roundtrip).
+pub fn is_safelisted_header(name : String) -> Bool {
+  let lower = name.to_lower()
+  lower == "accept" ||
+  lower == "accept-language" ||
+  lower == "content-language" ||
+  lower == "content-type"
+}
+
+///|
+/// Extract `scheme://host[:port]` from a URL. Falls back to returning
+/// the input unchanged when the input does not contain `://` — that
+/// way a malformed URL never accidentally compares equal to a
+/// well-formed origin.
+pub fn origin_of(url : String) -> String {
+  let scheme_end = match url.find("://") {
+    Some(i) => i
+    None => return url
+  }
+  let after_scheme = url.unsafe_substring(
+    start=scheme_end + 3,
+    end=url.length(),
+  )
+  let host_port = truncate_at_any(after_scheme, ['/', '?', '#'])
+  url.unsafe_substring(start=0, end=scheme_end) + "://" + host_port
+}
+
+///|
+/// Return the prefix of `s` up to (but not including) the first
+/// character in `stops`. Returns `s` unchanged if no stop matches.
+fn truncate_at_any(s : String, stops : Array[Char]) -> String {
+  let chars = s.to_array()
+  let mut end = chars.length()
+  for i = 0; i < chars.length(); i = i + 1 {
+    if stops.contains(chars[i]) {
+      end = i
+      break
+    }
+  }
+  s.unsafe_substring(start=0, end~)
+}

--- a/http/cors/cors.mbt
+++ b/http/cors/cors.mbt
@@ -179,6 +179,88 @@ pub fn origin_of(url : String) -> String {
 }
 
 ///|
+/// Validate the OPTIONS response that answered an earlier
+/// `PreflightRequest`. Returns `Ok(())` when every required
+/// Access-Control-Allow-* header is present and accepts the original
+/// request (origin / method / each custom header). Returns
+/// `Err(message)` describing the first failing check so the caller can
+/// surface a useful CORS error.
+///
+/// Rules (per Fetch spec, simplified):
+/// - response.status must be 2xx (200–299).
+/// - response.headers["access-control-allow-origin"] must equal
+///   `request.origin` exactly, or be `"*"`.
+/// - response.headers["access-control-allow-methods"] must contain
+///   `request.method` (case-sensitive) or `"*"`.
+/// - For each header name in `request.request_headers` (already
+///   lowercased by classify_request), the value of
+///   `access-control-allow-headers` parsed as a CSV must contain the
+///   header (lowercased) or `"*"`.
+pub fn validate_preflight_response(
+  request : PreflightRequest,
+  response : @http_impl.HttpResponse,
+) -> Result[Unit, String] {
+  if response.status < 200 || response.status >= 300 {
+    return Err("preflight non-2xx status: " + response.status.to_string())
+  }
+  let aco = header_or_empty(response.headers, "access-control-allow-origin")
+  if aco != request.origin && aco != "*" {
+    return Err(
+      "Access-Control-Allow-Origin missing or mismatched: \"" + aco + "\"",
+    )
+  }
+  let allowed_methods = parse_csv(
+    header_or_empty(response.headers, "access-control-allow-methods"),
+  )
+  if !allowed_methods.contains(request.method) && !allowed_methods.contains("*") {
+    return Err(
+      "Access-Control-Allow-Methods does not include " + request.method,
+    )
+  }
+  let allowed_headers : Array[String] = parse_csv(
+    header_or_empty(response.headers, "access-control-allow-headers"),
+  ).map(fn(s) { s.to_lower() })
+  for h in request.request_headers {
+    if !allowed_headers.contains(h) && !allowed_headers.contains("*") {
+      return Err("Access-Control-Allow-Headers does not include " + h)
+    }
+  }
+  Ok(())
+}
+
+///|
+/// Look up `key` in `headers` (case-insensitive: the response from a
+/// real fetch may use any casing). Returns the trimmed value, or `""`
+/// when absent. Treating "header missing" and "header empty" the same
+/// way is intentional — both leave validation with no positive
+/// information to act on, which is the failure case anyway.
+fn header_or_empty(headers : Map[String, String], key : String) -> String {
+  let lower_key = key.to_lower()
+  for k, v in headers {
+    if k.to_lower() == lower_key {
+      return v.trim().to_owned()
+    }
+  }
+  ""
+}
+
+///|
+/// Split a comma-separated header value into trimmed, non-empty tokens.
+/// E.g. `"GET, POST , "` → `["GET", "POST"]`. Caller is responsible
+/// for any case folding (preflight method names stay as-is; header
+/// names are lowercased upstream).
+pub fn parse_csv(value : String) -> Array[String] {
+  let out : Array[String] = []
+  for part in value.split(",") {
+    let token = part.trim(chars=" ").to_owned()
+    if token != "" {
+      out.push(token)
+    }
+  }
+  out
+}
+
+///|
 /// Return the prefix of `s` up to (but not including) the first
 /// character in `stops`. Returns `s` unchanged if no stop matches.
 fn truncate_at_any(s : String, stops : Array[Char]) -> String {

--- a/http/cors/cors.mbt
+++ b/http/cors/cors.mbt
@@ -229,6 +229,69 @@ pub fn validate_preflight_response(
 }
 
 ///|
+/// Validate the actual (non-OPTIONS) response from a cross-origin
+/// fetch against the CORS resource-sharing rules. Same-origin
+/// responses are always Ok; cross-origin responses must satisfy:
+///
+/// - `Access-Control-Allow-Origin` echoes `origin` exactly, or is
+///   `"*"` (only acceptable when credentials != Include).
+/// - When `credentials == Include`:
+///   - ACA-Origin must NOT be `"*"` (per Fetch spec: wildcard +
+///     credentials is a developer error and the response is blocked
+///     even if the browser already received it).
+///   - ACA-Origin must equal `origin` exactly.
+///   - `Access-Control-Allow-Credentials` must be the literal `"true"`
+///     (case-sensitive per spec).
+///
+/// Returns `Err(message)` describing the first failing check so the
+/// caller can surface a useful CORS error.
+pub fn validate_actual_response(
+  request_url~ : String,
+  origin~ : String,
+  credentials~ : @http_impl.CredentialsMode,
+  response~ : @http_impl.HttpResponse,
+) -> Result[Unit, String] {
+  if origin_of(request_url) == origin {
+    return Ok(())
+  }
+  let aco = header_or_empty(response.headers, "access-control-allow-origin")
+  match credentials {
+    Include => {
+      if aco == "*" {
+        return Err(
+          "Access-Control-Allow-Origin \"*\" is not allowed with credentials=Include",
+        )
+      }
+      if aco != origin {
+        return Err(
+          "Access-Control-Allow-Origin missing or mismatched: \"" + aco + "\"",
+        )
+      }
+      let acc = header_or_empty(
+        response.headers,
+        "access-control-allow-credentials",
+      )
+      if acc != "true" {
+        return Err(
+          "Access-Control-Allow-Credentials must be \"true\" with credentials=Include, got \"" +
+          acc +
+          "\"",
+        )
+      }
+      Ok(())
+    }
+    Omit | SameOrigin => {
+      if aco != origin && aco != "*" {
+        return Err(
+          "Access-Control-Allow-Origin missing or mismatched: \"" + aco + "\"",
+        )
+      }
+      Ok(())
+    }
+  }
+}
+
+///|
 /// Look up `key` in `headers` (case-insensitive: the response from a
 /// real fetch may use any casing). Returns the trimmed value, or `""`
 /// when absent. Treating "header missing" and "header empty" the same

--- a/http/cors/cors.mbt
+++ b/http/cors/cors.mbt
@@ -324,6 +324,145 @@ pub fn parse_csv(value : String) -> Array[String] {
 }
 
 ///|
+/// Memoized preflight: look up an entry for `request` in `self`, and
+/// either reuse it (when `expires_at_seconds` is still in the future
+/// relative to `now()`) or perform an OPTIONS roundtrip via `fetcher`
+/// and store a fresh entry.
+///
+/// On a cache hit we still re-check the cached entry against the
+/// current `request` (method + each request header must be in the
+/// allowed lists, accounting for `"*"`). A hit that fails this check
+/// is evicted and treated as a miss — that way a misconfigured server
+/// can recover after it updates its allow-lists without waiting for
+/// Max-Age to expire.
+///
+/// On a miss we delegate to `fetcher`, run the response through
+/// `validate_preflight_response`, and (on Ok) insert a new entry with
+/// `expires_at_seconds = now() + Access-Control-Max-Age`. Validation
+/// errors are propagated unchanged so the caller surfaces them.
+pub fn PreflightCache::get_or_validate(
+  self : PreflightCache,
+  request : PreflightRequest,
+  now : () -> Double,
+  fetcher : (PreflightRequest) -> @http_impl.HttpResponse,
+) -> Result[Unit, String] {
+  let key = cache_key(request)
+  let current = now()
+  if self.entries.get(key) is Some(entry) {
+    if entry.expires_at_seconds > current {
+      match validate_cached_entry(entry, request) {
+        Ok(_) => return Ok(())
+        Err(_) => self.entries.remove(key)
+      }
+    } else {
+      self.entries.remove(key)
+    }
+  }
+  let response = fetcher(request)
+  match validate_preflight_response(request, response) {
+    Err(e) => return Err(e)
+    Ok(_) => ()
+  }
+  let max_age = parse_double_default(
+    header_or_empty(response.headers, "access-control-max-age"),
+    0.0,
+  )
+  let allowed_methods = parse_csv(
+    header_or_empty(response.headers, "access-control-allow-methods"),
+  )
+  let allowed_headers = parse_csv(
+    header_or_empty(response.headers, "access-control-allow-headers"),
+  ).map(fn(s) { s.to_lower() })
+  let allow_credentials = header_or_empty(
+      response.headers,
+      "access-control-allow-credentials",
+    ) ==
+    "true"
+  self.entries[key] = PreflightEntry::{
+    allowed_methods,
+    allowed_headers,
+    allow_credentials,
+    expires_at_seconds: current + max_age,
+  }
+  Ok(())
+}
+
+///|
+/// Build a stable cache key for a preflight request.
+/// `request_headers` is already lowercased + sorted by
+/// `classify_request`, so the join is deterministic.
+fn cache_key(req : PreflightRequest) -> String {
+  req.origin +
+  "|" +
+  req.url +
+  "|" +
+  req.method +
+  "|" +
+  req.request_headers.join(",")
+}
+
+///|
+/// Re-check a cache hit against the current request. Mirrors the
+/// method / header subset of `validate_preflight_response`, but reads
+/// from the parsed `PreflightEntry` instead of HTTP headers.
+fn validate_cached_entry(
+  entry : PreflightEntry,
+  req : PreflightRequest,
+) -> Result[Unit, String] {
+  if !entry.allowed_methods.contains(req.method) &&
+    !entry.allowed_methods.contains("*") {
+    return Err("cached entry does not allow method " + req.method)
+  }
+  for h in req.request_headers {
+    if !entry.allowed_headers.contains(h) &&
+      !entry.allowed_headers.contains("*") {
+      return Err("cached entry does not allow header " + h)
+    }
+  }
+  Ok(())
+}
+
+///|
+/// Parse a numeric (integer or decimal) string to Double. Returns
+/// `default` on any malformed input — the spec treats unparseable
+/// Access-Control-Max-Age as if the header were absent, so callers
+/// pass `0.0` to force a fresh roundtrip on the next request.
+fn parse_double_default(s : String, default : Double) -> Double {
+  if s.length() == 0 {
+    return default
+  }
+  let mut int_part = 0.0
+  let mut frac_part = 0.0
+  let mut frac_div = 1.0
+  let mut seen_dot = false
+  let mut seen_digit = false
+  for i = 0; i < s.length(); i = i + 1 {
+    let c = s[i]
+    if c == '.' {
+      if seen_dot {
+        return default
+      }
+      seen_dot = true
+    } else if c >= '0' && c <= '9' {
+      let d = (c.to_int() - '0'.to_int()).to_double()
+      if seen_dot {
+        frac_div = frac_div * 10.0
+        frac_part = frac_part + d / frac_div
+      } else {
+        int_part = int_part * 10.0 + d
+      }
+      seen_digit = true
+    } else {
+      return default
+    }
+  }
+  if !seen_digit {
+    return default
+  }
+  int_part + frac_part
+}
+
+///|
 /// Return the prefix of `s` up to (but not including) the first
 /// character in `stops`. Returns `s` unchanged if no stop matches.
 fn truncate_at_any(s : String, stops : Array[Char]) -> String {

--- a/http/cors/cors_wbtest.mbt
+++ b/http/cors/cors_wbtest.mbt
@@ -146,3 +146,73 @@ test "validate_preflight_response: required method not listed → Err" {
     Ok(_) => fail("expected Err")
   }
 }
+
+///|
+test "validate_actual_response: same-origin always Ok regardless of headers" {
+  let resp = test_preflight_response(status=200)
+  match
+    validate_actual_response(
+      request_url="https://example.com/api/x",
+      origin="https://example.com",
+      credentials=@http_impl.CredentialsMode::Include,
+      response=resp,
+    ) {
+    Ok(_) => inspect(true, content="true")
+    Err(e) => fail("expected Ok, got Err: " + e)
+  }
+}
+
+///|
+test "validate_actual_response: cross-origin + ACA-Origin echo → Ok" {
+  let resp = test_preflight_response(
+    status=200,
+    aca_origin="https://example.com",
+  )
+  match
+    validate_actual_response(
+      request_url="https://api.other.com/x",
+      origin="https://example.com",
+      credentials=@http_impl.CredentialsMode::Omit,
+      response=resp,
+    ) {
+    Ok(_) => inspect(true, content="true")
+    Err(e) => fail("expected Ok, got Err: " + e)
+  }
+}
+
+///|
+test "validate_actual_response: credentials=Include with wildcard → Err" {
+  let resp = test_preflight_response(
+    status=200,
+    aca_origin="*",
+    aca_credentials="true",
+  )
+  match
+    validate_actual_response(
+      request_url="https://api.other.com/x",
+      origin="https://example.com",
+      credentials=@http_impl.CredentialsMode::Include,
+      response=resp,
+    ) {
+    Err(_) => inspect(true, content="true")
+    Ok(_) => fail("expected Err")
+  }
+}
+
+///|
+test "validate_actual_response: credentials=Include needs ACA-Credentials=true" {
+  let resp = test_preflight_response(
+    status=200,
+    aca_origin="https://example.com",
+  )
+  match
+    validate_actual_response(
+      request_url="https://api.other.com/x",
+      origin="https://example.com",
+      credentials=@http_impl.CredentialsMode::Include,
+      response=resp,
+    ) {
+    Err(_) => inspect(true, content="true")
+    Ok(_) => fail("expected Err")
+  }
+}

--- a/http/cors/cors_wbtest.mbt
+++ b/http/cors/cors_wbtest.mbt
@@ -216,3 +216,73 @@ test "validate_actual_response: credentials=Include needs ACA-Credentials=true" 
     Ok(_) => fail("expected Err")
   }
 }
+
+///|
+test "PreflightCache::get_or_validate: cache hit within Max-Age (fetcher called once)" {
+  let cache = PreflightCache::new()
+  let req = PreflightRequest::{
+    url: "https://api.other.com/x",
+    origin: "https://example.com",
+    method: "POST",
+    request_headers: ["content-type", "x-csrf"],
+  }
+  // Mutable counter via 1-element array (Ref not assumed available).
+  let calls : Array[Int] = [0]
+  let fetcher = fn(_r : PreflightRequest) -> @http_impl.HttpResponse {
+    calls[0] = calls[0] + 1
+    test_preflight_response(
+      status=204,
+      aca_origin="https://example.com",
+      aca_methods="POST",
+      aca_headers="content-type, x-csrf",
+      aca_max_age="600",
+    )
+  }
+  // Frozen clock; both calls happen at t=1000.0, well under 600s Max-Age.
+  let now = fn() -> Double { 1000.0 }
+  match cache.get_or_validate(req, now, fetcher) {
+    Ok(_) => inspect(true, content="true")
+    Err(e) => fail("first call expected Ok, got Err: " + e)
+  }
+  match cache.get_or_validate(req, now, fetcher) {
+    Ok(_) => inspect(true, content="true")
+    Err(e) => fail("second call expected Ok, got Err: " + e)
+  }
+  inspect(calls[0], content="1")
+}
+
+///|
+test "PreflightCache::get_or_validate: cache miss past Max-Age (fetcher called twice)" {
+  let cache = PreflightCache::new()
+  let req = PreflightRequest::{
+    url: "https://api.other.com/y",
+    origin: "https://example.com",
+    method: "PUT",
+    request_headers: ["x-token"],
+  }
+  let calls : Array[Int] = [0]
+  let fetcher = fn(_r : PreflightRequest) -> @http_impl.HttpResponse {
+    calls[0] = calls[0] + 1
+    test_preflight_response(
+      status=204,
+      aca_origin="https://example.com",
+      aca_methods="PUT",
+      aca_headers="x-token",
+      aca_max_age="60",
+    )
+  }
+  // Advance the clock past Max-Age between the two calls.
+  let clock : Array[Double] = [1000.0]
+  let now = fn() -> Double { clock[0] }
+  match cache.get_or_validate(req, now, fetcher) {
+    Ok(_) => inspect(true, content="true")
+    Err(e) => fail("first call expected Ok, got Err: " + e)
+  }
+  // 60s after first call → entry expires_at = 1060, now = 1100 ⇒ expired.
+  clock[0] = 1100.0
+  match cache.get_or_validate(req, now, fetcher) {
+    Ok(_) => inspect(true, content="true")
+    Err(e) => fail("second call expected Ok, got Err: " + e)
+  }
+  inspect(calls[0], content="2")
+}

--- a/http/cors/cors_wbtest.mbt
+++ b/http/cors/cors_wbtest.mbt
@@ -1,0 +1,57 @@
+///|
+test "classify_request: simple GET same-origin is Allow" {
+  let d = classify_request(
+    url="https://example.com/api/x",
+    origin="https://example.com",
+    mode=@http_impl.RequestMode::Cors,
+    method="GET",
+    headers={},
+  )
+  inspect(d, content="Allow")
+}
+
+///|
+test "classify_request: simple GET cross-origin is Allow (validate at response)" {
+  let d = classify_request(
+    url="https://api.other.com/x",
+    origin="https://example.com",
+    mode=@http_impl.RequestMode::Cors,
+    method="GET",
+    headers={},
+  )
+  inspect(d, content="Allow")
+}
+
+///|
+test "classify_request: POST cross-origin with custom header → PreflightRequired" {
+  let d = classify_request(
+    url="https://api.other.com/upload",
+    origin="https://example.com",
+    mode=@http_impl.RequestMode::Cors,
+    method="POST",
+    headers={ "X-Csrf": "tok", "Content-Type": "application/json" },
+  )
+  match d {
+    PreflightRequired(req) => {
+      inspect(req.url, content="https://api.other.com/upload")
+      inspect(req.method, content="POST")
+      inspect(req.request_headers, content="[x-csrf]")
+    }
+    _ => panic()
+  }
+}
+
+///|
+test "classify_request: NoCors + custom header → Blocked" {
+  let d = classify_request(
+    url="https://api.other.com/x",
+    origin="https://example.com",
+    mode=@http_impl.RequestMode::NoCors,
+    method="POST",
+    headers={ "X-Csrf": "tok" },
+  )
+  match d {
+    Blocked(_) => inspect(true, content="true")
+    _ => panic()
+  }
+}

--- a/http/cors/cors_wbtest.mbt
+++ b/http/cors/cors_wbtest.mbt
@@ -55,3 +55,94 @@ test "classify_request: NoCors + custom header → Blocked" {
     _ => panic()
   }
 }
+
+///|
+/// Build a synthetic preflight HttpResponse from optional ACA-* headers.
+/// All header names are written lowercased so the validator's lookup
+/// (which uses `get_header` semantics) finds them regardless of case.
+fn test_preflight_response(
+  status~ : Int,
+  aca_origin? : String,
+  aca_methods? : String,
+  aca_headers? : String,
+  aca_credentials? : String,
+  aca_max_age? : String,
+) -> @http_impl.HttpResponse {
+  let h : Map[String, String] = {}
+  if aca_origin is Some(v) {
+    h["access-control-allow-origin"] = v
+  }
+  if aca_methods is Some(v) {
+    h["access-control-allow-methods"] = v
+  }
+  if aca_headers is Some(v) {
+    h["access-control-allow-headers"] = v
+  }
+  if aca_credentials is Some(v) {
+    h["access-control-allow-credentials"] = v
+  }
+  if aca_max_age is Some(v) {
+    h["access-control-max-age"] = v
+  }
+  { status, headers: h, body: "" }
+}
+
+///|
+test "validate_preflight_response: all required headers present → Ok" {
+  let req = PreflightRequest::{
+    url: "https://api.other.com/x",
+    origin: "https://example.com",
+    method: "POST",
+    request_headers: ["content-type", "x-csrf"],
+  }
+  let resp = test_preflight_response(
+    status=204,
+    aca_origin="https://example.com",
+    aca_methods="POST",
+    aca_headers="content-type, x-csrf",
+    aca_credentials="true",
+    aca_max_age="600",
+  )
+  match validate_preflight_response(req, resp) {
+    Ok(_) => inspect(true, content="true")
+    Err(e) => fail("expected Ok, got Err: " + e)
+  }
+}
+
+///|
+test "validate_preflight_response: missing ACA-Origin → Err" {
+  let req = PreflightRequest::{
+    url: "https://api.other.com/x",
+    origin: "https://example.com",
+    method: "POST",
+    request_headers: ["content-type"],
+  }
+  let resp = test_preflight_response(
+    status=204,
+    aca_methods="POST",
+    aca_headers="content-type",
+  )
+  match validate_preflight_response(req, resp) {
+    Err(_) => inspect(true, content="true")
+    Ok(_) => fail("expected Err")
+  }
+}
+
+///|
+test "validate_preflight_response: required method not listed → Err" {
+  let req = PreflightRequest::{
+    url: "https://api.other.com/x",
+    origin: "https://example.com",
+    method: "DELETE",
+    request_headers: [],
+  }
+  let resp = test_preflight_response(
+    status=204,
+    aca_origin="https://example.com",
+    aca_methods="GET, POST",
+  )
+  match validate_preflight_response(req, resp) {
+    Err(_) => inspect(true, content="true")
+    Ok(_) => fail("expected Err")
+  }
+}

--- a/http/cors/cors_wbtest.mbt
+++ b/http/cors/cors_wbtest.mbt
@@ -252,6 +252,20 @@ test "PreflightCache::get_or_validate: cache hit within Max-Age (fetcher called 
 }
 
 ///|
+test "HttpError carries CorsBlocked variant" {
+  let e : @http_impl.HttpError = @http_impl.HttpError::CorsBlocked("test")
+  inspect(e, content="CorsBlocked(test)")
+}
+
+///|
+test "HttpError carries PreflightFailed variant" {
+  let e : @http_impl.HttpError = @http_impl.HttpError::PreflightFailed(
+    "missing ACA-Origin",
+  )
+  inspect(e, content="PreflightFailed(missing ACA-Origin)")
+}
+
+///|
 test "PreflightCache::get_or_validate: cache miss past Max-Age (fetcher called twice)" {
   let cache = PreflightCache::new()
   let req = PreflightRequest::{

--- a/http/cors/moon.pkg
+++ b/http/cors/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "mizchi/crater-browser-http" @http_impl,
+  "moonbitlang/core/string",
+  "moonbitlang/core/double",
+}
+
+warnings = "-unused_package"
+
+supported_targets = "js+native+wasm+wasm-gc"

--- a/http/cors/pkg.generated.mbti
+++ b/http/cors/pkg.generated.mbti
@@ -14,6 +14,10 @@ pub fn is_simple_method(String) -> Bool
 
 pub fn origin_of(String) -> String
 
+pub fn parse_csv(String) -> Array[String]
+
+pub fn validate_preflight_response(PreflightRequest, @crater-browser-http.HttpResponse) -> Result[Unit, String]
+
 // Errors
 
 // Types and methods

--- a/http/cors/pkg.generated.mbti
+++ b/http/cors/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub impl Show for CorsDecision
 pub struct PreflightCache {
   entries : Map[String, PreflightEntry]
 }
+pub fn PreflightCache::get_or_validate(Self, PreflightRequest, () -> Double, (PreflightRequest) -> @crater-browser-http.HttpResponse) -> Result[Unit, String]
 pub fn PreflightCache::new() -> Self
 
 pub(all) struct PreflightEntry {

--- a/http/cors/pkg.generated.mbti
+++ b/http/cors/pkg.generated.mbti
@@ -1,0 +1,50 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "mizchi/crater-browser-http/cors"
+
+import {
+  "mizchi/crater-browser-http",
+}
+
+// Values
+pub fn classify_request(url~ : String, origin~ : String, mode~ : @crater-browser-http.RequestMode, method~ : String, headers~ : Map[String, String]) -> CorsDecision
+
+pub fn is_safelisted_header(String) -> Bool
+
+pub fn is_simple_method(String) -> Bool
+
+pub fn origin_of(String) -> String
+
+// Errors
+
+// Types and methods
+pub(all) enum CorsDecision {
+  Allow
+  PreflightRequired(PreflightRequest)
+  Blocked(String)
+}
+pub impl Show for CorsDecision
+
+pub struct PreflightCache {
+  entries : Map[String, PreflightEntry]
+}
+pub fn PreflightCache::new() -> Self
+
+pub(all) struct PreflightEntry {
+  allowed_methods : Array[String]
+  allowed_headers : Array[String]
+  allow_credentials : Bool
+  expires_at_seconds : Double
+}
+
+pub(all) struct PreflightRequest {
+  url : String
+  origin : String
+  method : String
+  request_headers : Array[String]
+}
+pub impl Show for PreflightRequest
+
+// Type aliases
+
+// Traits
+

--- a/http/cors/pkg.generated.mbti
+++ b/http/cors/pkg.generated.mbti
@@ -16,6 +16,8 @@ pub fn origin_of(String) -> String
 
 pub fn parse_csv(String) -> Array[String]
 
+pub fn validate_actual_response(request_url~ : String, origin~ : String, credentials~ : @crater-browser-http.CredentialsMode, response~ : @crater-browser-http.HttpResponse) -> Result[Unit, String]
+
 pub fn validate_preflight_response(PreflightRequest, @crater-browser-http.HttpResponse) -> Result[Unit, String]
 
 // Errors

--- a/http/http.mbt
+++ b/http/http.mbt
@@ -15,6 +15,8 @@ pub(all) suberror HttpError {
   TimeoutError
   CorsError(String)
   SandboxError(String)
+  CorsBlocked(String)
+  PreflightFailed(String)
 }
 
 ///|
@@ -25,6 +27,8 @@ pub impl Show for HttpError with output(self, logger) {
     TimeoutError => logger.write_string("TimeoutError")
     CorsError(msg) => logger.write_string("CorsError: " + msg)
     SandboxError(msg) => logger.write_string("SandboxError: " + msg)
+    CorsBlocked(msg) => logger.write_string("CorsBlocked(" + msg + ")")
+    PreflightFailed(msg) => logger.write_string("PreflightFailed(" + msg + ")")
   }
 }
 

--- a/http/pkg.generated.mbti
+++ b/http/pkg.generated.mbti
@@ -21,6 +21,8 @@ pub(all) suberror HttpError {
   TimeoutError
   CorsError(String)
   SandboxError(String)
+  CorsBlocked(String)
+  PreflightFailed(String)
 }
 pub impl Show for HttpError
 

--- a/http/profile/auth.mbt
+++ b/http/profile/auth.mbt
@@ -1,0 +1,14 @@
+///|
+/// Placeholder for HTTP auth credentials carried by a Profile.
+/// P1: empty. Future expansion: basic_credentials, bearer_tokens.
+pub(all) struct AuthState {} derive(Debug)
+
+///|
+pub impl Show for AuthState with output(_self, logger) {
+  logger.write_string("{}")
+}
+
+///|
+pub fn AuthState::default() -> AuthState {
+  AuthState::{  }
+}

--- a/http/profile/moon.pkg
+++ b/http/profile/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "mizchi/crater-browser-http/cookie_jar" @cookie_jar,
+  "mizchi/crater-browser-http/cache" @cache,
+}
+
+warnings = "-unused_package"
+
+supported_targets = "js+native+wasm+wasm-gc"

--- a/http/profile/moon.pkg
+++ b/http/profile/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "mizchi/crater-browser-http/cookie_jar" @cookie_jar,
   "mizchi/crater-browser-http/cache" @cache,
+  "mizchi/crater-browser-http/cors" @cors,
 }
 
 warnings = "-unused_package"

--- a/http/profile/pkg.generated.mbti
+++ b/http/profile/pkg.generated.mbti
@@ -19,7 +19,7 @@ pub impl Show for AuthState
 
 pub(all) struct Profile {
   mut user_agent : String?
-  cookie_jar : @cookie_jar.CookieJar
+  mut cookie_jar : @cookie_jar.CookieJar
   http_cache : @cache.MemoryCacheBackend
   auth_state : AuthState
 }

--- a/http/profile/pkg.generated.mbti
+++ b/http/profile/pkg.generated.mbti
@@ -1,0 +1,33 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "mizchi/crater-browser-http/profile"
+
+import {
+  "mizchi/crater-browser-http/cache",
+  "mizchi/crater-browser-http/cookie_jar",
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct AuthState {
+} derive(@debug.Debug)
+pub fn AuthState::default() -> Self
+pub impl Show for AuthState
+
+pub(all) struct Profile {
+  mut user_agent : String?
+  cookie_jar : @cookie_jar.CookieJar
+  http_cache : @cache.MemoryCacheBackend
+  auth_state : AuthState
+}
+pub fn Profile::default() -> Self
+pub fn Profile::effective_user_agent(Self) -> String?
+pub fn Profile::new(user_agent? : String, jar_enabled? : Bool) -> Self
+
+// Type aliases
+
+// Traits
+

--- a/http/profile/pkg.generated.mbti
+++ b/http/profile/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "mizchi/crater-browser-http/profile"
 import {
   "mizchi/crater-browser-http/cache",
   "mizchi/crater-browser-http/cookie_jar",
+  "mizchi/crater-browser-http/cors",
   "moonbitlang/core/debug",
 }
 
@@ -22,6 +23,7 @@ pub(all) struct Profile {
   mut cookie_jar : @cookie_jar.CookieJar
   http_cache : @cache.MemoryCacheBackend
   auth_state : AuthState
+  preflight_cache : @cors.PreflightCache
 }
 pub fn Profile::default() -> Self
 pub fn Profile::effective_user_agent(Self) -> String?

--- a/http/profile/profile.mbt
+++ b/http/profile/profile.mbt
@@ -9,6 +9,7 @@ pub(all) struct Profile {
   mut cookie_jar : @cookie_jar.CookieJar
   http_cache : @cache.MemoryCacheBackend
   auth_state : AuthState
+  preflight_cache : @cors.PreflightCache
 }
 
 ///|
@@ -19,6 +20,7 @@ pub fn Profile::default() -> Profile {
     cookie_jar: @cookie_jar.CookieJar::new(enabled=true),
     http_cache: @cache.MemoryCacheBackend::new(max_entries=1000),
     auth_state: AuthState::default(),
+    preflight_cache: @cors.PreflightCache::new(),
   }
 }
 
@@ -35,6 +37,7 @@ pub fn Profile::new(
     cookie_jar: @cookie_jar.CookieJar::new(enabled=jar_enabled),
     http_cache: @cache.MemoryCacheBackend::new(max_entries=1000),
     auth_state: AuthState::default(),
+    preflight_cache: @cors.PreflightCache::new(),
   }
 }
 

--- a/http/profile/profile.mbt
+++ b/http/profile/profile.mbt
@@ -1,0 +1,47 @@
+///|
+/// Per-session bag of user-agent override, cookie jar, HTTP cache, and
+/// auth state. Bundled so layers above can pass a single Profile value
+/// instead of threading each field separately. P1 keeps the Profile
+/// single per BrowserState; per-userContext partitioning is a P2
+/// scenario.
+pub(all) struct Profile {
+  mut user_agent : String?
+  cookie_jar : @cookie_jar.CookieJar
+  http_cache : @cache.MemoryCacheBackend
+  auth_state : AuthState
+}
+
+///|
+/// Default Profile: jar enabled, no UA override, fresh in-memory cache.
+pub fn Profile::default() -> Profile {
+  Profile::{
+    user_agent: None,
+    cookie_jar: @cookie_jar.CookieJar::new(enabled=true),
+    http_cache: @cache.MemoryCacheBackend::new(max_entries=1000),
+    auth_state: AuthState::default(),
+  }
+}
+
+///|
+/// Construct a Profile with explicit overrides. WebDriver sessions
+/// use this with `jar_enabled=true` (the default) so login flows
+/// work without the operator having to opt in.
+pub fn Profile::new(
+  user_agent? : String,
+  jar_enabled~ : Bool = true,
+) -> Profile {
+  Profile::{
+    user_agent,
+    cookie_jar: @cookie_jar.CookieJar::new(enabled=jar_enabled),
+    http_cache: @cache.MemoryCacheBackend::new(max_entries=1000),
+    auth_state: AuthState::default(),
+  }
+}
+
+///|
+/// Returns the override string when set, else None — the caller
+/// (typically the WebDriver emulation layer) decides what to fall back
+/// to so this sub-package stays free of webdriver-side dependencies.
+pub fn Profile::effective_user_agent(self : Profile) -> String? {
+  self.user_agent
+}

--- a/http/profile/profile.mbt
+++ b/http/profile/profile.mbt
@@ -6,7 +6,7 @@
 /// scenario.
 pub(all) struct Profile {
   mut user_agent : String?
-  cookie_jar : @cookie_jar.CookieJar
+  mut cookie_jar : @cookie_jar.CookieJar
   http_cache : @cache.MemoryCacheBackend
   auth_state : AuthState
 }
@@ -28,7 +28,7 @@ pub fn Profile::default() -> Profile {
 /// work without the operator having to opt in.
 pub fn Profile::new(
   user_agent? : String,
-  jar_enabled~ : Bool = true,
+  jar_enabled? : Bool = true,
 ) -> Profile {
   Profile::{
     user_agent,

--- a/http/profile/profile_wbtest.mbt
+++ b/http/profile/profile_wbtest.mbt
@@ -1,0 +1,7 @@
+///|
+test "AuthState::default is empty" {
+  let state = AuthState::default()
+  inspect(state, content=(
+    #|{}
+  ))
+}

--- a/http/profile/profile_wbtest.mbt
+++ b/http/profile/profile_wbtest.mbt
@@ -1,9 +1,12 @@
 ///|
 test "AuthState::default is empty" {
   let state = AuthState::default()
-  inspect(state, content=(
-    #|{}
-  ))
+  inspect(
+    state,
+    content=(
+      #|{}
+    ),
+  )
 }
 
 ///|
@@ -12,9 +15,7 @@ test "Profile::default has jar enabled and no UA override" {
   inspect(p.user_agent, content="None")
   // Verify jar is enabled: store a cookie and check size > 0
   p.cookie_jar.store_from_header(
-    "Set-Cookie: test=1; Path=/",
-    "example.com",
-    false,
+    "Set-Cookie: test=1; Path=/", "example.com", false,
   )
   inspect(p.cookie_jar.size() > 0, content="true")
 }
@@ -24,9 +25,7 @@ test "Profile::new(jar_enabled=false) yields disabled jar" {
   let p = Profile::new(jar_enabled=false)
   // Verify jar is disabled: store attempt is no-op, size stays 0
   p.cookie_jar.store_from_header(
-    "Set-Cookie: test=1; Path=/",
-    "example.com",
-    false,
+    "Set-Cookie: test=1; Path=/", "example.com", false,
   )
   inspect(p.cookie_jar.size(), content="0")
 }

--- a/http/profile/profile_wbtest.mbt
+++ b/http/profile/profile_wbtest.mbt
@@ -5,3 +5,42 @@ test "AuthState::default is empty" {
     #|{}
   ))
 }
+
+///|
+test "Profile::default has jar enabled and no UA override" {
+  let p = Profile::default()
+  inspect(p.user_agent, content="None")
+  // Verify jar is enabled: store a cookie and check size > 0
+  p.cookie_jar.store_from_header(
+    "Set-Cookie: test=1; Path=/",
+    "example.com",
+    false,
+  )
+  inspect(p.cookie_jar.size() > 0, content="true")
+}
+
+///|
+test "Profile::new(jar_enabled=false) yields disabled jar" {
+  let p = Profile::new(jar_enabled=false)
+  // Verify jar is disabled: store attempt is no-op, size stays 0
+  p.cookie_jar.store_from_header(
+    "Set-Cookie: test=1; Path=/",
+    "example.com",
+    false,
+  )
+  inspect(p.cookie_jar.size(), content="0")
+}
+
+///|
+test "Profile::new(user_agent=Some(...)) is reflected" {
+  let p = Profile::new(user_agent="UA/1.0")
+  inspect(p.user_agent, content="Some(UA/1.0)")
+}
+
+///|
+test "effective_user_agent returns set UA, else None-passthrough" {
+  let with_ua = Profile::new(user_agent="UA/2.0")
+  inspect(with_ua.effective_user_agent(), content="Some(UA/2.0)")
+  let without = Profile::default()
+  inspect(without.effective_user_agent(), content="None")
+}

--- a/http/samesite/moon.pkg
+++ b/http/samesite/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "moonbitlang/core/string",
+}
+
+warnings = "-unused_package"
+
+supported_targets = "js+native+wasm+wasm-gc"

--- a/http/samesite/moon.pkg
+++ b/http/samesite/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/string",
+  "mizchi/crater-browser-http/cookie_jar" @cookie_jar,
 }
 
 warnings = "-unused_package"

--- a/http/samesite/pkg.generated.mbti
+++ b/http/samesite/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 // Values
 pub fn classify_site_context(String, String) -> SiteContext
 
-pub fn should_attach_cookie(@cookie_jar.ParsedCookie, String, SiteContext, Bool) -> Bool
+pub fn should_attach_cookie(@cookie_jar.ParsedCookie, SiteContext, Bool) -> Bool
 
 // Errors
 

--- a/http/samesite/pkg.generated.mbti
+++ b/http/samesite/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "mizchi/crater-browser-http/samesite"
+
+// Values
+pub fn classify_site_context(String, String) -> SiteContext
+
+// Errors
+
+// Types and methods
+pub(all) enum SiteContext {
+  SameSite
+  CrossSite
+} derive(Eq)
+pub impl Show for SiteContext
+
+// Type aliases
+
+// Traits
+

--- a/http/samesite/pkg.generated.mbti
+++ b/http/samesite/pkg.generated.mbti
@@ -1,8 +1,14 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "mizchi/crater-browser-http/samesite"
 
+import {
+  "mizchi/crater-browser-http/cookie_jar",
+}
+
 // Values
 pub fn classify_site_context(String, String) -> SiteContext
+
+pub fn should_attach_cookie(@cookie_jar.ParsedCookie, String, SiteContext, Bool) -> Bool
 
 // Errors
 

--- a/http/samesite/samesite.mbt
+++ b/http/samesite/samesite.mbt
@@ -65,6 +65,13 @@ fn parse_host(origin : String) -> String? {
   if host == "" {
     return None
   }
+  // Strip a single trailing dot — FQDN forms like "example.com." are
+  // equivalent to "example.com" for site comparison.
+  let host = if host.has_suffix(".") && host.length() > 1 {
+    host.unsafe_substring(start=0, end=host.length() - 1)
+  } else {
+    host
+  }
   Some(host)
 }
 
@@ -89,6 +96,13 @@ fn truncate_at_any(s : String, stops : Array[Char]) -> String {
 /// "last two labels" heuristic. localhost and IP literals are returned
 /// as-is so they only match themselves.
 fn registrable_domain(host : String) -> String {
+  // Strip a single trailing dot — FQDN forms like "example.com." are
+  // equivalent to "example.com" for site comparison.
+  let host = if host.has_suffix(".") && host.length() > 1 {
+    host.unsafe_substring(start=0, end=host.length() - 1)
+  } else {
+    host
+  }
   if host == "localhost" || is_ip_literal(host) {
     return host
   }
@@ -105,6 +119,11 @@ fn registrable_domain(host : String) -> String {
 ///|
 /// IPv4 dotted-quad heuristic plus IPv6 bracketed form. Conservative:
 /// any host that "looks like" an IP is treated as its own site.
+///
+/// Note: octet-range validation (0–255) is deliberately skipped.
+/// Because IP-ish strings only ever match themselves, false positives
+/// (e.g. "999.999.999.999") are safe — they simply won't match any
+/// other host.
 fn is_ip_literal(host : String) -> Bool {
   if host.has_prefix("[") && host.has_suffix("]") {
     return true

--- a/http/samesite/samesite.mbt
+++ b/http/samesite/samesite.mbt
@@ -117,6 +117,52 @@ fn registrable_domain(host : String) -> String {
 }
 
 ///|
+/// Decide whether `cookie` should be attached to a request for
+/// `request_url`, given the precomputed `site_context` (cookie domain vs
+/// request origin) and whether the request is a top-level navigation.
+///
+/// Implements the WHATWG cookies-bis SameSite attach filter:
+///
+/// - `Strict`: attach only when same-site (regardless of navigation kind).
+/// - `Lax`: attach when same-site; for cross-site, attach only on a
+///   top-level navigation (e.g. clicking a link).
+/// - `None` / unspecified: always attach. (Note: SameSite=None requires
+///   the Secure attribute, but that's enforced at parse / store time, not
+///   here — by the time a cookie is in the jar, the Secure check has
+///   already passed.)
+///
+/// `request_url` is currently accepted for API symmetry with the call
+/// sites (navigation_fetch / script_fetch) and ignored — the site
+/// classification has already been folded into `site_context`. Kept in
+/// the signature so callers don't have to thread two related-but-not-
+/// quite-same values.
+pub fn should_attach_cookie(
+  cookie : @cookie_jar.ParsedCookie,
+  request_url : String,
+  site_context : SiteContext,
+  is_top_level_navigation : Bool,
+) -> Bool {
+  let _ = request_url
+  // ParsedCookie stores SameSite as a lowercased string ("strict" / "lax"
+  // / "none" / ""). Unknown / empty values are treated as Lax per
+  // RFC 6265bis "Lax by default".
+  match cookie.same_site {
+    "strict" =>
+      match site_context {
+        SameSite => true
+        CrossSite => false
+      }
+    "none" => true
+    // "lax" and the empty / unknown default
+    _ =>
+      match site_context {
+        SameSite => true
+        CrossSite => is_top_level_navigation
+      }
+  }
+}
+
+///|
 /// IPv4 dotted-quad heuristic plus IPv6 bracketed form. Conservative:
 /// any host that "looks like" an IP is treated as its own site.
 ///

--- a/http/samesite/samesite.mbt
+++ b/http/samesite/samesite.mbt
@@ -1,0 +1,130 @@
+///|
+/// Whether a request origin and a cookie domain live on the same site
+/// (same registrable domain, a.k.a. eTLD+1). Used to decide SameSite
+/// cookie attach.
+pub(all) enum SiteContext {
+  SameSite
+  CrossSite
+} derive(Eq)
+
+///|
+pub impl Show for SiteContext with output(self, logger) {
+  match self {
+    SameSite => logger.write_string("SameSite")
+    CrossSite => logger.write_string("CrossSite")
+  }
+}
+
+///|
+/// Conservative eTLD+1 extractor. P1 uses a hard-coded "second-to-last
+/// label" heuristic: it correctly handles example.com / *.example.com
+/// vs unrelated.com, treats localhost / IP literals as their own site,
+/// and falls back to CrossSite on parse failure so we never over-attach.
+///
+/// Limitation: not Public Suffix List-aware. `example.co.uk` and
+/// `other.co.uk` would both reduce to `co.uk` and be treated as
+/// same-site. Acceptable for P1 fixture testing; PSL upgrade is tracked
+/// as a separate scenario.
+pub fn classify_site_context(
+  request_origin : String,
+  cookie_domain : String,
+) -> SiteContext {
+  match parse_host(request_origin) {
+    None => CrossSite
+    Some(req_host) => {
+      let req_site = registrable_domain(req_host)
+      let cookie_site = registrable_domain(cookie_domain)
+      if req_site == cookie_site {
+        SameSite
+      } else {
+        CrossSite
+      }
+    }
+  }
+}
+
+///|
+/// Extract the host portion of `scheme://host[:port][/path][?q][#f]`.
+/// Returns None if the input does not contain `://` or yields an empty
+/// host — both are treated as malformed and fall back to CrossSite by
+/// the caller.
+fn parse_host(origin : String) -> String? {
+  // strip scheme
+  let after_scheme = match origin.find("://") {
+    Some(i) => origin.unsafe_substring(start=i + 3, end=origin.length())
+    None => return None
+  }
+  // strip path / query / fragment by truncating at the first occurrence
+  // of any of '/', '?', '#'
+  let host_port = truncate_at_any(after_scheme, ['/', '?', '#'])
+  if host_port == "" {
+    return None
+  }
+  // strip port (use the part before the first ':')
+  let host = truncate_at_any(host_port, [':'])
+  if host == "" {
+    return None
+  }
+  Some(host)
+}
+
+///|
+/// Return the prefix of `s` up to (but not including) the first
+/// occurrence of any character in `stops`. If no stop char is present,
+/// returns `s` unchanged.
+fn truncate_at_any(s : String, stops : Array[Char]) -> String {
+  let chars = s.to_array()
+  let mut end = chars.length()
+  for i = 0; i < chars.length(); i = i + 1 {
+    if stops.contains(chars[i]) {
+      end = i
+      break
+    }
+  }
+  s.unsafe_substring(start=0, end~)
+}
+
+///|
+/// Reduce a host to its registrable domain ("eTLD+1") via the simple
+/// "last two labels" heuristic. localhost and IP literals are returned
+/// as-is so they only match themselves.
+fn registrable_domain(host : String) -> String {
+  if host == "localhost" || is_ip_literal(host) {
+    return host
+  }
+  let labels : Array[StringView] = host.split(".").collect()
+  let n = labels.length()
+  if n <= 2 {
+    return host
+  }
+  // last two labels: works for .com / .net / etc.; not PSL-aware but
+  // sufficient for fixture testing — PSL upgrade is a separate scenario.
+  labels[n - 2].to_owned() + "." + labels[n - 1].to_owned()
+}
+
+///|
+/// IPv4 dotted-quad heuristic plus IPv6 bracketed form. Conservative:
+/// any host that "looks like" an IP is treated as its own site.
+fn is_ip_literal(host : String) -> Bool {
+  if host.has_prefix("[") && host.has_suffix("]") {
+    return true
+  }
+  let parts : Array[StringView] = host.split(".").collect()
+  if parts.length() != 4 {
+    return false
+  }
+  for part in parts {
+    let s = part.to_owned()
+    if s == "" || s.length() > 3 {
+      return false
+    }
+    let chars = s.to_array()
+    for i = 0; i < chars.length(); i = i + 1 {
+      let c = chars[i]
+      if c < '0' || c > '9' {
+        return false
+      }
+    }
+  }
+  true
+}

--- a/http/samesite/samesite.mbt
+++ b/http/samesite/samesite.mbt
@@ -117,9 +117,9 @@ fn registrable_domain(host : String) -> String {
 }
 
 ///|
-/// Decide whether `cookie` should be attached to a request for
-/// `request_url`, given the precomputed `site_context` (cookie domain vs
-/// request origin) and whether the request is a top-level navigation.
+/// Decide whether `cookie` should be attached to a request, given the
+/// precomputed `site_context` (cookie domain vs request origin) and
+/// whether the request is a top-level navigation.
 ///
 /// Implements the WHATWG cookies-bis SameSite attach filter:
 ///
@@ -130,19 +130,12 @@ fn registrable_domain(host : String) -> String {
 ///   the Secure attribute, but that's enforced at parse / store time, not
 ///   here — by the time a cookie is in the jar, the Secure check has
 ///   already passed.)
-///
-/// `request_url` is currently accepted for API symmetry with the call
-/// sites (navigation_fetch / script_fetch) and ignored — the site
-/// classification has already been folded into `site_context`. Kept in
-/// the signature so callers don't have to thread two related-but-not-
-/// quite-same values.
+/// - Unknown values default to Lax per RFC 6265bis.
 pub fn should_attach_cookie(
   cookie : @cookie_jar.ParsedCookie,
-  request_url : String,
   site_context : SiteContext,
   is_top_level_navigation : Bool,
 ) -> Bool {
-  let _ = request_url
   // ParsedCookie stores SameSite as a lowercased string ("strict" / "lax"
   // / "none" / ""). Unknown / empty values are treated as Lax per
   // RFC 6265bis "Lax by default".

--- a/http/samesite/samesite_wbtest.mbt
+++ b/http/samesite/samesite_wbtest.mbt
@@ -70,73 +70,37 @@ fn test_cookie(
 test "should_attach_cookie: Strict only attaches when same-site" {
   let cookie = test_cookie("s", "Strict", false)
   // same-site, top-level nav
-  inspect(
-    should_attach_cookie(cookie, "https://example.com/x", SameSite, true),
-    content="true",
-  )
+  inspect(should_attach_cookie(cookie, SameSite, true), content="true")
   // same-site, subresource
-  inspect(
-    should_attach_cookie(cookie, "https://example.com/x", SameSite, false),
-    content="true",
-  )
+  inspect(should_attach_cookie(cookie, SameSite, false), content="true")
   // cross-site, top-level nav
-  inspect(
-    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, true),
-    content="false",
-  )
+  inspect(should_attach_cookie(cookie, CrossSite, true), content="false")
   // cross-site, subresource
-  inspect(
-    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, false),
-    content="false",
-  )
+  inspect(should_attach_cookie(cookie, CrossSite, false), content="false")
 }
 
 ///|
 test "should_attach_cookie: Lax attaches on cross-site top-level nav" {
   let cookie = test_cookie("l", "Lax", false)
   // same-site, top-level nav
-  inspect(
-    should_attach_cookie(cookie, "https://example.com/x", SameSite, true),
-    content="true",
-  )
+  inspect(should_attach_cookie(cookie, SameSite, true), content="true")
   // same-site, subresource
-  inspect(
-    should_attach_cookie(cookie, "https://example.com/x", SameSite, false),
-    content="true",
-  )
+  inspect(should_attach_cookie(cookie, SameSite, false), content="true")
   // cross-site, top-level nav
-  inspect(
-    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, true),
-    content="true",
-  )
+  inspect(should_attach_cookie(cookie, CrossSite, true), content="true")
   // cross-site, subresource
-  inspect(
-    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, false),
-    content="false",
-  )
+  inspect(should_attach_cookie(cookie, CrossSite, false), content="false")
 }
 
 ///|
 test "should_attach_cookie: None always attaches" {
   let cookie = test_cookie("n", "None", true)
   // same-site, top-level nav
-  inspect(
-    should_attach_cookie(cookie, "https://example.com/x", SameSite, true),
-    content="true",
-  )
+  inspect(should_attach_cookie(cookie, SameSite, true), content="true")
   // same-site, subresource
-  inspect(
-    should_attach_cookie(cookie, "https://example.com/x", SameSite, false),
-    content="true",
-  )
+  inspect(should_attach_cookie(cookie, SameSite, false), content="true")
   // cross-site, top-level nav
-  inspect(
-    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, true),
-    content="true",
-  )
+  inspect(should_attach_cookie(cookie, CrossSite, true), content="true")
   // cross-site, subresource
-  inspect(
-    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, false),
-    content="true",
-  )
+  inspect(should_attach_cookie(cookie, CrossSite, false), content="true")
 }

--- a/http/samesite/samesite_wbtest.mbt
+++ b/http/samesite/samesite_wbtest.mbt
@@ -37,3 +37,15 @@ test "classify_site_context: malformed origin falls back to CrossSite" {
     content="CrossSite",
   )
 }
+
+///|
+test "classify_site_context: trailing-dot FQDN matches non-dotted form" {
+  inspect(
+    classify_site_context("https://app.example.com.", "example.com"),
+    content="SameSite",
+  )
+  inspect(
+    classify_site_context("https://app.example.com", "example.com."),
+    content="SameSite",
+  )
+}

--- a/http/samesite/samesite_wbtest.mbt
+++ b/http/samesite/samesite_wbtest.mbt
@@ -1,0 +1,39 @@
+///|
+test "classify_site_context: same eTLD+1 is SameSite" {
+  inspect(
+    classify_site_context("https://app.example.com", "example.com"),
+    content="SameSite",
+  )
+}
+
+///|
+test "classify_site_context: different site is CrossSite" {
+  inspect(
+    classify_site_context("https://app.example.com", "evil.com"),
+    content="CrossSite",
+  )
+}
+
+///|
+test "classify_site_context: localhost is SameSite to itself" {
+  inspect(
+    classify_site_context("http://localhost:3000", "localhost"),
+    content="SameSite",
+  )
+}
+
+///|
+test "classify_site_context: IP literal matches itself" {
+  inspect(
+    classify_site_context("http://127.0.0.1", "127.0.0.1"),
+    content="SameSite",
+  )
+}
+
+///|
+test "classify_site_context: malformed origin falls back to CrossSite" {
+  inspect(
+    classify_site_context("not-a-url", "example.com"),
+    content="CrossSite",
+  )
+}

--- a/http/samesite/samesite_wbtest.mbt
+++ b/http/samesite/samesite_wbtest.mbt
@@ -49,3 +49,94 @@ test "classify_site_context: trailing-dot FQDN matches non-dotted form" {
     content="SameSite",
   )
 }
+
+///|
+/// Build a ParsedCookie via the real Set-Cookie parser so tests exercise
+/// the public surface rather than a private constructor.
+fn test_cookie(
+  name : String,
+  same_site_attr : String,
+  secure : Bool,
+) -> @cookie_jar.ParsedCookie {
+  let secure_attr = if secure { "; Secure" } else { "" }
+  let header = name + "=v; Path=/; SameSite=" + same_site_attr + secure_attr
+  match @cookie_jar.parse_set_cookie(header, "example.com", "/") {
+    Some(c) => c
+    None => panic()
+  }
+}
+
+///|
+test "should_attach_cookie: Strict only attaches when same-site" {
+  let cookie = test_cookie("s", "Strict", false)
+  // same-site, top-level nav
+  inspect(
+    should_attach_cookie(cookie, "https://example.com/x", SameSite, true),
+    content="true",
+  )
+  // same-site, subresource
+  inspect(
+    should_attach_cookie(cookie, "https://example.com/x", SameSite, false),
+    content="true",
+  )
+  // cross-site, top-level nav
+  inspect(
+    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, true),
+    content="false",
+  )
+  // cross-site, subresource
+  inspect(
+    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, false),
+    content="false",
+  )
+}
+
+///|
+test "should_attach_cookie: Lax attaches on cross-site top-level nav" {
+  let cookie = test_cookie("l", "Lax", false)
+  // same-site, top-level nav
+  inspect(
+    should_attach_cookie(cookie, "https://example.com/x", SameSite, true),
+    content="true",
+  )
+  // same-site, subresource
+  inspect(
+    should_attach_cookie(cookie, "https://example.com/x", SameSite, false),
+    content="true",
+  )
+  // cross-site, top-level nav
+  inspect(
+    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, true),
+    content="true",
+  )
+  // cross-site, subresource
+  inspect(
+    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, false),
+    content="false",
+  )
+}
+
+///|
+test "should_attach_cookie: None always attaches" {
+  let cookie = test_cookie("n", "None", true)
+  // same-site, top-level nav
+  inspect(
+    should_attach_cookie(cookie, "https://example.com/x", SameSite, true),
+    content="true",
+  )
+  // same-site, subresource
+  inspect(
+    should_attach_cookie(cookie, "https://example.com/x", SameSite, false),
+    content="true",
+  )
+  // cross-site, top-level nav
+  inspect(
+    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, true),
+    content="true",
+  )
+  // cross-site, subresource
+  inspect(
+    should_attach_cookie(cookie, "https://evil.com/x", CrossSite, false),
+    content="true",
+  )
+}

--- a/painter/paint/glyph/provider_wbtest.mbt
+++ b/painter/paint/glyph/provider_wbtest.mbt
@@ -3,9 +3,7 @@
 /// Implements: paint.font-weight-numeric (GitHub issue #48).
 
 ///|
-fn recording_provider_by_weight(
-  recorded : Ref[Double],
-) -> GlyphProvider {
+fn recording_provider_by_weight(recorded : Ref[Double]) -> GlyphProvider {
   {
     get_glyph: fn(_codepoint, _font_size, _is_bold) {
       (([] : Array[@svg.PathCommand]), 4.0)
@@ -67,9 +65,7 @@ test "glyph_from_provider forwards numeric font_weight 400 distinctly from 700" 
 }
 
 ///|
-fn legacy_bold_provider(
-  recorded_bold : Ref[Bool],
-) -> GlyphProvider {
+fn legacy_bold_provider(recorded_bold : Ref[Bool]) -> GlyphProvider {
   {
     get_glyph: fn(_codepoint, _font_size, is_bold) {
       recorded_bold.val = is_bold

--- a/webdriver/moon.mod.json
+++ b/webdriver/moon.mod.json
@@ -33,6 +33,10 @@
       "path": "../browser",
       "version": "0.17.1"
     },
+    "mizchi/crater-browser-http": {
+      "path": "../http",
+      "version": "0.17.1"
+    },
     "mizchi/crater-browser-helpers": {
       "path": "../browser_helpers",
       "version": "0.17.1"

--- a/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
+++ b/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
@@ -543,11 +543,7 @@ fn ensure_paint_provider_initialized() -> Unit {
         font_family,
       ) {
         js_kern_for_family_by_weight(
-          cp1,
-          cp2,
-          font_size,
-          font_weight,
-          font_family,
+          cp1, cp2, font_size, font_weight, font_family,
         )
       }),
       get_ascent_for_family: Some(fn(font_family) {

--- a/webdriver/webdriver/bidi_emulation_profile_wbtest.mbt
+++ b/webdriver/webdriver/bidi_emulation_profile_wbtest.mbt
@@ -39,6 +39,32 @@ test "clearing global UA clears session profile.user_agent" {
 }
 
 ///|
+/// After browsingContext.close the session_profiles entry must be removed.
+/// Regression test for the lifecycle gap flagged after Task 5.
+test "session_profiles entry is removed on browsingContext.close" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"emulation.setUserAgentOverride\",\"params\":{\"userAgent\":\"UA/test\"}}",
+  )
+  ignore(proto.take_messages())
+  // Confirm entry was created
+  assert_true(
+    proto.emulation_state.session_profiles.get("session-1") is Some(_),
+  )
+  // Close the context
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"browsingContext.close\",\"params\":{\"context\":\"session-1\"}}",
+  )
+  ignore(proto.take_messages())
+  // Entry must have been removed
+  assert_true(proto.emulation_state.session_profiles.get("session-1") is None)
+}
+
+///|
 /// `resolve_effective_user_agent` falls back to `profile.user_agent` when
 /// the standalone `emulation_user_agent_global` field is None. This
 /// exercises the fallback chain introduced in this task without going

--- a/webdriver/webdriver/bidi_emulation_profile_wbtest.mbt
+++ b/webdriver/webdriver/bidi_emulation_profile_wbtest.mbt
@@ -1,0 +1,61 @@
+///|
+/// Verifies that BiDi `emulation.setUserAgentOverride` (global form, no
+/// `contexts` / `userContexts`) mirrors the override into the per-session
+/// Profile that BidiEmulationState now carries alongside the legacy
+/// `emulation_user_agent_global` field.
+test "emulation_user_agent_global is mirrored on session profile.user_agent" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"emulation.setUserAgentOverride\",\"params\":{\"userAgent\":\"UA/test\"}}",
+  )
+  ignore(proto.take_messages())
+  let profile = proto.profile_for_session("session-1").unwrap()
+  assert_true(profile.user_agent is Some("UA/test"))
+}
+
+///|
+/// Clearing the global override (`userAgent: null`) clears the per-session
+/// profile.user_agent as well.
+test "clearing global UA clears session profile.user_agent" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"emulation.setUserAgentOverride\",\"params\":{\"userAgent\":\"UA/test\"}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"emulation.setUserAgentOverride\",\"params\":{\"userAgent\":null}}",
+  )
+  ignore(proto.take_messages())
+  let profile = proto.profile_for_session("session-1").unwrap()
+  assert_true(profile.user_agent is None)
+}
+
+///|
+/// `resolve_effective_user_agent` falls back to `profile.user_agent` when
+/// the standalone `emulation_user_agent_global` field is None. This
+/// exercises the fallback chain introduced in this task without going
+/// through a setter that mutates both — useful as a guard for the
+/// option (a) wiring.
+test "resolve_effective_user_agent falls back to profile.user_agent when global is None" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  // Seed only the profile (not the legacy global) — emulates a future
+  // caller that talks to the profile directly.
+  let profile = proto.profile_for_session("session-1").unwrap()
+  profile.user_agent = Some("UA/profile-only")
+  inspect(
+    proto.resolve_effective_user_agent("session-1"),
+    content="UA/profile-only",
+  )
+}

--- a/webdriver/webdriver/bidi_emulation_state.mbt
+++ b/webdriver/webdriver/bidi_emulation_state.mbt
@@ -3,10 +3,18 @@
 ///
 /// Each emulation feature follows the same precedence model:
 /// context override, user-context override, then global override.
+///
+/// Phase 1 of the browser-auth-cors plan additionally carries a per-session
+/// `@browser_http.Profile` so emulation writes can be mirrored into the
+/// session's profile. This is option (a) from Task 5 — the legacy
+/// `emulation_user_agent_global` field stays as the primary read path; the
+/// profile is the forward-compatible source of truth for later phases
+/// (cookies, auth, CORS).
 priv struct BidiEmulationState {
   mut emulation_user_agent_global : String?
   emulation_user_agent_by_context : Map[String, String] // top-level context -> userAgent override
   emulation_user_agent_by_user_context : Map[String, String] // user context -> userAgent override
+  session_profiles : Map[String, @browser_http.Profile] // session id -> per-session profile
   mut emulation_locale_global : String?
   emulation_locale_by_context : Map[String, String] // top-level context -> locale override
   emulation_locale_by_user_context : Map[String, String] // user context -> locale override
@@ -51,6 +59,7 @@ fn BidiEmulationState::new() -> BidiEmulationState {
     emulation_screen_area_global: None,
     emulation_screen_area_by_context: {},
     emulation_screen_area_by_user_context: {},
+    session_profiles: {},
   }
 }
 
@@ -77,6 +86,56 @@ fn BidiEmulationState::reset(self : BidiEmulationState) -> Unit {
   self.emulation_screen_area_global = None
   clear_json_map(self.emulation_screen_area_by_context)
   clear_json_map(self.emulation_screen_area_by_user_context)
+  clear_profile_map(self.session_profiles)
+}
+
+///|
+/// Look up (or lazily create) the per-session profile for `ctx_id`.
+/// Returns None when the session is unknown to the CDP session manager —
+/// the caller should treat that as "ignore this update", not as an error.
+fn BidiProtocol::profile_for_session(
+  self : BidiProtocol,
+  ctx_id : String,
+) -> @browser_http.Profile? {
+  if !self.manager.has_session(ctx_id) {
+    return None
+  }
+  match self.emulation_state.session_profiles.get(ctx_id) {
+    Some(profile) => Some(profile)
+    None => {
+      let profile = @browser_http.Profile::default()
+      self.emulation_state.session_profiles[ctx_id] = profile
+      Some(profile)
+    }
+  }
+}
+
+///|
+/// Mirror a global user-agent override into every known session profile.
+/// Called from the `setUserAgentOverride` global branch so the profile
+/// stays in sync with `emulation_user_agent_global`. Skips sessions that
+/// the manager no longer knows about.
+fn BidiProtocol::mirror_global_user_agent_to_session_profiles(
+  self : BidiProtocol,
+  user_agent : String?,
+) -> Unit {
+  for ctx_id in self.manager.list_sessions() {
+    match self.profile_for_session(ctx_id) {
+      Some(profile) => profile.user_agent = user_agent
+      None => ()
+    }
+  }
+}
+
+///|
+fn clear_profile_map(values : Map[String, @browser_http.Profile]) -> Unit {
+  let keys : Array[String] = []
+  for key, _ in values {
+    keys.push(key)
+  }
+  for key in keys {
+    values.remove(key)
+  }
 }
 
 ///|

--- a/webdriver/webdriver/bidi_emulation_state.mbt
+++ b/webdriver/webdriver/bidi_emulation_state.mbt
@@ -119,6 +119,10 @@ fn BidiProtocol::mirror_global_user_agent_to_session_profiles(
   self : BidiProtocol,
   user_agent : String?,
 ) -> Unit {
+  // TODO(review): skip this iteration entirely when user_agent is None and
+  // there are no existing session_profiles entries to clear, to avoid the
+  // lazy-alloc side-effect of profile_for_session on a no-op global None set.
+  // See code-review comment on commit 495dffe (Important #2).
   for ctx_id in self.manager.list_sessions() {
     match self.profile_for_session(ctx_id) {
       Some(profile) => profile.user_agent = user_agent

--- a/webdriver/webdriver/bidi_emulation_synthetic.mbt
+++ b/webdriver/webdriver/bidi_emulation_synthetic.mbt
@@ -164,7 +164,20 @@ fn BidiProtocol::resolve_effective_user_agent(
       self.emulation_state.emulation_user_agent_global,
     ) {
     Some(user_agent) => user_agent
-    None => @browser_domain.default_runtime_user_agent()
+    None =>
+      // Option (a) fallback: when no per-context, per-userContext, or
+      // legacy global override is in play, consult the per-session
+      // profile before reaching for the JS runtime default. Lets future
+      // callers seed `profile.user_agent` directly without touching the
+      // BiDi global.
+      match self.emulation_state.session_profiles.get(ctx_id) {
+        Some(profile) =>
+          match profile.user_agent {
+            Some(user_agent) => user_agent
+            None => @browser_domain.default_runtime_user_agent()
+          }
+        None => @browser_domain.default_runtime_user_agent()
+      }
   }
 }
 
@@ -533,6 +546,11 @@ fn BidiProtocol::resolve_emulation_set_user_agent_override(
   }
 
   self.emulation_state.emulation_user_agent_global = user_agent
+  // Option (a) mirroring: keep the legacy global field authoritative for
+  // the primary read path, but propagate the value into per-session
+  // profiles so Phase 2+ layers (SameSite / CORS) can resolve through
+  // `profile.user_agent` without going back to the BiDi global.
+  self.mirror_global_user_agent_to_session_profiles(user_agent)
   self.refresh_effective_user_agent_for_all_contexts()
   Some(true)
 }

--- a/webdriver/webdriver/bidi_network_cors_wbtest.mbt
+++ b/webdriver/webdriver/bidi_network_cors_wbtest.mbt
@@ -1,0 +1,61 @@
+///|
+/// CorsBlocked surfaces as BiDi errorText with the upstream reason embedded.
+test "CorsBlocked maps to BiDi errorText with reason" {
+  let text = error_text_of(@http.HttpError::CorsBlocked("missing ACA-Origin"))
+  inspect(text, content="CORS: missing ACA-Origin")
+}
+
+///|
+/// PreflightFailed surfaces as BiDi errorText with a distinct prefix so the
+/// driver can distinguish the actual-request rejection from preflight.
+test "PreflightFailed maps to BiDi errorText with preflight prefix" {
+  let text = error_text_of(
+    @http.HttpError::PreflightFailed("ACA-Methods missing PUT"),
+  )
+  inspect(text, content="CORS preflight: ACA-Methods missing PUT")
+}
+
+///|
+/// The legacy variants must keep producing a sensible errorText so the new
+/// arms don't break the fallthrough for existing fetch failures.
+test "legacy HttpError variants still map to readable errorText" {
+  inspect(
+    error_text_of(@http.HttpError::NetworkError("DNS failure")),
+    content="NetworkError: DNS failure",
+  )
+  inspect(
+    error_text_of(@http.HttpError::InvalidUrl("not a url")),
+    content="InvalidUrl: not a url",
+  )
+  inspect(error_text_of(@http.HttpError::TimeoutError), content="TimeoutError")
+  inspect(
+    error_text_of(@http.HttpError::CorsError("legacy reason")),
+    content="CorsError: legacy reason",
+  )
+  inspect(
+    error_text_of(@http.HttpError::SandboxError("blocked iframe")),
+    content="SandboxError: blocked iframe",
+  )
+}
+
+///|
+/// The synthetic fetchError event builder must accept the mapped errorText so
+/// driver clients see `"CORS: <reason>"` in the BiDi payload. This exercises
+/// the end-to-end path: mapper output flows through
+/// `build_synthetic_fetch_error_event_json` into the JSON wire format.
+test "build_synthetic_fetch_error_event_json embeds mapped CORS errorText" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  let _ = proto.take_messages()
+  let mapped = error_text_of(@http.HttpError::CorsBlocked("origin mismatch"))
+  let payload = "{\"id\":2,\"method\":\"network.buildFetchErrorEvent\",\"params\":{\"context\":\"session-1\",\"url\":\"http://localhost:8000/x\",\"method\":\"GET\",\"requestId\":\"request-1\",\"requestHeaders\":[],\"errorText\":\"" +
+    mapped +
+    "\"}}"
+  let _ = proto.process_message(payload)
+  let msgs = proto.take_messages()
+  assert_eq(msgs.length(), 1)
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"errorText\":\"CORS: origin mismatch\""))
+}

--- a/webdriver/webdriver/bidi_network_error_text.mbt
+++ b/webdriver/webdriver/bidi_network_error_text.mbt
@@ -1,0 +1,25 @@
+///|
+/// Map an `@http.HttpError` into the BiDi `errorText` string that
+/// `network.fetchError` / `network.responseCompleted` payloads expose to the
+/// driver.
+///
+/// The two CORS variants get distinguishing prefixes so a Playwright /
+/// WebDriver client can tell a preflight rejection apart from the actual
+/// request being blocked:
+///
+/// - `CorsBlocked(reason)`     -> `"CORS: <reason>"`
+/// - `PreflightFailed(reason)` -> `"CORS preflight: <reason>"`
+///
+/// Existing variants retain their `Show` form so legacy callers see the same
+/// errorText as before.
+pub fn error_text_of(e : @http.HttpError) -> String {
+  match e {
+    @http.HttpError::CorsBlocked(reason) => "CORS: " + reason
+    @http.HttpError::PreflightFailed(reason) => "CORS preflight: " + reason
+    @http.HttpError::NetworkError(msg) => "NetworkError: " + msg
+    @http.HttpError::InvalidUrl(url) => "InvalidUrl: " + url
+    @http.HttpError::TimeoutError => "TimeoutError"
+    @http.HttpError::CorsError(msg) => "CorsError: " + msg
+    @http.HttpError::SandboxError(msg) => "SandboxError: " + msg
+  }
+}

--- a/webdriver/webdriver/bidi_protocol_context_lifecycle.mbt
+++ b/webdriver/webdriver/bidi_protocol_context_lifecycle.mbt
@@ -413,6 +413,7 @@ fn BidiProtocol::close_context_and_cleanup(
   self.context_device_pixel_ratio.remove(ctx_id)
   self.subscription_state.remove_pending_log_entries(ctx_id)
   self.clear_input_state_for_context(ctx_id)
+  self.emulation_state.session_profiles.remove(ctx_id)
   match self.active_context_id {
     Some(active_ctx) =>
       if active_ctx == ctx_id {

--- a/webdriver/webdriver/moon.pkg
+++ b/webdriver/webdriver/moon.pkg
@@ -14,6 +14,7 @@ import {
   "mizchi/crater-core" @layout_types,
   "mizchi/crater-browser/cdp",
   "mizchi/crater-browser/http" @browser_http,
+  "mizchi/crater-browser-http" @http,
   "mizchi/crater-browser/interaction",
   "mizchi/crater-browser/tui/paint/export" @tui_paint_export,
   "mizchi/crater-browser/tui/paint/png" @tui_paint_png,

--- a/webdriver/webdriver/moon.pkg
+++ b/webdriver/webdriver/moon.pkg
@@ -13,6 +13,7 @@ import {
   "mizchi/css/values" @types,
   "mizchi/crater-core" @layout_types,
   "mizchi/crater-browser/cdp",
+  "mizchi/crater-browser/http" @browser_http,
   "mizchi/crater-browser/interaction",
   "mizchi/crater-browser/tui/paint/export" @tui_paint_export,
   "mizchi/crater-browser/tui/paint/png" @tui_paint_png,

--- a/webdriver/webdriver/pkg.generated.mbti
+++ b/webdriver/webdriver/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "mizchi/crater-webdriver-bidi/webdriver"
 
 import {
+  "mizchi/crater-browser-http",
   "mizchi/crater-browser/cdp",
   "mizchi/crater-webdriver-bidi/contract",
   "mizchi/crater-webdriver-bidi/rpc",
@@ -15,6 +16,8 @@ pub fn await_promise(@core.Any) -> String
 pub fn decode_base64(String) -> String
 
 pub fn delete_runtime_handle(String) -> Unit
+
+pub fn error_text_of(@crater-browser-http.HttpError) -> String
 
 pub fn eval_and_send_async(@core.Any, Int, String, String) -> Unit
 


### PR DESCRIPTION
## Summary

Implements **Phase 1–4** of the [browser auth + CORS plan](https://github.com/mizchi/crater/blob/main/docs/superpowers/plans/2026-05-17-browser-auth-cors.md). Phase 5 (Node fixture + Playwright e2e) and Phase 6 (pkspec scenarios) are deliberately deferred to separate PRs.

### Phase 1 — Profile bundle (Tasks 1-5)
- New sub-package `http/profile/` with `Profile { user_agent, cookie_jar, http_cache, auth_state, preflight_cache }` + `AuthState` placeholder.
- `BrowserState.profile : Profile` replaces the per-field `cookie_jar` / `http_cache`. Backward-compat accessors documented as migration shims.
- WebDriver `emulation_user_agent_global` mirrors into per-session `profile.user_agent`; `resolve_effective_user_agent` fallback chain extended.
- Per-session profile lifecycle hooked to `browsingContext.close` to avoid leaks.

### Phase 2 — SameSite attach policy (Tasks 6-9, Task 10 skipped)
- New sub-package `http/samesite/` with `classify_site_context` (eTLD+1 heuristic, trailing-dot FQDN normalized) and `should_attach_cookie` (WHATWG cookies-bis table).
- `navigation_cookie_header` seam in `browser/shell/navigation_fetch.mbt` filters cookies through `should_attach_cookie` with `is_top_level_navigation=true`.
- Aligned `cookie_jar`'s parallel SameSite filter to Lax-default for unknown values (matches RFC 6265bis).

### Phase 3 — CORS classification + preflight (Tasks 11-15)
- New sub-package `http/cors/` with `CorsDecision`, `PreflightRequest`, `PreflightEntry`, `PreflightCache`, plus `classify_request`, `validate_preflight_response`, `validate_actual_response`, `PreflightCache::get_or_validate`.
- `browser/http/` facade re-exports the full CORS surface.

### Phase 4 — Wiring + BiDi error propagation (Tasks 16-19)
- `HttpError` gains `CorsBlocked(String)` and `PreflightFailed(String)` variants.
- `script_fetch_with_cors` async seam gates `script_fetch` through classify → preflight (async/sync bridging via Ref capture) → validate (skipped for NoCors per spec).
- `external_css_fetch` refactored with `build_external_css_options` helper to lock the `NoCors` invariant.
- WebDriver `error_text_of` maps the new variants to BiDi `network.fetchError` `errorText`: `"CORS: <reason>"` / `"CORS preflight: <reason>"`.

## Test counts (all passing)

| Package | Tests |
|---|---|
| `mizchi/crater-browser-http/profile` | 5 |
| `mizchi/crater-browser-http/samesite` | 9 |
| `mizchi/crater-browser-http/cors` | 15 |
| `mizchi/crater-browser-http/cookie_jar` | 95 |
| `mizchi/crater-browser/shell` | 173 |
| `mizchi/crater-browser/http` (facade re-exports) | 3 |
| `mizchi/crater-webdriver/webdriver` | 306 |

## Known follow-ups (file as scenarios after merge)

| Item | Severity | Note |
|---|---|---|
| `PreflightCache::cache_key` duplicated in `script_fetch.mbt` peek helper | Important | Fix: expose `PreflightCache::contains_fresh` |
| `cookie_jar` parallel SameSite logic alongside `@samesite.should_attach_cookie` | Important | Unify by passing `SiteContext` into `get_cookie_header` (breaks circular dep) |
| `prefetch_images` bypasses CORS gate (per-spec defensible: `<img>` is no-CORS by default) | Important | Add explicit mode + comment, or document the policy |
| `validate_actual_response` accepts `*` for `SameOrigin` credentials mode | Minor | Should never reach there; block at navigation layer |
| Backward-compat `Browser::cookie_jar()` / `http_cache()` accessors | Minor | Drop after Phase 5 e2e lands |
| `is_simple_method` / `is_safelisted_header` / `parse_csv` exposed as `pub` | Minor | Drop visibility once Task 17 callers are confirmed |
| `mirror_global_user_agent_to_session_profiles` lazy-allocates on `None` set | Minor | Early-return when no entries to clear |

## Test plan

- [x] All existing tests pass (5/5/15/95/173/3/306 across new + touched packages)
- [x] `moon check` clean across workspace
- [x] `pkg.generated.mbti` regenerated for every touched package
- [x] No CI changes needed (no new tasks, no GitHub Actions edits)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)