### PR TITLE
Security follow-ups for browser auth + CORS: bounds, sanitize, dedupe

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,7 @@ pkf run spec-check                                          # contract が壊れ
 | `bug.inline-abspos-width-ahem` | inline abspos width Ahem | #17 |
 | `bug.border-radius-paint` | border-radius pixel diff | #19 |
 | `bug.flexbox-align-items` | align-items 反映 | #22 |
+| `bug.samesite.psl-required` | SameSite eTLD+1 は PSL が必要 (security review I3) | — |
 | `diagnostic.css-rule-usage-tracking` | dead CSS rule tracking | #27 |
 | `tui.raster-image-display` | TUI JPEG / PNG / GIF | #16 |
 | `ci.dead-module-detection` | dead-module sweep 続き | #60 |

--- a/browser/shell/script_fetch.mbt
+++ b/browser/shell/script_fetch.mbt
@@ -15,31 +15,6 @@ type ResponseFetcher = async (String, @http.FetchOptions) -> @http.HttpResponse 
 type PreflightFetcher = (@http_cors.PreflightRequest) -> @http.HttpResponse
 
 ///|
-/// Read-only peek into a PreflightCache: returns `true` when an entry
-/// exists for `req` and `now < expires_at_seconds`. Mirrors the cache's
-/// own `cache_key` formula (`origin|url|method|headers.join(",")`)
-/// which is documented + tested in http/cors/. We keep the formula
-/// local rather than exporting `cache_key` to avoid leaking an
-/// implementation detail.
-fn preflight_cache_has_fresh(
-  cache : @http_cors.PreflightCache,
-  req : @http_cors.PreflightRequest,
-  now : Double,
-) -> Bool {
-  let key = req.origin +
-    "|" +
-    req.url +
-    "|" +
-    req.method +
-    "|" +
-    req.request_headers.join(",")
-  match cache.entries.get(key) {
-    Some(entry) => entry.expires_at_seconds > now
-    None => false
-  }
-}
-
-///|
 /// Run a subresource fetch through the CORS gate:
 ///
 /// 1. `@http_cors.classify_request` → Allow / PreflightRequired / Blocked.
