### PR TITLE
Close 3 form micro-bug DOM scenarios

### DIFF
--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -773,30 +773,30 @@ scenarios {
     id = "bug.dom.requestSubmit-button-type-not-validated"
     name = "form.requestSubmit submitter validation does not check button type"
     description =
-      "requestSubmit(submitter) in webdriver/webdriver/bidi_runtime_eval.mbt currently validates only nodeType === 1 + descendsFrom(form). Per WHATWG, the submitter must additionally be a submit button: either button[type=submit] (default type for <button>) or input[type=submit] / input[type=image]. Today a <button type=button> or <input type=text> passed as submitter is accepted instead of triggering a TypeError. Source: PR review on dom/form-submit, follow-up to bug.dom.html-form-element-submit-missing."
+      "requestSubmit(submitter) in webdriver/webdriver/bidi_runtime_eval.mbt currently validates only nodeType === 1 + descendsFrom(form). Per WHATWG, the submitter must additionally be a submit button: either button[type=submit] (default type for <button>) or input[type=submit] / input[type=image]. Today a <button type=button> or <input type=text> passed as submitter is accepted instead of triggering a TypeError. Source: PR review on dom/form-submit, follow-up to bug.dom.html-form-element-submit-missing. Fixed: requestSubmit now classifies the submitter by tag and effective type — BUTTON without a type attribute or with type=submit, and INPUT with type=submit or type=image are accepted; anything else throws TypeError. Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
     tags { "dom"; "forms"; "bidi"; "bug" }
     severity = "minor"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.dom-compat" }
   }
   new {
     id = "bug.dom.form-reset-does-not-clear-values"
     name = "form.reset fires reset event but does not clear control values"
     description =
-      "el.reset() installed by createMockElement('form') in webdriver/webdriver/bidi_runtime_eval.mbt dispatches a cancelable 'reset' event, but never iterates form controls to restore them to their default state. Per WHATWG, each resettable control must be reset to its default value: input.defaultValue, select selectedness from the OPTION with the `selected` attribute, textarea.defaultValue, checkbox/radio default checkedness. Source: PR review on dom/form-submit."
+      "el.reset() installed by createMockElement('form') in webdriver/webdriver/bidi_runtime_eval.mbt dispatches a cancelable 'reset' event, but never iterates form controls to restore them to their default state. Per WHATWG, each resettable control must be reset to its default value: input.defaultValue, select selectedness from the OPTION with the `selected` attribute, textarea.defaultValue, checkbox/radio default checkedness. Source: PR review on dom/form-submit. Fixed: el.reset() now walks form descendants after the reset event and, unless a listener called preventDefault, restores INPUT (non-button), TEXTAREA value to defaultValue, INPUT checkbox/radio checked to defaultChecked, and SELECT option selectedness to defaultSelected. The value / checked setters snapshot the default on first mutation so reset has something to restore. Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
     tags { "dom"; "forms"; "bidi"; "bug" }
     severity = "minor"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.dom-compat" }
   }
   new {
     id = "bug.dom.form-select-multiple-not-supported"
     name = "form serialization does not handle select multiple"
     description =
-      "controlEffectiveValue in webdriver/webdriver/bidi_runtime_eval.mbt handles single-select <select> by emitting one name=value pair per element. For <select multiple>, WHATWG specifies one name=value pair per selected option, e.g. tags=a&tags=c. Today only the first selected option (single-select fallback) is emitted, so multi-select forms are serialized incorrectly. Source: PR review on dom/form-submit."
+      "controlEffectiveValue in webdriver/webdriver/bidi_runtime_eval.mbt handles single-select <select> by emitting one name=value pair per element. For <select multiple>, WHATWG specifies one name=value pair per selected option, e.g. tags=a&tags=c. Today only the first selected option (single-select fallback) is emitted, so multi-select forms are serialized incorrectly. Source: PR review on dom/form-submit. Fixed: controlEffectiveValue now detects <select multiple> (via _attrs.multiple or the JS field) and returns an Array of effective values for each selected option; serializeFormDataUrlEncoded emits one name=value pair per array entry. Single-select behavior is unchanged. Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
     tags { "dom"; "forms"; "bidi"; "bug" }
     severity = "minor"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.dom-compat" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -416,6 +416,36 @@ tests {
       "bash -lc 'set -e; test -f webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"get forms() {\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"const root = this.documentElement;\" webdriver/webdriver/bidi_runtime_eval.mbt; test -f webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"document.forms returns all FORM elements in document order\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt'"
   }
   new {
+    name = "bidi_form_request_submit_validates_submit_button"
+    description =
+      "form.requestSubmit(submitter) in webdriver/webdriver/bidi_runtime_eval.mbt validates the submitter is a submit button: BUTTON without a type attribute / BUTTON with type=submit / INPUT with type=submit / INPUT with type=image. Anything else (DIV, BUTTON type=button, INPUT type=text, INPUT type=reset, ...) throws TypeError per WHATWG. Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
+    tags { "dom"; "forms"; "bidi" }
+    specRef { "bug.dom.requestSubmit-button-type-not-validated" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"requestSubmit: submitter is not a submit button\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"isSubmitButton\" webdriver/webdriver/bidi_runtime_eval.mbt; test -f webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"requestSubmit throws when submitter is not a submit button\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"requestSubmit accepts button with type=submit\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"requestSubmit accepts default-type button\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"requestSubmit accepts input type=submit and type=image\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt'"
+  }
+  new {
+    name = "bidi_form_reset_restores_default_values"
+    description =
+      "form.reset() in webdriver/webdriver/bidi_runtime_eval.mbt walks form descendants and restores INPUT/TEXTAREA value to defaultValue and INPUT checkbox/radio checked to defaultChecked after the reset event. The value/checked setters on createMockElement snapshot the default on first mutation so reset has something to restore. Listeners that call preventDefault skip the restore step. Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
+    tags { "dom"; "forms"; "bidi" }
+    specRef { "bug.dom.form-reset-does-not-clear-values" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"_defaultValue\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"_defaultChecked\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"form-reset-algorithm\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"if (resetEvent.defaultPrevented) return undefined;\" webdriver/webdriver/bidi_runtime_eval.mbt; test -f webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"form.reset clears input values to defaultValue\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"form.reset restores checkbox checked to defaultChecked\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"form.reset preventDefault stops value clearing\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt'"
+  }
+  new {
+    name = "bidi_form_select_multiple_serialized"
+    description =
+      "controlEffectiveValue / serializeFormDataUrlEncoded in webdriver/webdriver/bidi_runtime_eval.mbt handles <select multiple> by emitting one name=value pair per selected option. controlEffectiveValue returns an Array for multi-select; single-select serialization is unchanged. Covered by webdriver/webdriver/bidi_runtime_form_wbtest.mbt."
+    tags { "dom"; "forms"; "bidi" }
+    specRef { "bug.dom.form-select-multiple-not-supported" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"// Multi-select: return every selected option\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"if (Array.isArray(value))\" webdriver/webdriver/bidi_runtime_eval.mbt; grep -Fq -- \"<select multiple>: one name=value pair per selected option\" webdriver/webdriver/bidi_runtime_eval.mbt; test -f webdriver/webdriver/bidi_runtime_form_wbtest.mbt; grep -Fq -- \"form.submit serializes multi-select as repeated name=value\" webdriver/webdriver/bidi_runtime_form_wbtest.mbt'"
+  }
+  new {
     name = "bidi_runtime_fetch_partition_cookie_bridge_wired"
     description =
       "The BiDi runtime fetch shim attaches partition cookies via a MoonBit-to-JS bridge. BidiProtocol::cookies_for_context_full_json aggregates the per-context jar; set_runtime_context_cookies pushes the snapshot into the JS realm; the JS shim's globalThis.__bidiResolveCookies(url) filters by URL and the fetch wrap injects the Cookie header when the caller has not supplied one. Covered by webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt."

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -917,13 +917,33 @@ extern "js" fn js_evaluate_expression(
   #|         return 'on';
   #|       }
   #|       if (tag === 'SELECT') {
+  #|         // Multi-select: return every selected option's effective value as
+  #|         // an array; serializer emits one name=value pair per entry per
+  #|         // https://html.spec.whatwg.org/#constructing-the-form-data-set.
+  #|         const isMultiple =
+  #|           !!attrs.multiple ||
+  #|           control.multiple === true ||
+  #|           (typeof control.multiple === 'string' && control.multiple !== '');
+  #|         if (isMultiple) {
+  #|           const options = collectSelectOptions(control);
+  #|           const values = [];
+  #|           for (const opt of options) {
+  #|             const oAttrs = opt._attrs || {};
+  #|             const selected = opt.selected === true ||
+  #|               (opt.selected === undefined && !!oAttrs.selected);
+  #|             if (selected) values.push(optionEffectiveValue(opt));
+  #|           }
+  #|           return values;
+  #|         }
   #|         if (typeof control.value === 'string' && control.value !== '') return control.value;
   #|         if (typeof attrs.value === 'string' && attrs.value !== '') return attrs.value;
   #|         const options = collectSelectOptions(control);
   #|         if (options.length === 0) return '';
   #|         for (const opt of options) {
   #|           const oAttrs = opt._attrs || {};
-  #|           if (oAttrs.selected) return optionEffectiveValue(opt);
+  #|           const selected = opt.selected === true ||
+  #|             (opt.selected === undefined && !!oAttrs.selected);
+  #|           if (selected) return optionEffectiveValue(opt);
   #|         }
   #|         // HTML default: first option is selected if none marked.
   #|         return optionEffectiveValue(options[0]);
@@ -960,7 +980,14 @@ extern "js" fn js_evaluate_expression(
   #|         const name = attrs.name;
   #|         if (typeof name !== 'string' || name.length === 0) continue;
   #|         const value = controlEffectiveValue(c);
-  #|         parts.push(enc(name) + '=' + enc(value));
+  #|         if (Array.isArray(value)) {
+  #|           // <select multiple>: one name=value pair per selected option.
+  #|           for (const v of value) {
+  #|             parts.push(enc(name) + '=' + enc(v));
+  #|           }
+  #|         } else {
+  #|           parts.push(enc(name) + '=' + enc(value));
+  #|         }
   #|       }
   #|       return parts.join('&');
   #|     };
@@ -1123,6 +1150,22 @@ extern "js" fn js_evaluate_expression(
   #|           if (submitter.nodeType !== 1 || !(submitter._parent === this || descendsFrom(submitter, this))) {
   #|             throw new TypeError("requestSubmit: submitter is not a descendant of this form");
   #|           }
+  #|           // Per WHATWG https://html.spec.whatwg.org/#dom-form-requestsubmit
+  #|           // the submitter must be a submit button: BUTTON without a type
+  #|           // attribute (default type=submit) or BUTTON with type=submit, or
+  #|           // INPUT with type=submit / type=image.
+  #|           const sTag = String(submitter.tagName || '');
+  #|           const sAttrs = submitter._attrs || {};
+  #|           const sType = typeof sAttrs.type === 'string' ? sAttrs.type.toLowerCase() : '';
+  #|           let isSubmitButton = false;
+  #|           if (sTag === 'BUTTON') {
+  #|             isSubmitButton = !('type' in sAttrs) || sType === '' || sType === 'submit';
+  #|           } else if (sTag === 'INPUT') {
+  #|             isSubmitButton = sType === 'submit' || sType === 'image';
+  #|           }
+  #|           if (!isSubmitButton) {
+  #|             throw new TypeError("requestSubmit: submitter is not a submit button");
+  #|           }
   #|           validatedSubmitter = submitter;
   #|         }
   #|         const allowed = dispatchFormSubmitEvent(this, validatedSubmitter);
@@ -1136,6 +1179,68 @@ extern "js" fn js_evaluate_expression(
   #|           : null;
   #|         if (resetEvent && typeof this.dispatchEvent === 'function') {
   #|           try { this.dispatchEvent(resetEvent); } catch (_e) {}
+  #|           // If a listener canceled the event, skip clearing values.
+  #|           if (resetEvent.defaultPrevented) return undefined;
+  #|         }
+  #|         // Walk form descendants and reset each resettable control to its
+  #|         // default state (https://html.spec.whatwg.org/#form-reset-algorithm).
+  #|         const resettable = new Set(['INPUT', 'SELECT', 'TEXTAREA']);
+  #|         const buttonInputTypes = new Set(['button', 'submit', 'reset', 'image']);
+  #|         const stack = [this];
+  #|         while (stack.length) {
+  #|           const node = stack.pop();
+  #|           if (!node) continue;
+  #|           const kids = node._children || node.childNodes || [];
+  #|           for (let i = kids.length - 1; i >= 0; i--) stack.push(kids[i]);
+  #|           if (node === this) continue;
+  #|           if (node.nodeType !== 1) continue;
+  #|           const tag = String(node.tagName || '');
+  #|           if (!resettable.has(tag)) continue;
+  #|           const attrs = node._attrs || {};
+  #|           if (tag === 'INPUT') {
+  #|             const type = typeof attrs.type === 'string' ? attrs.type.toLowerCase() : '';
+  #|             if (buttonInputTypes.has(type)) continue;
+  #|             if (type === 'checkbox' || type === 'radio') {
+  #|               // defaultChecked falls back to current `checked` attribute
+  #|               // when no override was recorded.
+  #|               const dc = (node._defaultChecked !== undefined)
+  #|                 ? node._defaultChecked
+  #|                 : !!attrs.checked;
+  #|               // Bypass the value/checked setter snapshot so reset does not
+  #|               // become the new "default" baseline.
+  #|               if (dc) attrs.checked = 'checked'; else delete attrs.checked;
+  #|             } else {
+  #|               const dv = (node._defaultValue !== undefined)
+  #|                 ? node._defaultValue
+  #|                 : (typeof attrs.value === 'string' ? attrs.value : '');
+  #|               attrs.value = dv;
+  #|             }
+  #|             continue;
+  #|           }
+  #|           if (tag === 'TEXTAREA') {
+  #|             const dv = (node._defaultValue !== undefined)
+  #|               ? node._defaultValue
+  #|               : (typeof attrs.value === 'string' ? attrs.value : '');
+  #|             attrs.value = dv;
+  #|             continue;
+  #|           }
+  #|           if (tag === 'SELECT') {
+  #|             const options = collectSelectOptions(node);
+  #|             for (const opt of options) {
+  #|               const oAttrs = opt._attrs || {};
+  #|               const ds = (opt._defaultSelected !== undefined)
+  #|                 ? opt._defaultSelected
+  #|                 : !!oAttrs.selected;
+  #|               // Bypass setter snapshot.
+  #|               if (ds) oAttrs.selected = 'selected'; else delete oAttrs.selected;
+  #|               // Keep any explicit opt.selected JS field in sync.
+  #|               if ('selected' in opt) opt.selected = ds;
+  #|             }
+  #|             // Clear any cached select.value so controlEffectiveValue
+  #|             // re-reads option selectedness from defaults.
+  #|             try { node._attrs.value = ''; } catch (_e) {}
+  #|             continue;
+  #|           }
   #|         }
   #|         return undefined;
   #|       };
@@ -1268,9 +1373,39 @@ extern "js" fn js_evaluate_expression(
   #|           return createStyleDeclaration(this);
   #|         },
   #|         get value() { return this._attrs.value || ''; },
-  #|         set value(v) { this._attrs.value = v; },
+  #|         set value(v) {
+  #|           // Snapshot the default (from the value attribute) on first
+  #|           // mutation so form.reset() can restore it.
+  #|           if (this._defaultValue === undefined) {
+  #|             this._defaultValue = typeof this._attrs.value === 'string' ? this._attrs.value : '';
+  #|           }
+  #|           this._attrs.value = v;
+  #|         },
   #|         get checked() { return !!this._attrs.checked; },
-  #|         set checked(v) { this._attrs.checked = v; },
+  #|         set checked(v) {
+  #|           if (this._defaultChecked === undefined) {
+  #|             this._defaultChecked = !!this._attrs.checked;
+  #|           }
+  #|           this._attrs.checked = v;
+  #|         },
+  #|         get defaultValue() {
+  #|           return this._defaultValue !== undefined
+  #|             ? this._defaultValue
+  #|             : (typeof this._attrs.value === 'string' ? this._attrs.value : '');
+  #|         },
+  #|         set defaultValue(v) {
+  #|           this._defaultValue = String(v);
+  #|           this._attrs.value = String(v);
+  #|         },
+  #|         get defaultChecked() {
+  #|           return this._defaultChecked !== undefined
+  #|             ? this._defaultChecked
+  #|             : !!this._attrs.checked;
+  #|         },
+  #|         set defaultChecked(v) {
+  #|           this._defaultChecked = !!v;
+  #|           if (v) this._attrs.checked = 'checked'; else delete this._attrs.checked;
+  #|         },
   #|         get type() { return this._attrs.type || ''; },
   #|         set type(v) { this._attrs.type = v; },
   #|         get src() { return this._attrs.src || ''; },

--- a/webdriver/webdriver/bidi_runtime_form_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_form_wbtest.mbt
@@ -259,6 +259,308 @@ test "bidi form.requestSubmit submitter validation accepts element without _attr
 }
 
 ///|
+/// requestSubmit submitter type validation (bug.dom.requestSubmit-button-type-not-validated)
+test "bidi form.requestSubmit throws when submitter is not a submit button" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  globalThis.__loadPageWithScripts = () => Promise.resolve({ url: '', status: 200 });
+    #|  globalThis.__loadPage = () => Promise.resolve({ url: '', status: 200 });
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="f" action="/x" method="GET">' +
+    #|          '<div id="d">click me</div>' +
+    #|          '<button id="btnButton" type="button">Plain</button>' +
+    #|          '<input id="txt" type="text" name="q" value="hi">' +
+    #|          '<input id="reset" type="reset">' +
+    #|        '</form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    const f = document.getElementById('f');
+    #|    const results = [];
+    #|    const tryIt = (label, el) => {
+    #|      let threw = '';
+    #|      try { f.requestSubmit(el); } catch (e) { threw = String(e && e.name || ''); }
+    #|      results.push(label + '=' + (threw || 'ok'));
+    #|    };
+    #|    tryIt('div', document.getElementById('d'));
+    #|    tryIt('btnTypeButton', document.getElementById('btnButton'));
+    #|    tryIt('inputText', document.getElementById('txt'));
+    #|    tryIt('inputReset', document.getElementById('reset'));
+    #|    return results.join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  // Each of these should throw TypeError because submitter is not a submit
+  // button per WHATWG.
+  assert_true(json.contains("div=TypeError"))
+  assert_true(json.contains("btnTypeButton=TypeError"))
+  assert_true(json.contains("inputText=TypeError"))
+  assert_true(json.contains("inputReset=TypeError"))
+}
+
+///|
+test "bidi form.requestSubmit accepts button with type=submit" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  globalThis.__loadPageWithScripts = () => Promise.resolve({ url: '', status: 200 });
+    #|  globalThis.__loadPage = () => Promise.resolve({ url: '', status: 200 });
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="f" action="/x" method="GET">' +
+    #|          '<button id="b" type="submit">Go</button>' +
+    #|        '</form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    const f = document.getElementById('f');
+    #|    const b = document.getElementById('b');
+    #|    let fired = 0;
+    #|    let matched = 'no';
+    #|    f.addEventListener('submit', (event) => {
+    #|      fired++;
+    #|      matched = event.submitter === b ? 'yes' : 'other';
+    #|      event.preventDefault();
+    #|    });
+    #|    let threw = '';
+    #|    try { f.requestSubmit(b); } catch (e) { threw = String(e && e.name || ''); }
+    #|    return ['threw=' + (threw || 'ok'), 'fired=' + fired, 'matched=' + matched].join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("threw=ok"))
+  assert_true(json.contains("fired=1"))
+  assert_true(json.contains("matched=yes"))
+}
+
+///|
+test "bidi form.requestSubmit accepts default-type button (no type attr)" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  globalThis.__loadPageWithScripts = () => Promise.resolve({ url: '', status: 200 });
+    #|  globalThis.__loadPage = () => Promise.resolve({ url: '', status: 200 });
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="f" action="/x" method="GET">' +
+    #|          '<button id="b">Default</button>' +
+    #|        '</form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    const f = document.getElementById('f');
+    #|    const b = document.getElementById('b');
+    #|    let fired = 0;
+    #|    f.addEventListener('submit', (event) => { fired++; event.preventDefault(); });
+    #|    let threw = '';
+    #|    try { f.requestSubmit(b); } catch (e) { threw = String(e && e.name || ''); }
+    #|    return ['threw=' + (threw || 'ok'), 'fired=' + fired].join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("threw=ok"))
+  assert_true(json.contains("fired=1"))
+}
+
+///|
+test "bidi form.requestSubmit accepts input type=submit and type=image" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  globalThis.__loadPageWithScripts = () => Promise.resolve({ url: '', status: 200 });
+    #|  globalThis.__loadPage = () => Promise.resolve({ url: '', status: 200 });
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="f" action="/x" method="GET">' +
+    #|          '<input id="s" type="submit" value="Go">' +
+    #|          '<input id="i" type="image" src="/g.png">' +
+    #|        '</form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    const f = document.getElementById('f');
+    #|    let fired = 0;
+    #|    f.addEventListener('submit', (event) => { fired++; event.preventDefault(); });
+    #|    let threwSubmit = '';
+    #|    let threwImage = '';
+    #|    try { f.requestSubmit(document.getElementById('s')); } catch (e) { threwSubmit = String(e && e.name || ''); }
+    #|    try { f.requestSubmit(document.getElementById('i')); } catch (e) { threwImage = String(e && e.name || ''); }
+    #|    return ['submit=' + (threwSubmit || 'ok'), 'image=' + (threwImage || 'ok'), 'fired=' + fired].join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("submit=ok"))
+  assert_true(json.contains("image=ok"))
+  assert_true(json.contains("fired=2"))
+}
+
+///|
+/// form.reset clears values to defaults (bug.dom.form-reset-does-not-clear-values)
+test "bidi form.reset clears input values to defaultValue" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  globalThis.__loadHTML(
+    #|    '<!doctype html><html><body>' +
+    #|      '<form id="f">' +
+    #|        '<input id="a" name="a" value="alpha">' +
+    #|        '<input id="b" name="b" value="beta">' +
+    #|      '</form>' +
+    #|    '</body></html>'
+    #|  );
+    #|  const a = document.getElementById('a');
+    #|  const b = document.getElementById('b');
+    #|  a.value = 'AAA';
+    #|  b.value = 'BBB';
+    #|  const beforeA = a.value;
+    #|  const beforeB = b.value;
+    #|  document.getElementById('f').reset();
+    #|  return [
+    #|    'beforeA=' + beforeA,
+    #|    'beforeB=' + beforeB,
+    #|    'afterA=' + a.value,
+    #|    'afterB=' + b.value
+    #|  ].join(';');
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("beforeA=AAA"))
+  assert_true(json.contains("beforeB=BBB"))
+  assert_true(json.contains("afterA=alpha"))
+  assert_true(json.contains("afterB=beta"))
+}
+
+///|
+test "bidi form.reset restores checkbox checked to defaultChecked" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  globalThis.__loadHTML(
+    #|    '<!doctype html><html><body>' +
+    #|      '<form id="f">' +
+    #|        '<input id="c1" name="c1" type="checkbox" checked>' +
+    #|        '<input id="c2" name="c2" type="checkbox">' +
+    #|      '</form>' +
+    #|    '</body></html>'
+    #|  );
+    #|  const c1 = document.getElementById('c1');
+    #|  const c2 = document.getElementById('c2');
+    #|  // Flip from defaults.
+    #|  c1.checked = false;
+    #|  c2.checked = true;
+    #|  const before = 'c1=' + c1.checked + ',c2=' + c2.checked;
+    #|  document.getElementById('f').reset();
+    #|  const after = 'c1=' + c1.checked + ',c2=' + c2.checked;
+    #|  return [before, after].join(';');
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("c1=false,c2=true"))
+  // After reset: c1 returns to checked=true (defaultChecked), c2 to false.
+  assert_true(json.contains("c1=true,c2=false"))
+}
+
+///|
+test "bidi form.reset preventDefault stops value clearing" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  globalThis.__loadHTML(
+    #|    '<!doctype html><html><body>' +
+    #|      '<form id="f">' +
+    #|        '<input id="a" name="a" value="alpha">' +
+    #|      '</form>' +
+    #|    '</body></html>'
+    #|  );
+    #|  const a = document.getElementById('a');
+    #|  const f = document.getElementById('f');
+    #|  a.value = 'modified';
+    #|  let fired = 0;
+    #|  f.addEventListener('reset', (event) => {
+    #|    fired++;
+    #|    event.preventDefault();
+    #|  });
+    #|  f.reset();
+    #|  return ['fired=' + fired, 'value=' + a.value].join(';');
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("fired=1"))
+  // preventDefault on the reset event leaves the modified value in place.
+  assert_true(json.contains("value=modified"))
+}
+
+///|
+/// select multiple serialization (bug.dom.form-select-multiple-not-supported)
+test "bidi form.submit serializes multi-select as repeated name=value" {
+  reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  let expr =
+    #|(() => {
+    #|  let navTarget = '';
+    #|  const savedWithScripts = globalThis.__loadPageWithScripts;
+    #|  const savedLoadPage = globalThis.__loadPage;
+    #|  globalThis.__loadPageWithScripts = (url) => { navTarget = String(url || ''); return Promise.resolve({ url: navTarget, status: 200 }); };
+    #|  globalThis.__loadPage = (url) => { navTarget = String(url || ''); return Promise.resolve({ url: navTarget, status: 200 }); };
+    #|  try {
+    #|    globalThis.__loadHTML(
+    #|      '<!doctype html><html><body>' +
+    #|        '<form id="f" action="https://example.test/multi" method="GET">' +
+    #|          '<select name="tags" multiple>' +
+    #|            '<option value="a" selected>A</option>' +
+    #|            '<option value="b">B</option>' +
+    #|            '<option value="c" selected>C</option>' +
+    #|          '</select>' +
+    #|        '</form>' +
+    #|      '</body></html>'
+    #|    );
+    #|    document.getElementById('f').submit();
+    #|    return [
+    #|      'hasA=' + navTarget.includes('tags=a'),
+    #|      'hasC=' + navTarget.includes('tags=c'),
+    #|      'noB=' + !navTarget.includes('tags=b'),
+    #|      'orderAC=' + (navTarget.indexOf('tags=a') < navTarget.indexOf('tags=c')),
+    #|      'navTarget=' + navTarget
+    #|    ].join(';');
+    #|  } finally {
+    #|    globalThis.__loadPageWithScripts = savedWithScripts;
+    #|    globalThis.__loadPage = savedLoadPage;
+    #|  }
+    #|})()
+  let json = evaluate_js(expr)
+  assert_true(json.contains("hasA=true"))
+  assert_true(json.contains("hasC=true"))
+  assert_true(json.contains("noB=true"))
+  assert_true(json.contains("orderAC=true"))
+}
+
+///|
 test "bidi form.submit bypasses submit event listener and encodes GET query" {
   reset_runtime_js_state()
   let _ = evaluate_js("0")


### PR DESCRIPTION
## Summary

Closes 3 form-related DOM draft scenarios filed in PR #135 review:

| Scenario | Fix |
|---|---|
| \`bug.dom.requestSubmit-button-type-not-validated\` | \`requestSubmit\` now validates submitter is a submit button per WHATWG: BUTTON without \`type\` or \`type=submit\`, or INPUT with \`type=submit\` / \`type=image\`. Anything else throws TypeError. |
| \`bug.dom.form-reset-does-not-clear-values\` | \`el.reset()\` walks descendants after the reset event; restores \`value\` / \`checked\` to their defaultValue / defaultChecked snapshots. Honors \`event.preventDefault\`. |
| \`bug.dom.form-select-multiple-not-supported\` | \`controlEffectiveValue\` for \`<select multiple>\` returns Array; \`serializeFormDataUrlEncoded\` emits one \`name=value\` per selected option. Single-select behavior unchanged. |

## Implementation notes

- The mock \`<input>\` value/checked setters now snapshot the original attribute into \`_defaultValue\` / \`_defaultChecked\` on first mutation so reset has a meaningful value to restore. \`defaultValue\` / \`defaultChecked\` getters and setters added.
- Submitter validation in \`requestSubmit\` checks \`(tagName, _attrs.type)\` pair so the existing "accepts element without _attrs" path still works: deleting \`_attrs\` leaves an empty object → \`'type' in {}\` is false → BUTTON treated as default-type-submit.
- TEXTAREA reset is covered by the impl walk but lacks a dedicated assert; the mock doesn't expose textContent-derived defaultValue cleanly. Out of scope.

## Tests

8 new wbtests in \`bidi_runtime_form_wbtest.mbt\`:
- requestSubmit rejects div submitter / accepts BUTTON / accepts default-type BUTTON / accepts INPUT type=submit / accepts INPUT type=image
- form.reset clears input values / restores checkbox checked / preventDefault skips clearing
- multi-select serializes all selected options

## Test counts

| Suite | Before | After |
|---|---|---|
| \`webdriver/webdriver\` | 327 | 335 |
| \`pkf run spec-test\` | 37 | 40 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)