### PR TITLE
File 3 BiDi runtime gaps surfaced by Phase 5 form-based e2e attempt

### DIFF
--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -829,6 +829,36 @@ scenarios {
     reviewStatus = "approved"
     contributes { "goal.dom-compat" }
   }
+  new {
+    id = "bug.bidi.navigate-http-url-not-parsed"
+    name = "BiDi navigate to http URL does not populate the runtime document"
+    description =
+      "PR #137 made browsingContext.navigate { wait: complete } actually await __loadPageWithScripts for http URLs, but the production navigation pipeline does not invoke __loadPageWithScripts for non-data URLs in the first place. After navigate to http://127.0.0.1:.../login resolves successfully, the BiDi runtime document mock is still about:blank with the default <div id='root'></div> shell — document.forms is empty. Bridging shell-side navigation_fetch results into the BiDi runtime mock is the missing piece. Source: PR #138 (Phase 5 form-based e2e attempt) — the e2e test poll loop never observes any body change after navigate."
+    tags { "bidi"; "navigation"; "runtime"; "bug" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.protocol-compat"; "goal.dom-compat" }
+  }
+  new {
+    id = "bug.bidi.form-submit-no-followup-navigation"
+    name = "form.submit in BiDi runtime does not drive a follow-up navigation"
+    description =
+      "PR #135 added form.submit() to the BiDi runtime DOM with URL-encoded body construction and __loadPageWithScripts dispatch. In practice, calling form.submit() from script.evaluate does not produce a document update — the POST + 302 + GET sequence does not flow through the navigation pipeline that updates document.body. Likely the same root cause as bug.bidi.navigate-http-url-not-parsed (BiDi runtime mock vs shell-side navigation are disjoint). Source: PR #138."
+    tags { "bidi"; "form"; "runtime"; "navigation"; "bug" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.dom-compat"; "goal.protocol-compat" }
+  }
+  new {
+    id = "bug.bidi.context-state-leaks-across-tests"
+    name = "BiDi runtime context state leaks across test sessions"
+    description =
+      "Running the existing storage.setCookie + rememberSyntheticLocationHref e2e test changes runtime state such that a subsequent navigate parses HTML correctly, while a standalone form-based test does not. Specifically rememberSyntheticLocationHref appears to leave behind something that makes the next navigate populate document.forms. This is a test-isolation smell that masks bug.bidi.navigate-http-url-not-parsed when the cookie-injection test runs first. Source: PR #138 e2e investigation."
+    tags { "bidi"; "test-isolation"; "bug" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.protocol-compat" }
+  }
 
   // -- Diagnostic / Tools (issue-driven) -------------------------------------
   new {


### PR DESCRIPTION
## Summary

Attempting to rewrite \`tests/auth-flow-via-bidi.test.ts\` to drive the real form-based BiDi login flow — now that PRs #135 / #136 / #137 closed the documented DOM and runtime gaps — surfaced that the production BiDi runtime path still doesn't actually fetch + parse http URLs, and \`form.submit()\` doesn't drive a follow-up navigation that updates \`document.body\`.

The wbtests for PRs #135 / #137 used stubs of \`__loadPageWithScripts\` so they exercised the structural contract and passed; the production navigate path doesn't invoke \`__loadPageWithScripts\`, so the structural fix didn't translate into a working end-to-end. File these as draft scenarios so the gap is tracked.

## New draft scenarios

| Scenario | Severity | What |
|---|---|---|
| \`bug.bidi.navigate-http-url-not-parsed\` | major | After \`browsingContext.navigate { url: "http://...", wait: "complete" }\` resolves, the BiDi runtime document is still \`about:blank\` with the default \`<div id="root"></div>\` shell. \`document.forms\` is empty. The shell-side navigation_fetch result is not bridged into the BiDi runtime mock. |
| \`bug.bidi.form-submit-no-followup-navigation\` | major | \`form.submit()\` (added in PR #135) does not produce a document update. The POST + 302 + GET sequence does not flow through whatever pipeline updates \`document.body\` in the BiDi runtime. Likely the same root cause. |
| \`bug.bidi.context-state-leaks-across-tests\` | minor | The existing storage.setCookie + rememberSyntheticLocationHref e2e test changes runtime state such that the next \`navigate\` parses HTML correctly, while a standalone form-based test does not. Test-isolation smell that masked the above gaps. |

## Architectural diagnosis

The BiDi runtime layer (\`webdriver/webdriver/bidi_runtime_eval.mbt\`) has its own \`document\` mock starting at line 2161. \`script.evaluate\` reads from this mock, NOT from the shell's loaded document. PR #137's async bridge awaits \`__loadPageWithScripts\` and sends the BiDi response when it resolves — but \`__loadPageWithScripts\` is the JS-side loader that populates the BiDi mock, and the actual production navigation goes through MoonBit's \`session.navigate_to()\` (shell layer), which does not call \`__loadPageWithScripts\`.

The two DOMs are disjoint. Resolving this needs either (a) unifying the two DOMs, (b) bridging shell-side navigation results into the BiDi runtime mock after each navigation, or (c) routing BiDi navigate through \`__loadPageWithScripts\` end-to-end so the shell-side load also populates the runtime mock. Each option has substantial design impact and is out of scope for this PR.

## What this PR does NOT do

- Does NOT modify the production code (PRs #135 / #136 / #137 stay as-is — their structural contracts are met, the gap is in the upstream navigation pipeline).
- Does NOT rewrite the e2e test. The cookie-injection-based test from PR #132 still works and is the only form of e2e coverage until these gaps are addressed.
- Does NOT re-open any closed issues. Files new scenarios so the gaps survive context loss.

## Test plan

- [x] \`pkf run spec-check\` — all 38 declared specs implemented (was 35; +3 drafts that don't need impls)
- [x] \`pkf run spec-lint\` — clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)