@@ -168,11 +143,7 @@ async fn Browser::fetch_external_script_source(
   )
   match pre_decision {
     PreflightRequired(preflight_req) =>
-      if !preflight_cache_has_fresh(
-          preflight_cache,
-          preflight_req,
-          @http_cache.now_seconds(),
-        ) {
+      if !preflight_cache.contains_fresh(preflight_req, @http_cache.now_seconds) {
         let headers : Map[String, String] = {
           "Access-Control-Request-Method": preflight_req.method,
         }

--- a/http/cookie_jar/cookie_jar.mbt
+++ b/http/cookie_jar/cookie_jar.mbt
@@ -358,6 +358,13 @@ fn cookie_same_site(domain_a : String, domain_b : String) -> Bool {
 /// Extract registrable domain (last 2 labels). Simplified, no PSL.
 /// "sub.example.com" → "example.com", "example.com" → "example.com"
 fn cookie_registrable_domain(domain : String) -> String {
+  // Strip a single trailing dot — FQDN forms like "example.com." are
+  // equivalent to "example.com" for site comparison.
+  let domain = if domain.has_suffix(".") && domain.length() > 1 {
+    domain.unsafe_substring(start=0, end=domain.length() - 1)
+  } else {
+    domain
+  }
   let mut last_dot = -1
   let mut second_last_dot = -1
   for i = 0; i < domain.length(); i = i + 1 {
@@ -446,7 +453,7 @@ fn cookie_path_matches(request_path : String, cookie_path : String) -> Bool {
 ///|
 /// Extract domain from URL
 fn cookie_extract_domain(url : String) -> String {
-  match url.find("://") {
+  let host = match url.find("://") {
     Some(i) => {
       let after = url[i + 3:].to_owned()
       let end = match after.find("/") {
@@ -461,6 +468,13 @@ fn cookie_extract_domain(url : String) -> String {
       }
     }
     None => url.to_lower()
+  }
+  // Strip a single trailing dot — FQDN forms like "example.com." are
+  // equivalent to "example.com" for site comparison.
+  if host.has_suffix(".") && host.length() > 1 {
+    host.unsafe_substring(start=0, end=host.length() - 1)
+  } else {
+    host
   }
 }
 

--- a/http/cookie_jar/cookie_jar_wbtest.mbt
+++ b/http/cookie_jar/cookie_jar_wbtest.mbt
@@ -1234,3 +1234,78 @@ test "cookie_registrable_domain: three labels" {
 test "cookie_registrable_domain: single label" {
   inspect(cookie_registrable_domain("localhost"), content="localhost")
 }
+
+// ============================================================
+// FU2: TRAILING-DOT FQDN NORMALIZATION (security follow-up I4)
+// ============================================================
+
+///|
+/// Regression: trailing-dot FQDN in request URL must match cookie stored
+/// without the trailing dot (and vice-versa).
+test "cookie_jar: trailing-dot FQDN matches non-dotted form" {
+  let jar = CookieJar::new(enabled=true)
+  // Store cookie via normal URL
+  jar.store_from_header(
+    "session=v; Path=/; SameSite=Lax; Secure", "https://example.com/", true,
+  )
+  // Request to trailing-dot FQDN form should attach the cookie
+  let cookies = jar.get_cookie_header(
+    "https://example.com./",
+    true,
+    true,
+    site_origin="https://example.com.",
+    is_top_level_navigation=true,
+  )
+  debug_inspect(cookies, content="Some(\"session=v\")")
+}
+
+///|
+/// Regression: cookie stored via trailing-dot FQDN URL matches non-dotted request.
+test "cookie_jar: cookie stored with trailing-dot FQDN retrieved by non-dotted host" {
+  let jar = CookieJar::new(enabled=true)
+  // Store cookie via trailing-dot URL
+  jar.store_from_header(
+    "session=v; Path=/; SameSite=Lax; Secure", "https://example.com./", true,
+  )
+  // Retrieve via normal URL — should still find it
+  let cookies = jar.get_cookie_header("https://example.com/", true, true)
+  debug_inspect(cookies, content="Some(\"session=v\")")
+}
+
+///|
+/// Regression: cross-site check with trailing-dot FQDN site_origin must be
+/// same-site with the trailing-dot request URL (no spurious cross-site block).
+test "cookie_jar: trailing-dot same-site not misclassified as cross-site" {
+  let jar = CookieJar::new(enabled=true)
+  jar.store_from_header(
+    "csrf=tok; Path=/; SameSite=Strict; Secure", "https://example.com/", true,
+  )
+  // Both request and site_origin use trailing-dot form — must be same-site
+  let cookies = jar.get_cookie_header(
+    "https://example.com./api",
+    true,
+    true,
+    site_origin="https://example.com.",
+  )
+  debug_inspect(cookies, content="Some(\"csrf=tok\")")
+}
+
+///|
+test "cookie_registrable_domain: trailing-dot stripped before extraction" {
+  inspect(cookie_registrable_domain("example.com."), content="example.com")
+}
+
+///|
+test "cookie_registrable_domain: sub trailing-dot stripped" {
+  inspect(cookie_registrable_domain("sub.example.com."), content="example.com")
+}
+
+///|
+test "cookie_same_site: trailing-dot form is same-site as non-dotted" {
+  inspect(cookie_same_site("example.com.", "example.com"), content="true")
+}
+
+///|
+test "cookie_same_site: both trailing-dot are same-site" {
+  inspect(cookie_same_site("example.com.", "example.com."), content="true")
+}

--- a/http/cors/cors.mbt
+++ b/http/cors/cors.mbt
@@ -421,6 +421,35 @@ pub fn PreflightCache::get_or_validate(
 }
 
 ///|
+/// Returns true when the cache holds an unexpired entry whose
+/// allow-lists cover this request. Used by callers that want to
+/// skip pre-dispatching the OPTIONS preflight on a cache hit.
+///
+/// This is the read-only peek companion to `get_or_validate` and shares
+/// the same `cache_key` formula, so callers do not need to mirror the
+/// key construction (which would silently drift if the formula ever
+/// adds a new axis like credentials).
+pub fn PreflightCache::contains_fresh(
+  self : PreflightCache,
+  request : PreflightRequest,
+  now : () -> Double,
+) -> Bool {
+  let key = cache_key(request)
+  match self.entries.get(key) {
+    Some(entry) =>
+      if entry.expires_at_seconds > now() {
+        match validate_cached_entry(entry, request) {
+          Ok(_) => true
+          Err(_) => false
+        }
+      } else {
+        false
+      }
+    None => false
+  }
+}
+
+///|
 /// Remove an entry from both the map and the insertion-order tracker.
 /// Used internally when a cache entry is expired or fails the per-call
 /// allow-list re-check.

--- a/http/cors/cors.mbt
+++ b/http/cors/cors.mbt
@@ -74,13 +74,26 @@ pub(all) struct PreflightEntry {
 /// In-memory preflight cache. Key is built by the caller (typically
 /// `origin + "|" + url + "|" + method + "|" + headers.join(",")`); the
 /// CorsDecision module itself is intentionally key-agnostic for now.
+///
+/// `max_entries` caps the total number of distinct keys held; when the
+/// cap is hit on insert the oldest entry (FIFO insertion order) is
+/// evicted. This prevents unbounded growth per Profile lifetime — a
+/// permissive remote could otherwise stuff the cache with a unique
+/// preflight per request. `insertion_order` tracks keys in the order
+/// they were first inserted so eviction is O(1) amortized at the front.
 pub struct PreflightCache {
   entries : Map[String, PreflightEntry]
+  insertion_order : Array[String]
+  max_entries : Int
 }
 
 ///|
-pub fn PreflightCache::new() -> PreflightCache {
-  PreflightCache::{ entries: Map::new() }
+/// Construct a preflight cache with an optional `max_entries` cap
+/// (default 512). The cap is a self-DoS bound: same justification as
+/// MemoryCacheBackend's max_entries=1000. Hitting the cap evicts the
+/// oldest entry in FIFO insertion order.
+pub fn PreflightCache::new(max_entries? : Int = 512) -> PreflightCache {
+  PreflightCache::{ entries: Map::new(), insertion_order: [], max_entries }
 }
 
 ///|
@@ -352,10 +365,10 @@ pub fn PreflightCache::get_or_validate(
     if entry.expires_at_seconds > current {
       match validate_cached_entry(entry, request) {
         Ok(_) => return Ok(())
-        Err(_) => self.entries.remove(key)
+        Err(_) => self.remove_entry(key)
       }
     } else {
-      self.entries.remove(key)
+      self.remove_entry(key)
     }
   }
   let response = fetcher(request)
@@ -363,10 +376,21 @@ pub fn PreflightCache::get_or_validate(
     Err(e) => return Err(e)
     Ok(_) => ()
   }
-  let max_age = parse_double_default(
+  let raw_max_age = parse_double_default(
     header_or_empty(response.headers, "access-control-max-age"),
     0.0,
   )
+  // Clamp Access-Control-Max-Age to [0, 7200] seconds matching
+  // Chromium's browser policy. Without this clamp a malicious origin
+  // could serve Access-Control-Max-Age: 99999999999999 and pin a
+  // permissive preflight policy for the Profile's entire lifetime.
+  let max_age = if raw_max_age > 7200.0 {
+    7200.0
+  } else if raw_max_age < 0.0 {
+    0.0
+  } else {
+    raw_max_age
+  }
   let allowed_methods = parse_csv(
     header_or_empty(response.headers, "access-control-allow-methods"),
   )
@@ -378,13 +402,36 @@ pub fn PreflightCache::get_or_validate(
       "access-control-allow-credentials",
     ) ==
     "true"
+  // Evict oldest entry (FIFO) if we are at capacity. The cap is a
+  // self-DoS bound — see PreflightCache::new for justification.
+  if self.entries.length() >= self.max_entries {
+    if self.insertion_order.length() > 0 {
+      let oldest = self.insertion_order.remove(0)
+      self.entries.remove(oldest)
+    }
+  }
   self.entries[key] = PreflightEntry::{
     allowed_methods,
     allowed_headers,
     allow_credentials,
     expires_at_seconds: current + max_age,
   }
+  self.insertion_order.push(key)
   Ok(())
+}
+
+///|
+/// Remove an entry from both the map and the insertion-order tracker.
+/// Used internally when a cache entry is expired or fails the per-call
+/// allow-list re-check.
+fn PreflightCache::remove_entry(self : PreflightCache, key : String) -> Unit {
+  self.entries.remove(key)
+  for i = 0; i < self.insertion_order.length(); i = i + 1 {
+    if self.insertion_order[i] == key {
+      let _ = self.insertion_order.remove(i)
+      break
+    }
+  }
 }
 
 ///|

--- a/http/cors/cors_wbtest.mbt
+++ b/http/cors/cors_wbtest.mbt
@@ -266,6 +266,99 @@ test "HttpError carries PreflightFailed variant" {
 }
 
 ///|
+test "PreflightCache::get_or_validate: max_entries cap evicts oldest in FIFO order" {
+  // max_entries=2 lets us add 3 distinct preflights and confirm the
+  // first one was evicted (must re-fetch on lookup) while the second
+  // and third remain cached (no re-fetch).
+  let cache = PreflightCache::new(max_entries=2)
+  let calls : Array[Int] = [0]
+  let fetcher = fn(r : PreflightRequest) -> @http_impl.HttpResponse {
+    calls[0] = calls[0] + 1
+    test_preflight_response(
+      status=204,
+      aca_origin=r.origin,
+      aca_methods=r.method,
+      aca_headers=r.request_headers.join(", "),
+      aca_max_age="600",
+    )
+  }
+  let now = fn() -> Double { 1000.0 }
+  let req_a = PreflightRequest::{
+    url: "https://api.other.com/a",
+    origin: "https://example.com",
+    method: "PUT",
+    request_headers: ["x-a"],
+  }
+  let req_b = PreflightRequest::{
+    url: "https://api.other.com/b",
+    origin: "https://example.com",
+    method: "PUT",
+    request_headers: ["x-b"],
+  }
+  let req_c = PreflightRequest::{
+    url: "https://api.other.com/c",
+    origin: "https://example.com",
+    method: "PUT",
+    request_headers: ["x-c"],
+  }
+  let _ = cache.get_or_validate(req_a, now, fetcher)
+  let _ = cache.get_or_validate(req_b, now, fetcher)
+  let _ = cache.get_or_validate(req_c, now, fetcher)
+  // 3 distinct preflights → 3 fetches so far.
+  inspect(calls[0], content="3")
+  // Cache must hold exactly max_entries=2 entries.
+  inspect(cache.entries.length(), content="2")
+  // b and c are still cached → no extra fetch.
+  let _ = cache.get_or_validate(req_b, now, fetcher)
+  let _ = cache.get_or_validate(req_c, now, fetcher)
+  inspect(calls[0], content="3")
+  // a was evicted (oldest) → re-fetch on lookup.
+  let _ = cache.get_or_validate(req_a, now, fetcher)
+  inspect(calls[0], content="4")
+}
+
+///|
+test "PreflightCache::get_or_validate: Access-Control-Max-Age is clamped to 7200s" {
+  // Server claims Max-Age=86400 (Firefox cap, 24h). The clamp pulls
+  // it back to 7200 (Chromium cap, 2h) so a malicious origin cannot
+  // pin a permissive policy beyond 2 hours.
+  let cache = PreflightCache::new()
+  let req = PreflightRequest::{
+    url: "https://api.other.com/clamp",
+    origin: "https://example.com",
+    method: "PUT",
+    request_headers: ["x-token"],
+  }
+  let fetcher = fn(_r : PreflightRequest) -> @http_impl.HttpResponse {
+    test_preflight_response(
+      status=204,
+      aca_origin="https://example.com",
+      aca_methods="PUT",
+      aca_headers="x-token",
+      aca_max_age="86400",
+    )
+  }
+  let now = fn() -> Double { 1000.0 }
+  match cache.get_or_validate(req, now, fetcher) {
+    Ok(_) => inspect(true, content="true")
+    Err(e) => fail("expected Ok, got Err: " + e)
+  }
+  // expires_at_seconds = now (1000) + clamped Max-Age (7200) = 8200,
+  // not 1000 + 86400 = 87400.
+  let key = req.origin +
+    "|" +
+    req.url +
+    "|" +
+    req.method +
+    "|" +
+    req.request_headers.join(",")
+  match cache.entries.get(key) {
+    Some(entry) => inspect(entry.expires_at_seconds, content="8200")
+    None => fail("expected cache entry to exist")
+  }
+}
+
+///|
 test "PreflightCache::get_or_validate: cache miss past Max-Age (fetcher called twice)" {
   let cache = PreflightCache::new()
   let req = PreflightRequest::{

--- a/http/cors/cors_wbtest.mbt
+++ b/http/cors/cors_wbtest.mbt
@@ -359,6 +359,47 @@ test "PreflightCache::get_or_validate: Access-Control-Max-Age is clamped to 7200
 }
 
 ///|
+test "PreflightCache::contains_fresh agrees with get_or_validate (hit, miss-by-expiry, miss-by-allowlist)" {
+  let cache = PreflightCache::new()
+  let req = PreflightRequest::{
+    url: "https://api.example.com/x",
+    origin: "https://example.com",
+    method: "POST",
+    request_headers: ["x-csrf"],
+  }
+  let now = fn() -> Double { 1000.0 }
+  // Before any roundtrip: cache is empty, peek must be false.
+  inspect(cache.contains_fresh(req, now), content="false")
+  // Populate via get_or_validate (Max-Age=600 → clamped to 600).
+  let fetcher = fn(_r : PreflightRequest) -> @http_impl.HttpResponse {
+    test_preflight_response(
+      status=204,
+      aca_origin="https://example.com",
+      aca_methods="POST",
+      aca_headers="x-csrf",
+      aca_max_age="600",
+    )
+  }
+  match cache.get_or_validate(req, now, fetcher) {
+    Ok(_) => inspect(true, content="true")
+    Err(e) => fail("expected Ok, got Err: " + e)
+  }
+  // Cached → peek is true.
+  inspect(cache.contains_fresh(req, now), content="true")
+  // Past Max-Age → peek is false (expires_at = 1000 + 600 = 1600).
+  inspect(cache.contains_fresh(req, fn() -> Double { 2000.0 }), content="false")
+  // Same key but with a request_headers value the cached entry didn't
+  // allow → peek is false (allow-list mismatch, same expiry).
+  let mismatch = PreflightRequest::{
+    url: "https://api.example.com/x",
+    origin: "https://example.com",
+    method: "POST",
+    request_headers: ["x-csrf", "x-not-allowed"],
+  }
+  inspect(cache.contains_fresh(mismatch, now), content="false")
+}
+
+///|
 test "PreflightCache::get_or_validate: cache miss past Max-Age (fetcher called twice)" {
   let cache = PreflightCache::new()
   let req = PreflightRequest::{

--- a/http/cors/pkg.generated.mbti
+++ b/http/cors/pkg.generated.mbti
@@ -32,9 +32,11 @@ pub impl Show for CorsDecision
 
 pub struct PreflightCache {
   entries : Map[String, PreflightEntry]
+  insertion_order : Array[String]
+  max_entries : Int
 }
 pub fn PreflightCache::get_or_validate(Self, PreflightRequest, () -> Double, (PreflightRequest) -> @crater-browser-http.HttpResponse) -> Result[Unit, String]
-pub fn PreflightCache::new() -> Self
+pub fn PreflightCache::new(max_entries? : Int) -> Self
 
 pub(all) struct PreflightEntry {
   allowed_methods : Array[String]

--- a/http/cors/pkg.generated.mbti
+++ b/http/cors/pkg.generated.mbti
@@ -35,6 +35,7 @@ pub struct PreflightCache {
   insertion_order : Array[String]
   max_entries : Int
 }
+pub fn PreflightCache::contains_fresh(Self, PreflightRequest, () -> Double) -> Bool
 pub fn PreflightCache::get_or_validate(Self, PreflightRequest, () -> Double, (PreflightRequest) -> @crater-browser-http.HttpResponse) -> Result[Unit, String]
 pub fn PreflightCache::new(max_entries? : Int) -> Self
 

--- a/scripts/fixtures/auth-server.ts
+++ b/scripts/fixtures/auth-server.ts
@@ -1,3 +1,12 @@
+/**
+ * TEST FIXTURE ONLY — do not import from production code.
+ *
+ * - Uses `Math.random()` for session ids (non-cryptographic).
+ * - Hardcoded credentials `alice / wonderland`.
+ * - Mismatched-origin /me handler intentionally returns 200 to
+ *   exercise Crater's CORS gate (M5 in PR #131 security review).
+ */
+
 import http, { IncomingMessage, ServerResponse } from "node:http";
 import { AddressInfo } from "node:net";
 
@@ -16,8 +25,6 @@ type StartResult = {
   /** Drop a previously-seeded session id. */
   forgetSession: (sid: string) => void;
 };
-
-const SESSIONS = new Map<string, string>();   // session-id → username
 
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -47,7 +54,11 @@ function loginPageHtml(): string {
 </form></body></html>`;
 }
 
-function handleApp(req: IncomingMessage, res: ServerResponse): Promise<void> {
+function handleApp(
+  req: IncomingMessage,
+  res: ServerResponse,
+  sessions: Map<string, string>,
+): Promise<void> {
   return (async () => {
     const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
     if (url.pathname === "/login" && req.method === "GET") {
@@ -61,7 +72,7 @@ function handleApp(req: IncomingMessage, res: ServerResponse): Promise<void> {
       // secretlint-disable-next-line no-credentials
       if (params.get("user") === "alice" && params.get("pass") === "wonderland") {
         const id = `s_${Math.random().toString(36).slice(2)}`;
-        SESSIONS.set(id, "alice");
+        sessions.set(id, "alice");
         res.writeHead(302, {
           "set-cookie": `session=${id}; Path=/; HttpOnly; SameSite=Lax`,
           location: "/dashboard",
@@ -76,7 +87,7 @@ function handleApp(req: IncomingMessage, res: ServerResponse): Promise<void> {
     if (url.pathname === "/dashboard") {
       const cookies = parseCookies(req.headers.cookie);
       const sid = cookies.get("session");
-      const who = sid ? SESSIONS.get(sid) : undefined;
+      const who = sid ? sessions.get(sid) : undefined;
       if (who) {
         res.writeHead(200, { "content-type": "text/html" });
         res.end(`<html><body>welcome ${who}</body></html>`);
@@ -91,7 +102,12 @@ function handleApp(req: IncomingMessage, res: ServerResponse): Promise<void> {
   })();
 }
 
-function handleApi(req: IncomingMessage, res: ServerResponse, appOrigin: string): void {
+function handleApi(
+  req: IncomingMessage,
+  res: ServerResponse,
+  appOrigin: string,
+  sessions: Map<string, string>,
+): void {
   const origin = req.headers.origin ?? "";
   const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
   if (url.pathname === "/me") {
@@ -114,23 +130,34 @@ function handleApi(req: IncomingMessage, res: ServerResponse, appOrigin: string)
       });
       res.end(JSON.stringify({ user: "alice" }));
     } else {
-      // Deliberately omit ACA headers so Crater's CORS gate blocks.
+      // SECURITY: Mismatched-origin branch intentionally returns 200 with user
+      // data but omits ACA headers. This is a negative-path fixture so tests can
+      // verify that Crater's CORS gate blocks the response before JS reads it,
+      // even though the server itself responded successfully. Do not "fix" this.
+      // (M5 in PR #131 security review.)
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ user: "alice" }));
     }
     return;
   }
+  void sessions; // sessions available for future authenticated /api/* routes
   res.writeHead(404);
   res.end();
 }
 
 export async function startAuthServer(opts: StartOptions = {}): Promise<StartResult> {
-  const appServer = http.createServer((req, res) => { handleApp(req, res).catch(() => res.end()); });
+  // Scoped per startAuthServer call so vitest --pool=threads can't share state
+  // across parallel test files. (M6 in PR #131 security review.)
+  const sessions = new Map<string, string>();   // session-id → username
+
+  const appServer = http.createServer((req, res) => {
+    handleApp(req, res, sessions).catch(() => res.end());
+  });
   await new Promise<void>(r => appServer.listen(opts.port ?? 0, "127.0.0.1", r));
   const appPort = (appServer.address() as AddressInfo).port;
   const appUrl = `http://127.0.0.1:${appPort}`;
 
-  const apiServer = http.createServer((req, res) => handleApi(req, res, appUrl));
+  const apiServer = http.createServer((req, res) => handleApi(req, res, appUrl, sessions));
   await new Promise<void>(r => apiServer.listen(opts.apiPort ?? 0, "127.0.0.1", r));
   const apiPort = (apiServer.address() as AddressInfo).port;
   const apiUrl = `http://127.0.0.1:${apiPort}`;
@@ -141,10 +168,11 @@ export async function startAuthServer(opts: StartOptions = {}): Promise<StartRes
     stop: () => new Promise(r => appServer.close(() => r())),
     apiStop: () => new Promise(r => apiServer.close(() => r())),
     recordSession: (sid: string, user: string) => {
-      SESSIONS.set(sid, user);
+      if (!sid) throw new Error("sid required");
+      sessions.set(sid, user);
     },
     forgetSession: (sid: string) => {
-      SESSIONS.delete(sid);
+      sessions.delete(sid);
     },
   };
 }

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -705,6 +705,16 @@ scenarios {
     reviewStatus = "draft"
     contributes { "goal.css-compat"; "goal.paint-accuracy" }
   }
+  new {
+    id = "bug.samesite.psl-required"
+    name = "SameSite site classification needs Public Suffix List"
+    description =
+      "http/samesite/classify_site_context and http/cookie_jar/cookie_registrable_domain both reduce hosts to their last two labels. PSL is not consulted, so eTLD+1 detection over-collapses for multi-level public suffixes (example.co.uk and other.co.uk classify as same-site). Today this only affects Crater test fixtures, but any rollout that drives real cross-site auth traffic must upgrade to a PSL-aware classifier. See PR #131 / #132 security review item I3."
+    tags { "cookies"; "samesite"; "security"; "psl" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.dom-compat" }
+  }
 
   // -- Diagnostic / Tools (issue-driven) -------------------------------------
   new {

--- a/webdriver/webdriver/bidi_network_cors_wbtest.mbt
+++ b/webdriver/webdriver/bidi_network_cors_wbtest.mbt
@@ -39,6 +39,32 @@ test "legacy HttpError variants still map to readable errorText" {
 }
 
 ///|
+/// sanitize_for_log must strip raw CR and LF so a malicious server cannot
+/// inject fake log lines into the WebDriver client via CORS reason strings.
+test "sanitize_for_log strips CRLF" {
+  let e : @http.HttpError = @http.HttpError::CorsBlocked(
+    "origin\r\nAdmin-Spoof: true",
+  )
+  let txt = error_text_of(e)
+  inspect(txt.contains("\r"), content="false")
+  inspect(txt.contains("\n"), content="false")
+}
+
+///|
+/// sanitize_for_log must strip ANSI CSI escape sequences (ESC [ … letter) so
+/// terminal-rendered logs cannot be manipulated by malicious reason strings.
+test "sanitize_for_log strips ANSI CSI escape" {
+  let e : @http.HttpError = @http.HttpError::PreflightFailed(
+    "foo\u{1b}[31mred\u{1b}[0mbar",
+  )
+  let txt = error_text_of(e)
+  inspect(txt.contains("foo"), content="true")
+  inspect(txt.contains("red"), content="true")
+  inspect(txt.contains("bar"), content="true")
+  inspect(txt.contains("\u{1b}"), content="false")
+}
+
+///|
 /// The synthetic fetchError event builder must accept the mapped errorText so
 /// driver clients see `"CORS: <reason>"` in the BiDi payload. This exercises
 /// the end-to-end path: mapper output flows through

--- a/webdriver/webdriver/bidi_network_error_text.mbt
+++ b/webdriver/webdriver/bidi_network_error_text.mbt
@@ -1,4 +1,46 @@
 ///|
+/// Strip CRLF, ANSI CSI escapes, and other control characters from
+/// server-controlled strings before they reach WebDriver client logs.
+/// Defends against log injection / log forging from malicious response
+/// headers that propagate via HttpError reason strings.
+fn sanitize_for_log(s : String) -> String {
+  let buf = StringBuilder::new()
+  let chars = s.to_array()
+  let mut i = 0
+  while i < chars.length() {
+    let c = chars[i]
+    let code = c.to_int()
+    if code == 0x1b {
+      // ESC — skip the entire CSI sequence (ESC [ ... terminating-letter)
+      i = i + 1
+      if i < chars.length() && chars[i] == '[' {
+        i = i + 1
+        while i < chars.length() {
+          let cc = chars[i]
+          let ccode = cc.to_int()
+          i = i + 1
+          // CSI terminator is any byte in 0x40-0x7e
+          if ccode >= 0x40 && ccode <= 0x7e {
+            break
+          }
+        }
+      }
+    } else if code == 0x09 {
+      // Allow tab
+      buf.write_char(c)
+      i = i + 1
+    } else if code < 0x20 {
+      // Drop all other control characters (CR, LF, BEL, BS, …)
+      i = i + 1
+    } else {
+      buf.write_char(c)
+      i = i + 1
+    }
+  }
+  buf.to_string()
+}
+
+///|
 /// Map an `@http.HttpError` into the BiDi `errorText` string that
 /// `network.fetchError` / `network.responseCompleted` payloads expose to the
 /// driver.
@@ -12,14 +54,19 @@
 ///
 /// Existing variants retain their `Show` form so legacy callers see the same
 /// errorText as before.
+///
+/// Reason strings from `CorsBlocked`, `PreflightFailed`, and `CorsError` are
+/// sanitized via `sanitize_for_log` before interpolation to prevent log
+/// injection from malicious server-controlled values.
 pub fn error_text_of(e : @http.HttpError) -> String {
   match e {
-    @http.HttpError::CorsBlocked(reason) => "CORS: " + reason
-    @http.HttpError::PreflightFailed(reason) => "CORS preflight: " + reason
+    @http.HttpError::CorsBlocked(reason) => "CORS: " + sanitize_for_log(reason)
+    @http.HttpError::PreflightFailed(reason) =>
+      "CORS preflight: " + sanitize_for_log(reason)
     @http.HttpError::NetworkError(msg) => "NetworkError: " + msg
     @http.HttpError::InvalidUrl(url) => "InvalidUrl: " + url
     @http.HttpError::TimeoutError => "TimeoutError"
-    @http.HttpError::CorsError(msg) => "CorsError: " + msg
+    @http.HttpError::CorsError(msg) => "CorsError: " + sanitize_for_log(msg)
     @http.HttpError::SandboxError(msg) => "SandboxError: " + msg
   }
 }


### PR DESCRIPTION
## Summary

Bundles all six follow-up items from the post-merge security review of PRs #131 (Phase 1-4) and #132 (Phase 5). No new attack surface; no Critical issues from the original review (none existed). These are latent-risk hardening and code hygiene.

| Commit | Item | Fix |
|---|---|---|
| `bc04e93` | **I1+I2** | `PreflightCache::new(max_entries=512)` caps entry count with FIFO eviction. `Access-Control-Max-Age` clamped to `[0, 7200]` seconds (matches Chromium 2h policy). +2 wbtests. |
| `98e4be7` | **I4** | `http/cookie_jar/cookie_jar.mbt` `cookie_extract_domain` + `cookie_registrable_domain` now strip trailing-dot FQDN, matching the normalization that `http/samesite/samesite.mbt` already did (commit `bd9ffb7` on main). The two SameSite gates can no longer disagree on `example.com.` vs `example.com`. +7 wbtests. |
| `e2422fc` | **I3** | `bug.samesite.psl-required` draft scenario added to `specs/crater.pkl` so the PSL-naive eTLD+1 heuristic doesn't get forgotten when real cross-site auth traffic lands. TODO.md row added. |
| `caf7022` | **M3** | `sanitize_for_log(s)` helper in `webdriver/webdriver/bidi_network_error_text.mbt` strips CRLF, ANSI CSI escapes, and other control chars from server-controlled reason strings before they reach BiDi `errorText`. Defends against log forging via malicious response header values. +2 wbtests. |
| `bbb7598` | **M4-M6** | `scripts/fixtures/auth-server.ts` file-top TEST FIXTURE ONLY header; `recordSession("")` now throws; `SESSIONS` moved from module scope inside `startAuthServer` so vitest `--pool=threads` can't share state; SECURITY comment on the intentional mismatched-origin leak path. |
| `a1bebbc` | **M7** | `PreflightCache::contains_fresh` exposed as `pub fn`; `browser/shell/script_fetch.mbt`'s duplicated `cache_key` formula deleted in favor of the single source of truth in `http/cors/cors.mbt`. +1 wbtest covering agreement with `get_or_validate`. |

## Test counts

| Package | Before | After |
|---|---|---|
| `http/cors` | 15 | 18 |
| `http/cookie_jar` | 95 | 102 |
| `browser/shell` | 173 | 173 (unchanged) |
| `webdriver/webdriver` | 306 | 308 |
| `scripts/fixtures` | 3 | 3 (unchanged) |
| `specs/crater.pkl` (declared) | 27 | 28 (1 new draft) |

All pass. `pkf run spec-check` + `spec-lint` clean.

## Threat scenarios that no longer apply after this PR

1. **PreflightCache memory exhaustion** (I1): bounded to 512 entries per Profile.
2. **Cross-origin policy persistence past 2h** (I2): Max-Age clamp prevents pinning of permissive policies.
3. **SameSite gate disagreement on trailing-dot FQDN** (I4): cookie_jar and samesite agree.
4. **Log forging via Access-Control-Allow-Origin header value** (M3): control chars + ANSI escapes stripped.
5. **Shared session state across vitest threads** (M6): SESSIONS scoped to factory.
6. **Silent drift between `cache_key` and `preflight_cache_has_fresh`** (M7): single implementation.

## Test plan

- [x] `moon test -p mizchi/crater-browser-http/cors` — 18/18
- [x] `moon test -p mizchi/crater-browser-http/cookie_jar` — 102/102
- [x] `moon test -p mizchi/crater-browser/shell` — 173/173
- [x] `moon test -p mizchi/crater-webdriver/webdriver` — 308/308
- [x] `pnpm exec vitest run scripts/fixtures/` — 3/3
- [x] `pkf run spec-check` — 28 declared specs implemented
- [x] `pkf run spec-lint` — clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)