### PR TITLE
Narrow WPT pkfire inputs to actual dependencies

### DIFF
--- a/tasks/sources.pkl
+++ b/tasks/sources.pkl
@@ -29,6 +29,13 @@ nodeSources: Listing<String> = new {
   "benchmarks/**/*.ts"
 }
 
+wptToolchainSources: Listing<String> = new {
+  "package.json"
+  "pnpm-lock.yaml"
+  "pnpm-workspace.yaml"
+  "tsconfig.json"
+}
+
 pkspecSources: Listing<String> = new {
   ".github/workflows/**/*.yml"
   "Taskfile.pkl"

--- a/tasks/visual.pkl
+++ b/tasks/visual.pkl
@@ -23,7 +23,9 @@ testWptVrt: pkfire.Task = new {
   cmd = "just test-wpt-vrt"
   cache = false
   inputs {
-    ...src.nodeSources
+    ...src.wptToolchainSources
+    "playwright.config.ts"
+    "tests/wpt-vrt.test.ts"
     "wpt-vrt.json"
     "tests/wpt-vrt-baseline.json"
     "wpt/**"

--- a/tasks/wpt.pkl
+++ b/tasks/wpt.pkl
@@ -8,7 +8,7 @@ testWptCss: pkfire.Task = new {
   cmd = "just wpt-all"
   cache = false
   inputs {
-    ...src.nodeSources
+    ...src.wptToolchainSources
     "css/**"
     "layout/**"
     "painter/**"
@@ -32,7 +32,7 @@ testWptDom: pkfire.Task = new {
   cmd = "just wpt-dom-all"
   cache = false
   inputs {
-    ...src.nodeSources
+    ...src.wptToolchainSources
     "dom/**"
     "runtime/**"
     "js/**"
@@ -49,7 +49,7 @@ testWptWebdriver: pkfire.Task = new {
   cmd = "just wpt-webdriver-all"
   cache = false
   inputs {
-    ...src.nodeSources
+    ...src.wptToolchainSources
     "browser/**"
     "testing/**"
     "webdriver/**"


### PR DESCRIPTION
## Summary

WPT runs are long (10+ min for the full matrix). Today, every edit to any \`.ts\` file under \`scripts/\` or \`tests/\`, every \`benchmarks/\` change, every \`browser/scripts/**/*.mjs\` edit invalidates the WPT cache and re-runs the suites — because all four WPT tasks (\`testWptCss\`, \`testWptDom\`, \`testWptWebdriver\`, \`testWptVrt\`) pull in \`...src.nodeSources\` which is the broad node toolchain sweep.

This PR narrows the WPT cache key to just the files that actually affect WPT outcomes.

## Changes

- **\`tasks/sources.pkl\`** — new \`wptToolchainSources\` listing with only the toolchain files (package.json, pnpm-lock.yaml, pnpm-workspace.yaml, tsconfig.json).
- **\`tasks/wpt.pkl\`** — \`testWptCss\` / \`testWptDom\` / \`testWptWebdriver\` swap \`...src.nodeSources\` → \`...src.wptToolchainSources\`. The per-task \`scripts/wpt-*.ts\` files stay listed explicitly.
- **\`tasks/visual.pkl\`** — \`testWptVrt\` swaps to the narrow set plus \`playwright.config.ts\` + \`tests/wpt-vrt.test.ts\`. \`testVrt\` (paint VRT) keeps \`...src.nodeSources\` since its surface is broader than WPT-specific.

## What now invalidates WPT cache

Only the legitimately relevant changes:

| Task | Triggers WPT re-run |
|---|---|
| testWptCss | css/, layout/, painter/, renderer/, runtime/, scripts/wpt-{runner,config,html-utils}.ts, scripts/test-wpt-module-baseline.sh, tests/wpt-baselines/**, wpt.json, wpt/css/**, wpt/resources/**, toolchain config |
| testWptDom | dom/, runtime/, js/, scripts/wpt-dom-runner.ts, wpt/dom/**, wpt/domparsing/**, wpt/resources/**, toolchain |
| testWptWebdriver | browser/, testing/, webdriver/, scripts/wpt-bidi-subset.json, scripts/wpt-webdriver-runner.ts, wpt/webdriver/**, toolchain |
| testWptVrt | wpt-vrt.json, tests/wpt-vrt-baseline.json, wpt/**, playwright.config.ts, tests/wpt-vrt.test.ts, toolchain |

What no longer invalidates (huge win):
- Editing other \`tests/*.test.ts\` (unrelated test files)
- Editing other \`scripts/**/*.ts\` (e.g. flaker-*, vrt-*, real-world-paint-bench)
- Editing \`benchmarks/**\`
- Editing \`browser/scripts/**/*.mjs\`

## Test plan

- [x] \`pkf run check\` — 0 errors
- [x] \`pkf run spec-check\` — 37 declared specs implemented
- [x] \`pkf run spec-test\` — 37/37 pass
- [ ] CI green on this PR — verify the WPT tasks still trigger on relevant changes (this PR touches none of the WPT-relevant sources, so all WPT gates should skip)

## Expected CI signal

This PR only edits \`tasks/*.pkl\` (and the narrow toolchain change is purely metadata). Under the new gating:
- \`testWptCss\` / \`testWptDom\` / \`testWptWebdriver\` / \`testWptVrt\` should all SKIP (no input file changed)
- \`affected pkfire\` should still run (it gates everything)
- \`flaker-config\` should still run
- The narrow-input change itself is metadata-only, so no production tests need to re-run

If WPT tasks fire anyway, the narrowing didn't take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)