### PR TITLE
DOM: implement form.submit / requestSubmit / document.forms in BiDi runtime

### DIFF
--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -751,22 +751,22 @@ scenarios {
   // -- Auth / CORS / runtime gaps discovered during Phase 5 e2e (PR #132) ----
   new {
     id = "bug.dom.html-form-element-submit-missing"
-    name = "HTMLFormElement.submit and requestSubmit are not exposed"
+    name = "HTMLFormElement.submit and requestSubmit are exposed in the BiDi runtime"
     description =
-      "Crater's DOM JS bindings do not expose HTMLFormElement.prototype.submit() or .requestSubmit(). This blocks form-based login flows driven via BiDi (script.evaluate calling form.submit()) and forces tests to fall back to manual fetch() + window.location reassign. Source: PR #132 Phase 5 e2e attempt."
+      "createMockElement('form') in webdriver/webdriver/bidi_runtime_eval.mbt installs submit(), requestSubmit(submitter?), and reset() on form elements. form.submit() bypasses the submit event (per WHATWG), serializes controls into application/x-www-form-urlencoded, resolves the action relative to globalThis.location, and routes through __loadPageWithScripts / __loadPage (GET) or fetch() with redirect handling (POST). form.requestSubmit dispatches a cancelable 'submit' event with .submitter and honors preventDefault before invoking the submission helper. Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
     tags { "dom"; "forms"; "bidi"; "bug"; "phase5" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.dom-compat" }
   }
   new {
     id = "bug.dom.document-forms-missing"
-    name = "document.forms HTMLCollection is not exposed"
+    name = "document.forms returns FORM elements in document order via tree walk"
     description =
-      "document.forms (HTMLCollection of all <form> elements in document order) is not exposed on the JS document binding, so scripted form discovery from BiDi cannot work without querySelectorAll. Source: PR #132 Phase 5 e2e attempt."
+      "globalThis.document in webdriver/webdriver/bidi_runtime_eval.mbt exposes a `forms` getter that walks the documentElement subtree iteratively and returns every Element whose tagName is FORM in document order. Scripts driven via BiDi script.evaluate can discover forms without falling back to querySelectorAll('form'). Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
     tags { "dom"; "forms"; "bug"; "phase5" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.dom-compat" }
   }
   new {

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -770,6 +770,36 @@ scenarios {
     contributes { "goal.dom-compat" }
   }
   new {
+    id = "bug.dom.requestSubmit-button-type-not-validated"
+    name = "form.requestSubmit submitter validation does not check button type"
+    description =
+      "requestSubmit(submitter) in webdriver/webdriver/bidi_runtime_eval.mbt currently validates only nodeType === 1 + descendsFrom(form). Per WHATWG, the submitter must additionally be a submit button: either button[type=submit] (default type for <button>) or input[type=submit] / input[type=image]. Today a <button type=button> or <input type=text> passed as submitter is accepted instead of triggering a TypeError. Source: PR review on dom/form-submit, follow-up to bug.dom.html-form-element-submit-missing."
+    tags { "dom"; "forms"; "bidi"; "bug" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.dom-compat" }
+  }
+  new {
+    id = "bug.dom.form-reset-does-not-clear-values"
+    name = "form.reset fires reset event but does not clear control values"
+    description =
+      "el.reset() installed by createMockElement('form') in webdriver/webdriver/bidi_runtime_eval.mbt dispatches a cancelable 'reset' event, but never iterates form controls to restore them to their default state. Per WHATWG, each resettable control must be reset to its default value: input.defaultValue, select selectedness from the OPTION with the `selected` attribute, textarea.defaultValue, checkbox/radio default checkedness. Source: PR review on dom/form-submit."
+    tags { "dom"; "forms"; "bidi"; "bug" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.dom-compat" }
+  }
+  new {
+    id = "bug.dom.form-select-multiple-not-supported"
+    name = "form serialization does not handle select multiple"
+    description =
+      "controlEffectiveValue in webdriver/webdriver/bidi_runtime_eval.mbt handles single-select <select> by emitting one name=value pair per element. For <select multiple>, WHATWG specifies one name=value pair per selected option, e.g. tags=a&tags=c. Today only the first selected option (single-select fallback) is emitted, so multi-select forms are serialized incorrectly. Source: PR review on dom/form-submit."
+    tags { "dom"; "forms"; "bidi"; "bug" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.dom-compat" }
+  }
+  new {
     id = "bug.bidi.navigate-wait-complete-returns-early"
     name = "browsingContext.navigate wait complete resolves before HTML fetch on JS target"
     description =

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -395,4 +395,24 @@ tests {
     cmd =
       "bash -lc 'set -e; test -f http/samesite/samesite.mbt; grep -Fq -- \"pub fn classify_site_context\" http/samesite/samesite.mbt; grep -Fq -- \"pub fn should_attach_cookie\" http/samesite/samesite.mbt; test -f browser/shell/navigation_fetch.mbt; grep -Fq -- \"navigation_cookie_header\" browser/shell/navigation_fetch.mbt; grep -Fq -- \"is_top_level_navigation=true\" browser/shell/navigation_fetch.mbt; grep -Fq -- \"SameSite enforcement (RFC 6265bis)\" http/cookie_jar/cookie_jar.mbt; test -f http/samesite/samesite_wbtest.mbt; test -f browser/shell/navigation_samesite_wbtest.mbt; test -f http/cookie_jar/cookie_jar_wbtest.mbt; grep -Fq -- \"samesite: Strict cookie blocked on cross-site request\" http/cookie_jar/cookie_jar_wbtest.mbt'"
   }
+  new {
+    name = "bidi_form_submit_methods_exposed"
+    description =
+      "BiDi runtime exposes HTMLFormElement.submit / requestSubmit / reset. createMockElement('form') in webdriver/webdriver/bidi_runtime_eval.mbt installs installFormSubmissionMethods, which serializes controls into application/x-www-form-urlencoded and routes through the existing __loadPageWithScripts / fetch navigation helpers. Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
+    tags { "dom"; "forms"; "bidi" }
+    specRef { "bug.dom.html-form-element-submit-missing" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"installFormSubmissionMethods(el)\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"const installFormSubmissionMethods = (el)\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"el.requestSubmit = function\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"serializeFormDataUrlEncoded\" webdriver/webdriver/bidi_runtime_eval.mbt; test -f webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"form.requestSubmit dispatches submit event and honors preventDefault\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"form.submit bypasses submit event listener\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt'"
+  }
+  new {
+    name = "bidi_document_forms_getter_exposed"
+    description =
+      "BiDi runtime document exposes a `forms` getter that walks the documentElement subtree iteratively and returns every Element whose tagName is FORM in document order. Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
+    tags { "dom"; "forms"; "bidi" }
+    specRef { "bug.dom.document-forms-missing" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"get forms() {\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"const root = this.documentElement;\" webdriver/webdriver/bidi_runtime_eval.mbt; test -f webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"document.forms returns all FORM elements in document order\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt'"
+  }
 }

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -876,6 +876,38 @@ extern "js" fn js_evaluate_expression(
   #|       }
   #|       return out;
   #|     };
+  #|     const optionEffectiveValue = (option) => {
+  #|       const oAttrs = option._attrs || {};
+  #|       if (typeof oAttrs.value === 'string') return oAttrs.value;
+  #|       // Fall back to the option's text content (concatenated descendant text).
+  #|       const collectText = (node) => {
+  #|         if (!node) return '';
+  #|         if (node.nodeType === 3) {
+  #|           if (typeof node.data === 'string') return node.data;
+  #|           if (typeof node.nodeValue === 'string') return node.nodeValue;
+  #|           return '';
+  #|         }
+  #|         const kids = node._children || node.childNodes || [];
+  #|         let buf = '';
+  #|         for (let i = 0; i < kids.length; i++) buf += collectText(kids[i]);
+  #|         return buf;
+  #|       };
+  #|       return collectText(option);
+  #|     };
+  #|     const collectSelectOptions = (selectEl) => {
+  #|       const out = [];
+  #|       const stack = [selectEl];
+  #|       while (stack.length) {
+  #|         const node = stack.pop();
+  #|         if (!node) continue;
+  #|         const kids = node._children || node.childNodes || [];
+  #|         for (let i = kids.length - 1; i >= 0; i--) stack.push(kids[i]);
+  #|         if (node === selectEl) continue;
+  #|         if (node.nodeType !== 1) continue;
+  #|         if (String(node.tagName || '') === 'OPTION') out.push(node);
+  #|       }
+  #|       return out;
+  #|     };
   #|     const controlEffectiveValue = (control) => {
   #|       const attrs = control._attrs || {};
   #|       const tag = String(control.tagName || '');
@@ -883,6 +915,18 @@ extern "js" fn js_evaluate_expression(
   #|       if (tag === 'INPUT' && (type === 'checkbox' || type === 'radio')) {
   #|         if (typeof attrs.value === 'string' && attrs.value !== '') return attrs.value;
   #|         return 'on';
+  #|       }
+  #|       if (tag === 'SELECT') {
+  #|         if (typeof control.value === 'string' && control.value !== '') return control.value;
+  #|         if (typeof attrs.value === 'string' && attrs.value !== '') return attrs.value;
+  #|         const options = collectSelectOptions(control);
+  #|         if (options.length === 0) return '';
+  #|         for (const opt of options) {
+  #|           const oAttrs = opt._attrs || {};
+  #|           if (oAttrs.selected) return optionEffectiveValue(opt);
+  #|         }
+  #|         // HTML default: first option is selected if none marked.
+  #|         return optionEffectiveValue(options[0]);
   #|       }
   #|       if (typeof control.value === 'string' && control.value !== '') return control.value;
   #|       if (typeof attrs.value === 'string') return attrs.value;
@@ -948,12 +992,34 @@ extern "js" fn js_evaluate_expression(
   #|         return String(action || base);
   #|       }
   #|     };
+  #|     // WHATWG "Plan to navigate" filters unsafe URL schemes. We allow the
+  #|     // realistic safe set for a test runtime and explicitly drop anything else
+  #|     // (notably javascript: / vbscript: / other script-evaluating schemes) so a
+  #|     // scripted page cannot navigate via form.action="javascript:...".
+  #|     const isSubmissionSchemeAllowed = (url) => {
+  #|       let proto = '';
+  #|       try {
+  #|         proto = new URL(String(url || '')).protocol;
+  #|       } catch (_e) {
+  #|         return false;
+  #|       }
+  #|       const allowedSchemes = new Set(['http:', 'https:', 'about:', 'blob:', 'data:', 'file:']);
+  #|       return allowedSchemes.has(proto);
+  #|     };
   #|     const performSubmission = (formEl, submitter) => {
   #|       try {
   #|         const attrs = formEl._attrs || {};
   #|         const actionAttr = (typeof attrs.action === 'string' && attrs.action) ? attrs.action : '';
   #|         const method = String(attrs.method || 'GET').toUpperCase();
   #|         let action = resolveSubmissionUrl(actionAttr);
+  #|         if (!isSubmissionSchemeAllowed(action)) {
+  #|           let proto = '';
+  #|           try { proto = new URL(String(action || '')).protocol; } catch (_e) {}
+  #|           if (typeof console !== 'undefined' && console.error) {
+  #|             try { console.error('[bidi] form submission to unsafe scheme:', proto || action); } catch (_e) {}
+  #|           }
+  #|           return;
+  #|         }
   #|         const controls = collectFormControls(formEl);
   #|         const serialized = serializeFormDataUrlEncoded(controls, submitter);
   #|         if (method === 'POST') {
@@ -1054,7 +1120,7 @@ extern "js" fn js_evaluate_expression(
   #|       el.requestSubmit = function(submitter) {
   #|         let validatedSubmitter = null;
   #|         if (submitter !== undefined && submitter !== null) {
-  #|           if (!submitter._attrs || !(submitter._parent === this || descendsFrom(submitter, this))) {
+  #|           if (submitter.nodeType !== 1 || !(submitter._parent === this || descendsFrom(submitter, this))) {
   #|             throw new TypeError("requestSubmit: submitter is not a descendant of this form");
   #|           }
   #|           validatedSubmitter = submitter;

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -847,6 +847,234 @@ extern "js" fn js_evaluate_expression(
   #|       });
   #|     };
   #|
+  #|     // ---- HTML form submission helpers (used by createMockElement('form')) ----
+  #|     const descendsFrom = (node, ancestor) => {
+  #|       let cur = node && (node._parent || node.parentNode || null);
+  #|       while (cur) {
+  #|         if (cur === ancestor) return true;
+  #|         cur = cur._parent || cur.parentNode || null;
+  #|       }
+  #|       return false;
+  #|     };
+  #|     const collectFormControls = (formEl) => {
+  #|       const out = [];
+  #|       const stack = [formEl];
+  #|       const allowed = new Set(['INPUT', 'SELECT', 'TEXTAREA', 'BUTTON']);
+  #|       while (stack.length) {
+  #|         const node = stack.pop();
+  #|         if (!node) continue;
+  #|         const kids = node._children || node.childNodes || [];
+  #|         for (let i = kids.length - 1; i >= 0; i--) stack.push(kids[i]);
+  #|         if (node === formEl) continue;
+  #|         if (node.nodeType !== 1) continue;
+  #|         if (!allowed.has(String(node.tagName || ''))) continue;
+  #|         const attrs = node._attrs || {};
+  #|         if ('disabled' in attrs) continue;
+  #|         const name = attrs.name;
+  #|         if (typeof name !== 'string' || name.length === 0) continue;
+  #|         out.push(node);
+  #|       }
+  #|       return out;
+  #|     };
+  #|     const controlEffectiveValue = (control) => {
+  #|       const attrs = control._attrs || {};
+  #|       const tag = String(control.tagName || '');
+  #|       const type = String(attrs.type || '').toLowerCase();
+  #|       if (tag === 'INPUT' && (type === 'checkbox' || type === 'radio')) {
+  #|         if (typeof attrs.value === 'string' && attrs.value !== '') return attrs.value;
+  #|         return 'on';
+  #|       }
+  #|       if (typeof control.value === 'string' && control.value !== '') return control.value;
+  #|       if (typeof attrs.value === 'string') return attrs.value;
+  #|       return '';
+  #|     };
+  #|     const isSubmissionExcluded = (control, submitter) => {
+  #|       const tag = String(control.tagName || '');
+  #|       const type = String((control._attrs && control._attrs.type) || '').toLowerCase();
+  #|       if (tag === 'BUTTON') {
+  #|         // Only the explicit submitter contributes; buttons without type default to submit.
+  #|         if (control === submitter) return false;
+  #|         return true;
+  #|       }
+  #|       if (tag === 'INPUT') {
+  #|         if (type === 'button' || type === 'reset' || type === 'image' || type === 'file') {
+  #|           return control !== submitter;
+  #|         }
+  #|         if (type === 'submit') return control !== submitter;
+  #|         if (type === 'checkbox' || type === 'radio') {
+  #|           return !control._attrs || !control._attrs.checked;
+  #|         }
+  #|       }
+  #|       return false;
+  #|     };
+  #|     const serializeFormDataUrlEncoded = (controls, submitter) => {
+  #|       const parts = [];
+  #|       const enc = (s) => encodeURIComponent(String(s));
+  #|       for (const c of controls) {
+  #|         if (isSubmissionExcluded(c, submitter)) continue;
+  #|         const attrs = c._attrs || {};
+  #|         const name = attrs.name;
+  #|         if (typeof name !== 'string' || name.length === 0) continue;
+  #|         const value = controlEffectiveValue(c);
+  #|         parts.push(enc(name) + '=' + enc(value));
+  #|       }
+  #|       return parts.join('&');
+  #|     };
+  #|     const dispatchFormSubmitEvent = (formEl, submitter) => {
+  #|       const baseEvent = globalThis.__bidiCreateEvent
+  #|         ? globalThis.__bidiCreateEvent('submit', { bubbles: true, cancelable: true })
+  #|         : {
+  #|             type: 'submit',
+  #|             bubbles: true,
+  #|             cancelable: true,
+  #|             defaultPrevented: false,
+  #|             preventDefault() { this.defaultPrevented = true; },
+  #|             stopPropagation() {},
+  #|             stopImmediatePropagation() {},
+  #|           };
+  #|       baseEvent.submitter = submitter || null;
+  #|       if (typeof formEl.dispatchEvent === 'function') {
+  #|         try { formEl.dispatchEvent(baseEvent); } catch (_e) {}
+  #|       }
+  #|       return !baseEvent.defaultPrevented;
+  #|     };
+  #|     const resolveSubmissionUrl = (action) => {
+  #|       const base = (globalThis.location && typeof globalThis.location.href === 'string')
+  #|         ? globalThis.location.href
+  #|         : (globalThis.__pageUrl || 'about:blank');
+  #|       try {
+  #|         return new URL(String(action || ''), base).href;
+  #|       } catch (_e) {
+  #|         return String(action || base);
+  #|       }
+  #|     };
+  #|     const performSubmission = (formEl, submitter) => {
+  #|       try {
+  #|         const attrs = formEl._attrs || {};
+  #|         const actionAttr = (typeof attrs.action === 'string' && attrs.action) ? attrs.action : '';
+  #|         const method = String(attrs.method || 'GET').toUpperCase();
+  #|         let action = resolveSubmissionUrl(actionAttr);
+  #|         const controls = collectFormControls(formEl);
+  #|         const serialized = serializeFormDataUrlEncoded(controls, submitter);
+  #|         if (method === 'POST') {
+  #|           const fetchFn = globalThis.__fetchInternal || globalThis.fetch;
+  #|           if (typeof fetchFn === 'function') {
+  #|             const init = {
+  #|               method: 'POST',
+  #|               headers: { 'content-type': 'application/x-www-form-urlencoded' },
+  #|               body: serialized,
+  #|               redirect: 'manual',
+  #|             };
+  #|             try {
+  #|               const p = fetchFn(action, init);
+  #|               if (p && typeof p.then === 'function') {
+  #|                 p.then((response) => {
+  #|                   if (!response) return;
+  #|                   const status = Number(response.status || 0);
+  #|                   if (status >= 300 && status < 400) {
+  #|                     let loc = null;
+  #|                     try { loc = response.headers && response.headers.get && response.headers.get('location'); } catch (_e) {}
+  #|                     if (loc) {
+  #|                       const resolved = resolveSubmissionUrl(loc);
+  #|                       if (globalThis.location) {
+  #|                         try { globalThis.location.href = resolved; } catch (_e) {}
+  #|                       }
+  #|                       globalThis.__pageUrl = resolved;
+  #|                       if (typeof globalThis.__loadPageWithScripts === 'function') {
+  #|                         try {
+  #|                           const rp = globalThis.__loadPageWithScripts(resolved);
+  #|                           if (rp && typeof rp.then === 'function') rp.then(() => {}, () => {});
+  #|                         } catch (_e) {}
+  #|                       } else if (typeof globalThis.__loadPage === 'function') {
+  #|                         try {
+  #|                           const rp = globalThis.__loadPage(resolved);
+  #|                           if (rp && typeof rp.then === 'function') rp.then(() => {}, () => {});
+  #|                         } catch (_e) {}
+  #|                       }
+  #|                     }
+  #|                   } else if (status >= 200 && status < 300) {
+  #|                     try {
+  #|                       const tp = response.text && response.text();
+  #|                       if (tp && typeof tp.then === 'function') {
+  #|                         tp.then((html) => {
+  #|                           if (typeof globalThis.__loadHTML === 'function') {
+  #|                             try { globalThis.__loadHTML(String(html || '')); } catch (_e) {}
+  #|                           }
+  #|                           if (globalThis.location) {
+  #|                             try { globalThis.location.href = action; } catch (_e) {}
+  #|                           }
+  #|                           globalThis.__pageUrl = action;
+  #|                         }, () => {});
+  #|                       }
+  #|                     } catch (_e) {}
+  #|                   }
+  #|                 }, () => {});
+  #|               }
+  #|             } catch (_e) {}
+  #|           }
+  #|           return;
+  #|         }
+  #|         // GET (and any other method) — encode in query string and navigate.
+  #|         let target = action;
+  #|         if (serialized.length > 0) {
+  #|           try {
+  #|             const u = new URL(target);
+  #|             u.search = '?' + serialized;
+  #|             target = u.href;
+  #|           } catch (_e) {
+  #|             const hashIdx = target.indexOf('#');
+  #|             const base = hashIdx >= 0 ? target.slice(0, hashIdx) : target;
+  #|             const frag = hashIdx >= 0 ? target.slice(hashIdx) : '';
+  #|             const qIdx = base.indexOf('?');
+  #|             target = (qIdx >= 0 ? base.slice(0, qIdx) : base) + '?' + serialized + frag;
+  #|           }
+  #|         }
+  #|         if (globalThis.location) {
+  #|           try { globalThis.location.href = target; } catch (_e) {}
+  #|         }
+  #|         globalThis.__pageUrl = target;
+  #|         if (typeof globalThis.__loadPageWithScripts === 'function') {
+  #|           try {
+  #|             const np = globalThis.__loadPageWithScripts(target);
+  #|             if (np && typeof np.then === 'function') np.then(() => {}, () => {});
+  #|           } catch (_e) {}
+  #|         } else if (typeof globalThis.__loadPage === 'function') {
+  #|           try {
+  #|             const np = globalThis.__loadPage(target);
+  #|             if (np && typeof np.then === 'function') np.then(() => {}, () => {});
+  #|           } catch (_e) {}
+  #|         }
+  #|       } catch (_e) {}
+  #|     };
+  #|     const installFormSubmissionMethods = (el) => {
+  #|       el.submit = function() {
+  #|         performSubmission(this, null);
+  #|         return undefined;
+  #|       };
+  #|       el.requestSubmit = function(submitter) {
+  #|         let validatedSubmitter = null;
+  #|         if (submitter !== undefined && submitter !== null) {
+  #|           if (!submitter._attrs || !(submitter._parent === this || descendsFrom(submitter, this))) {
+  #|             throw new TypeError("requestSubmit: submitter is not a descendant of this form");
+  #|           }
+  #|           validatedSubmitter = submitter;
+  #|         }
+  #|         const allowed = dispatchFormSubmitEvent(this, validatedSubmitter);
+  #|         if (!allowed) return undefined;
+  #|         performSubmission(this, validatedSubmitter);
+  #|         return undefined;
+  #|       };
+  #|       el.reset = function() {
+  #|         const resetEvent = globalThis.__bidiCreateEvent
+  #|           ? globalThis.__bidiCreateEvent('reset', { bubbles: true, cancelable: true })
+  #|           : null;
+  #|         if (resetEvent && typeof this.dispatchEvent === 'function') {
+  #|           try { this.dispatchEvent(resetEvent); } catch (_e) {}
+  #|         }
+  #|         return undefined;
+  #|       };
+  #|     };
+  #|
   #|     // Minimal Mock DOM for Preact compatibility
   #|     const createMockElement = (tagName) => {
   #|       const lowerTag = String(tagName || "").toLowerCase();
@@ -1443,6 +1671,9 @@ extern "js" fn js_evaluate_expression(
   #|           return toCollection(results, "htmlcollection");
   #|         }
   #|       };
+  #|       if (lowerTag === 'form') {
+  #|         installFormSubmissionMethods(el);
+  #|       }
   #|       return el;
   #|     };
   #|
@@ -2391,6 +2622,20 @@ extern "js" fn js_evaluate_expression(
   #|       },
   #|       getElementsByTagName(tag) { return html.getElementsByTagName(tag); },
   #|       getElementsByClassName(cls) { return html.getElementsByClassName(cls); },
+  #|       get forms() {
+  #|         const out = [];
+  #|         const root = this.documentElement;
+  #|         if (!root) return out;
+  #|         const stack = [root];
+  #|         while (stack.length) {
+  #|           const node = stack.pop();
+  #|           if (!node) continue;
+  #|           if (node.nodeType === 1 && String(node.tagName || '') === 'FORM') out.push(node);
+  #|           const kids = node._children || node.childNodes || [];
+  #|           for (let i = kids.length - 1; i >= 0; i--) stack.push(kids[i]);
+  #|         }
+  #|         return out;
+  #|       },
   #|       execCommand(command) {
   #|         const cmd = String(command || '').toLowerCase();
   #|         if (cmd === 'selectall') return true;

--- a/webdriver/webdriver/bidi_runtime_form_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_form_wbtest.mbt
@@ -98,6 +98,167 @@ test "bidi form.requestSubmit dispatches submit event and honors preventDefault"
 }
 
 ///|
+test "bidi form.submit ignores javascript: action (URL scheme allowlist)" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  let navCalled = 0;
+    #|  let fetchCalled = 0;
+    #|  let errorCalls = 0;
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  const savedFetch = globalThis.fetch;
+    #|  const savedFetchInternal = globalThis.__fetchInternal;
+    #|  const savedConsoleError = (globalThis.console && globalThis.console.error) || null;
+    #|  globalThis.__loadPageWithScripts = (url) => { navCalled++; return Promise.resolve({ url: String(url || ''), status: 200 }); };
+    #|  globalThis.__loadPage = (url) => { navCalled++; return Promise.resolve({ url: String(url || ''), status: 200 }); };
+    #|  globalThis.fetch = () => { fetchCalled++; return Promise.resolve({ status: 200, headers: { get: () => null }, text: () => Promise.resolve('') }); };
+    #|  globalThis.__fetchInternal = () => { fetchCalled++; return Promise.resolve({ status: 200, headers: { get: () => null }, text: () => Promise.resolve('') }); };
+    #|  if (globalThis.console) { globalThis.console.error = () => { errorCalls++; }; }
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="jsf" action="javascript:throw new Error(\'xss\')" method="GET"></form>' +
+    #|        '<form id="vbf" action="vbscript:msgbox(1)" method="GET"></form>' +
+    #|        '<form id="filef" action="ftp://example.test/bad" method="GET"></form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    const beforeHref = String(globalThis.location.href);
+    #|    globalThis.__pageUrl = beforeHref;
+    #|    let threw = 0;
+    #|    try { document.getElementById('jsf').submit(); } catch (_e) { threw++; }
+    #|    try { document.getElementById('vbf').submit(); } catch (_e) { threw++; }
+    #|    try { document.getElementById('filef').submit(); } catch (_e) { threw++; }
+    #|    const afterHref = String(globalThis.location.href);
+    #|    return [
+    #|      'threw=' + threw,
+    #|      'navCalled=' + navCalled,
+    #|      'fetchCalled=' + fetchCalled,
+    #|      'errorCalls=' + errorCalls,
+    #|      'hrefChanged=' + (beforeHref !== afterHref)
+    #|    ].join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|    globalThis.fetch = savedFetch;
+    #|    globalThis.__fetchInternal = savedFetchInternal;
+    #|    if (globalThis.console && savedConsoleError) globalThis.console.error = savedConsoleError;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  // No exception should escape (silent drop), no navigation, no fetch.
+  assert_true(json.contains("threw=0"))
+  assert_true(json.contains("navCalled=0"))
+  assert_true(json.contains("fetchCalled=0"))
+  assert_true(json.contains("hrefChanged=false"))
+  // All three (javascript:, vbscript:, ftp:) are blocked and each logs a
+  // single console.error.
+  assert_true(json.contains("errorCalls=3"))
+}
+
+///|
+test "bidi form.submit serializes SELECT options correctly" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  let navTarget = '';
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  globalThis.__loadPageWithScripts = (url) => { navTarget = String(url || ''); return Promise.resolve({ url: navTarget, status: 200 }); };
+    #|  globalThis.__loadPage = (url) => { navTarget = String(url || ''); return Promise.resolve({ url: navTarget, status: 200 }); };
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="f" action="https://example.test/sel" method="GET">' +
+    #|          '<select name="color">' +
+    #|            '<option value="r">Red</option>' +
+    #|            '<option value="g" selected>Green</option>' +
+    #|            '<option value="b">Blue</option>' +
+    #|          '</select>' +
+    #|          '<select name="size">' +
+    #|            '<option value="s">Small</option>' +
+    #|            '<option value="m">Medium</option>' +
+    #|          '</select>' +
+    #|          '<select name="fruit">' +
+    #|            '<option>Apple</option>' +
+    #|            '<option selected>Banana</option>' +
+    #|          '</select>' +
+    #|        '</form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    document.getElementById('f').submit();
+    #|    return [
+    #|      'hasColor=' + navTarget.includes('color=g'),
+    #|      'hasSize=' + navTarget.includes('size=s'),
+    #|      'hasFruit=' + navTarget.includes('fruit=Banana'),
+    #|      'noEmptyColor=' + !/[?&]color=(&|$)/.test(navTarget),
+    #|      'navTarget=' + navTarget
+    #|    ].join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("hasColor=true"))
+  assert_true(json.contains("hasSize=true"))
+  assert_true(json.contains("hasFruit=true"))
+  assert_true(json.contains("noEmptyColor=true"))
+}
+
+///|
+test "bidi form.requestSubmit submitter validation accepts element without _attrs" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  globalThis.__loadPageWithScripts = () => Promise.resolve({ url: '', status: 200 });
+    #|  globalThis.__loadPage = () => Promise.resolve({ url: '', status: 200 });
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="f" action="/x" method="GET">' +
+    #|          '<button id="b" type="submit">Go</button>' +
+    #|        '</form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    const f = document.getElementById('f');
+    #|    const b = document.getElementById('b');
+    #|    // Strip _attrs to simulate a host element lacking it. nodeType === 1
+    #|    // + descendsFrom should still satisfy the validation.
+    #|    delete b._attrs;
+    #|    let sawSubmitter = 'unset';
+    #|    let threwForChild = 0;
+    #|    f.addEventListener('submit', (event) => {
+    #|      sawSubmitter = event.submitter === b ? 'matches' : (event.submitter === null ? 'null' : 'other');
+    #|      event.preventDefault();
+    #|    });
+    #|    try { f.requestSubmit(b); } catch (_e) { threwForChild++; }
+    #|    // Non-descendant should still throw.
+    #|    let threwForOutside = 0;
+    #|    const outsideEl = document.createElement('button');
+    #|    try { f.requestSubmit(outsideEl); } catch (_e) { threwForOutside++; }
+    #|    return [
+    #|      'submitter=' + sawSubmitter,
+    #|      'threwForChild=' + threwForChild,
+    #|      'threwForOutside=' + threwForOutside
+    #|    ].join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("submitter=matches"))
+  assert_true(json.contains("threwForChild=0"))
+  assert_true(json.contains("threwForOutside=1"))
+}
+
+///|
 test "bidi form.submit bypasses submit event listener and encodes GET query" {
   reset_runtime_js_state()
   let _ = evaluate_js("0")

--- a/webdriver/webdriver/bidi_runtime_form_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_form_wbtest.mbt
@@ -1,0 +1,143 @@
+///|
+/// Form submission / document.forms tests for the BiDi runtime mock DOM.
+/// Covers bug.dom.html-form-element-submit-missing and bug.dom.document-forms-missing.
+
+///|
+test "bidi document.forms returns all FORM elements in document order" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  globalThis.__loadHTML(
+    #|    '<!doctype html><html><body>' +
+    #|      '<form id="a" action="/one"></form>' +
+    #|      '<div><form id="b" action="/two"></form></div>' +
+    #|      '<form id="c" action="/three"></form>' +
+    #|    '</body></html>'
+    #|  );
+    #|  const forms = document.forms;
+    #|  return [
+    #|    'len=' + forms.length,
+    #|    'ids=' + forms.map((f) => f.id).join(','),
+    #|    'allForms=' + forms.every((f) => f.tagName === 'FORM')
+    #|  ].join(';');
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("len=3"))
+  assert_true(json.contains("ids=a,b,c"))
+  assert_true(json.contains("allForms=true"))
+}
+
+///|
+test "bidi form.submit and form.requestSubmit are functions on form elements" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  globalThis.__loadHTML('<!doctype html><html><body><form id="f"></form></body></html>');
+    #|  const f = document.getElementById('f');
+    #|  return [
+    #|    'submit=' + typeof f.submit,
+    #|    'requestSubmit=' + typeof f.requestSubmit,
+    #|    'reset=' + typeof f.reset
+    #|  ].join(';');
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("submit=function"))
+  assert_true(json.contains("requestSubmit=function"))
+  assert_true(json.contains("reset=function"))
+}
+
+///|
+test "bidi form.requestSubmit dispatches submit event and honors preventDefault" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  let navCalled = 0;
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  globalThis.__loadPageWithScripts = () => { navCalled++; return Promise.resolve({ url: '', status: 200 }); };
+    #|  globalThis.__loadPage = () => { navCalled++; return Promise.resolve({ url: '', status: 200 }); };
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="f" action="/blocked" method="GET">' +
+    #|          '<input name="user" value="alice">' +
+    #|        '</form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    const beforeHref = String(globalThis.location.href);
+    #|    globalThis.__pageUrl = beforeHref;
+    #|    const f = document.getElementById('f');
+    #|    let fired = 0;
+    #|    let sawSubmitter = 'unset';
+    #|    f.addEventListener('submit', (event) => {
+    #|      fired++;
+    #|      sawSubmitter = (event.submitter === null) ? 'null' : (event.submitter ? 'set' : 'unset');
+    #|      event.preventDefault();
+    #|    });
+    #|    f.requestSubmit();
+    #|    const afterHref = String(globalThis.location.href);
+    #|    return [
+    #|      'fired=' + fired,
+    #|      'submitter=' + sawSubmitter,
+    #|      'navCalled=' + navCalled,
+    #|      'navigated=' + (beforeHref !== afterHref)
+    #|    ].join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("fired=1"))
+  assert_true(json.contains("submitter=null"))
+  assert_true(json.contains("navCalled=0"))
+  assert_true(json.contains("navigated=false"))
+}
+
+///|
+test "bidi form.submit bypasses submit event listener and encodes GET query" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  let navTarget = '';
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  globalThis.__loadPageWithScripts = (url) => { navTarget = String(url || ''); return Promise.resolve({ url: navTarget, status: 200 }); };
+    #|  globalThis.__loadPage = (url) => { navTarget = String(url || ''); return Promise.resolve({ url: navTarget, status: 200 }); };
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="f" action="https://example.test/submit" method="GET">' +
+    #|          '<input name="q" value="hello world">' +
+    #|          '<input name="t" type="checkbox" checked>' +
+    #|          '<input name="ignored" type="checkbox">' +
+    #|        '</form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    const f = document.getElementById('f');
+    #|    let fired = 0;
+    #|    f.addEventListener('submit', () => { fired++; });
+    #|    f.submit();
+    #|    return [
+    #|      'fired=' + fired,
+    #|      'hasQ=' + navTarget.includes('q=hello%20world'),
+    #|      'hasT=' + navTarget.includes('t=on'),
+    #|      'noIgnored=' + !navTarget.includes('ignored'),
+    #|      'host=' + navTarget.includes('example.test')
+    #|    ].join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("fired=0"))
+  assert_true(json.contains("hasQ=true"))
+  assert_true(json.contains("hasT=true"))
+  assert_true(json.contains("noIgnored=true"))
+  assert_true(json.contains("host=true"))
+}


### PR DESCRIPTION
## Summary

Closes 2 DOM gap scenarios filed in PR #134 and files 3 new follow-up drafts surfaced during review.

### Closes (flips to approved)
- `bug.dom.html-form-element-submit-missing`
- `bug.dom.document-forms-missing`

### What changed

`webdriver/webdriver/bidi_runtime_eval.mbt`:

- **`createMockElement(tag)`** now hooks `installFormSubmissionMethods(el)` when `lowerTag === 'form'`.
- **`form.submit()`** (per WHATWG): bypasses the submit event, navigates directly.
- **`form.requestSubmit(submitter?)`**: validates submitter is an Element descendant, dispatches cancelable submit event with `event.submitter`, honors `preventDefault`. Navigates if not prevented.
- **Form data serialization**: `application/x-www-form-urlencoded` only. SELECT serializes selected option's value (falling back to text content, then first option per HTML default). Multipart not supported (filed as draft).
- **URL scheme allowlist** for `form.action`: only `http:` / `https:` / `about:` / `blob:` / `data:` / `file:` are accepted. `javascript:`, `vbscript:`, etc. are dropped with `console.error`. Defends against XSS via attacker-controlled form.action.
- **Navigation dispatch**: GET → append query, call `__loadPageWithScripts`; POST → `fetch` with urlencoded body + manual redirect, follow 3xx Location or `__loadHTML` the 2xx body. All async paths are fire-and-forget with `.then(noop, noop)` so the BiDi sync runtime never throws.
- **`document.forms`**: iterative tree walk over `documentElement`, returns FORM elements in document order.

### Files

- `webdriver/webdriver/bidi_runtime_eval.mbt` — +243 LOC JS (impl) + 3 small fixes from review
- `webdriver/webdriver/bidi_runtime_form_wbtest.mbt` — 7 new wbtests (4 initial + 3 from review fixes)
- `specs/crater.pkl` — 2 scenarios flipped draft → approved + 3 new drafts
- `specs/tasks.Test.pkl` — 2 new pkspec smoke tests

### Test counts (all passing)

| Suite | Before | After |
|---|---|---|
| `webdriver/webdriver` | 308 | 315 |
| `pkf run spec-test` | 30 | 32 |

### New follow-up drafts

| Scenario | Notes |
|---|---|
| `bug.dom.requestSubmit-button-type-not-validated` | Submitter validation checks descendant + Element nodeType but not button[type=submit] / input[type=submit] |
| `bug.dom.form-reset-does-not-clear-values` | `el.reset()` fires reset event but doesn't clear control values |
| `bug.dom.form-select-multiple-not-supported` | Only single-select is serialized; multi-select needs special handling |

## Threat scenarios closed by this PR

1. **`form.action = "javascript:malicious()"` would execute** — URL scheme allowlist blocks it (the most serious item from code review).
2. **`script.evaluate("typeof form.submit")` returned `"undefined"`** — now returns `"function"`.
3. **`script.evaluate("document.forms.length")` was `undefined`** — now an iterative tree walk.

## Test plan

- [x] `moon test -p mizchi/crater-webdriver/webdriver` — 315/315
- [x] `pkf run spec-test` — 32/32
- [x] `pkf run spec-check` / `spec-lint` — clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)