### PR TITLE
BiDi origin-scoped Authorization injection (Phase 1 of auth extension)

### DIFF
--- a/docs/superpowers/plans/2026-05-18-bidi-origin-authorization.md
+++ b/docs/superpowers/plans/2026-05-18-bidi-origin-authorization.md
@@ -1,0 +1,1173 @@
+# BiDi Origin-Scoped Authorization Injection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let WebDriver clients register `Authorization` header values per origin via three `crater.*` BiDi commands; the runtime fetch shim attaches the value to outgoing requests for matching origins unless the caller has already set `Authorization` (caller wins).
+
+**Architecture:** Extend the existing `AuthState` placeholder in `http/profile/auth.mbt` with a per-origin map. Add a new MoonBit handler file in `webdriver/webdriver/` for the three `crater.*` commands. Mirror the proven cookie snapshot push pattern: MoonBit pushes a JSON snapshot of the partition's `origin_headers` into `globalThis.__bidiContextAuth[ctxId]` during `apply_effective_viewport_to_runtime_context`, and the JS-side `__bidiResolveAuth(url)` bridge inspects the snapshot at request time. The fetch shim attaches the resolved value before dispatch, skipping if the caller already provided `Authorization`.
+
+**Tech Stack:** MoonBit (browser-http profile + webdriver dispatch + runtime context bridges), embedded JS (runtime fetch shim), pkspec (scenario approval).
+
+---
+
+## File Structure
+
+**Modified MoonBit files:**
+
+- `http/profile/auth.mbt` — `AuthState` gains `origin_headers : Map[String, String]`, accessor methods, redacting `Show` impl.
+- `webdriver/webdriver/bidi_runtime_context.mbt` — new `js_set_runtime_context_authorization` extern js + thin wrapper.
+- `webdriver/webdriver/bidi_protocol_context_lifecycle.mbt` — push auth snapshot alongside the cookie push.
+- `webdriver/webdriver/bidi_runtime_eval.mbt` — fetch shim attaches `Authorization` header when caller hasn't.
+- One of `webdriver/webdriver/bidi_protocol_dispatch_*.mbt` — route three new `crater.*` command names. Survey before editing; pick the dispatch file that already routes other `crater.*` commands.
+
+**New MoonBit files:**
+
+- `webdriver/webdriver/bidi_authorization.mbt` — three handler functions + origin normalization helper + JSON snapshot serializer.
+- `webdriver/webdriver/bidi_authorization_wbtest.mbt` — handler + validation tests.
+- `webdriver/webdriver/bidi_runtime_authorization_bridge_wbtest.mbt` — `__bidiResolveAuth` bridge behavior tests.
+- `http/profile/auth_wbtest.mbt` — unit tests on `AuthState` API + redacting `Show`.
+
+**Modified test file:**
+
+- `webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt` — add Authorization integration cases.
+
+**Modified spec files:**
+
+- `specs/crater.pkl` — new scenario `protocol.bidi-origin-authorization-injection` approved with implementation pointer.
+- `specs/tasks.Test.pkl` — pkspec smoke test wired to the new scenario.
+
+---
+
+## Task 1: Extend AuthState with origin_headers + accessors
+
+**Files:**
+- Modify: `http/profile/auth.mbt`
+- Create: `http/profile/auth_wbtest.mbt`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `http/profile/auth_wbtest.mbt`:
+
+```moonbit
+///|
+test "AuthState::default has empty origin_headers" {
+  let state = AuthState::default()
+  inspect(state.origin_headers.size(), content="0")
+}
+
+///|
+test "set_origin_header round-trips through header_for_origin" {
+  let state = AuthState::default()
+  state.set_origin_header("https://api.example.com", "Bearer abc123")
+  inspect(
+    state.header_for_origin("https://api.example.com"),
+    content="Some(\"Bearer abc123\")",
+  )
+  inspect(state.header_for_origin("https://other.com"), content="None")
+}
+
+///|
+test "set_origin_header overwrites prior value for same origin" {
+  let state = AuthState::default()
+  state.set_origin_header("https://api.example.com", "Bearer first")
+  state.set_origin_header("https://api.example.com", "Bearer second")
+  inspect(
+    state.header_for_origin("https://api.example.com"),
+    content="Some(\"Bearer second\")",
+  )
+}
+
+///|
+test "clear_origin_header removes the entry" {
+  let state = AuthState::default()
+  state.set_origin_header("https://api.example.com", "Bearer abc")
+  state.clear_origin_header("https://api.example.com")
+  inspect(state.header_for_origin("https://api.example.com"), content="None")
+}
+
+///|
+test "list_origins returns sorted origins" {
+  let state = AuthState::default()
+  state.set_origin_header("https://b.example.com", "Bearer b")
+  state.set_origin_header("https://a.example.com", "Bearer a")
+  state.set_origin_header("https://c.example.com", "Bearer c")
+  let origins = state.list_origins()
+  inspect(
+    origins,
+    content="[\"https://a.example.com\", \"https://b.example.com\", \"https://c.example.com\"]",
+  )
+}
+
+///|
+test "Show impl redacts header values" {
+  let state = AuthState::default()
+  state.set_origin_header("https://api.example.com", "Bearer secret-token")
+  let buf = StringBuilder::new()
+  state.output(buf)
+  let rendered = buf.to_string()
+  inspect(rendered.contains("secret-token"), content="false")
+  inspect(rendered.contains("<redacted>"), content="true")
+  inspect(rendered.contains("https://api.example.com"), content="true")
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `moon test -p mizchi/crater-browser-http/profile`
+Expected: FAIL — `AuthState` has no `origin_headers` / no method.
+
+- [ ] **Step 3: Extend AuthState in `http/profile/auth.mbt`**
+
+Replace the current contents:
+
+```moonbit
+///|
+/// Per-origin Authorization header storage carried by a Profile.
+/// Header values are written via WebDriver `crater.setOriginAuthorization`
+/// and attached by the BiDi runtime fetch shim when the caller has not
+/// already supplied an `Authorization` header.
+pub(all) struct AuthState {
+  mut origin_headers : Map[String, String]
+} derive(Debug)
+
+///|
+/// Show impl deliberately redacts header values; only origins are
+/// rendered. Prevents secret leaks via panic stack traces or
+/// structural debugging.
+pub impl Show for AuthState with output(self, logger) {
+  logger.write_string("AuthState{")
+  let origins = self.list_origins()
+  for i = 0; i < origins.length(); i = i + 1 {
+    if i > 0 {
+      logger.write_string(", ")
+    }
+    logger.write_string(origins[i])
+    logger.write_string(": <redacted>")
+  }
+  logger.write_string("}")
+}
+
+///|
+pub fn AuthState::default() -> AuthState {
+  AuthState::{ origin_headers: Map::new() }
+}
+
+///|
+pub fn AuthState::set_origin_header(
+  self : AuthState,
+  origin : String,
+  header_value : String,
+) -> Unit {
+  self.origin_headers[origin] = header_value
+}
+
+///|
+pub fn AuthState::clear_origin_header(
+  self : AuthState,
+  origin : String,
+) -> Unit {
+  self.origin_headers.remove(origin)
+}
+
+///|
+pub fn AuthState::header_for_origin(
+  self : AuthState,
+  origin : String,
+) -> String? {
+  self.origin_headers.get(origin)
+}
+
+///|
+pub fn AuthState::list_origins(self : AuthState) -> Array[String] {
+  let result = []
+  for origin, _ in self.origin_headers {
+    result.push(origin)
+  }
+  result.sort()
+  result
+}
+```
+
+If `Map::new()` is not the right MoonBit API, look at how `cookie_jar.mbt` constructs its internal map. The exact constructor name may differ.
+
+If the project's `Show` deprecation guidance (per MEMORY.md) requires deriving `Debug` and manually implementing `Show`, the code above already does that — but verify the `output` parameter type (`StringBuilder` vs `Logger`) matches what the existing `Show` impls in `http/profile/profile.mbt` use.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `moon test -p mizchi/crater-browser-http/profile`
+Expected: PASS (6 new tests + 5 pre-existing = 11 total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add http/profile/auth.mbt http/profile/auth_wbtest.mbt http/profile/pkg.generated.mbti
+git commit -m "Extend AuthState with origin_headers map and redacting Show
+
+Adds set_origin_header / clear_origin_header / header_for_origin /
+list_origins methods plus a Show impl that redacts every stored
+header value. Prepares the AuthState placeholder for the new
+crater.setOriginAuthorization BiDi command.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Origin normalization helper
+
+**Files:**
+- Modify: `webdriver/webdriver/bidi_authorization.mbt` (create as part of Task 3)
+- Modify: `webdriver/webdriver/bidi_authorization_wbtest.mbt` (create)
+
+This task gets folded into Task 3 since the helper has no separate consumer. Keeping the description here to lock the contract:
+
+```moonbit
+/// Normalize an origin string per the spec:
+/// - Reject non-http/https schemes.
+/// - Reject input that contains path / query / fragment.
+/// - Lowercase scheme and host.
+/// - Strip default port (`:80` for http, `:443` for https).
+/// - Strip trailing slash.
+/// Returns Err(reason) for invalid input.
+fn normalize_origin(input : String) -> Result[String, String]
+```
+
+Tests:
+- `https://Example.COM` → `https://example.com`
+- `https://Example.COM:443` → `https://example.com`
+- `http://example.com:80` → `http://example.com`
+- `https://example.com:8443` → `https://example.com:8443`
+- `https://example.com/` → `https://example.com`
+- `https://example.com/path` → Err
+- `https://example.com?q=1` → Err
+- `https://example.com#frag` → Err
+- `ftp://example.com` → Err
+- `javascript:void(0)` → Err
+- Empty / not-a-url → Err
+
+These tests live in `bidi_authorization_wbtest.mbt`.
+
+---
+
+## Task 3: Create bidi_authorization.mbt with set / clear / list handlers
+
+**Files:**
+- Create: `webdriver/webdriver/bidi_authorization.mbt`
+- Create: `webdriver/webdriver/bidi_authorization_wbtest.mbt`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `webdriver/webdriver/bidi_authorization_wbtest.mbt`. Use the existing test pattern from `bidi_emulation_profile_wbtest.mbt` as a template for spinning up a `BidiProtocol` stub and dispatching a message.
+
+```moonbit
+///|
+test "crater.setOriginAuthorization stores per-origin header" {
+  let proto = make_test_bidi_protocol()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{}}}",
+  )
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer abc123\"}}",
+  )
+  let profile = proto.profile_for_session("session-1").unwrap()
+  inspect(
+    profile.auth_state.header_for_origin("https://api.example.com"),
+    content="Some(\"Bearer abc123\")",
+  )
+}
+
+///|
+test "crater.setOriginAuthorization normalizes origin" {
+  let proto = make_test_bidi_protocol()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{}}}",
+  )
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://Example.COM:443\",\"headerValue\":\"Bearer abc\"}}",
+  )
+  let profile = proto.profile_for_session("session-1").unwrap()
+  // Stored under normalized form
+  inspect(
+    profile.auth_state.header_for_origin("https://example.com"),
+    content="Some(\"Bearer abc\")",
+  )
+  // Original casing does NOT match
+  inspect(
+    profile.auth_state.header_for_origin("https://Example.COM:443"),
+    content="None",
+  )
+}
+
+///|
+test "crater.setOriginAuthorization rejects missing headerValue" {
+  let proto = make_test_bidi_protocol()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{}}}",
+  )
+  let response = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\"}}",
+  )
+  assert_true(response.contains("\"error\":\"invalid argument\""))
+  assert_true(response.contains("headerValue"))
+}
+
+///|
+test "crater.setOriginAuthorization rejects CRLF in headerValue" {
+  let proto = make_test_bidi_protocol()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{}}}",
+  )
+  let response = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer abc\\r\\nX-Spoof: evil\"}}",
+  )
+  assert_true(response.contains("\"error\":\"invalid argument\""))
+  assert_true(response.contains("control"))
+}
+
+///|
+test "crater.setOriginAuthorization rejects non-http scheme" {
+  let proto = make_test_bidi_protocol()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{}}}",
+  )
+  let response = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"ftp://example.com\",\"headerValue\":\"Bearer abc\"}}",
+  )
+  assert_true(response.contains("\"error\":\"invalid argument\""))
+}
+
+///|
+test "crater.setOriginAuthorization rejects path in origin" {
+  let proto = make_test_bidi_protocol()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{}}}",
+  )
+  let response = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://example.com/api\",\"headerValue\":\"Bearer abc\"}}",
+  )
+  assert_true(response.contains("\"error\":\"invalid argument\""))
+}
+
+///|
+test "crater.clearOriginAuthorization removes the entry" {
+  let proto = make_test_bidi_protocol()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{}}}",
+  )
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer abc\"}}",
+  )
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"crater.clearOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\"}}",
+  )
+  let profile = proto.profile_for_session("session-1").unwrap()
+  inspect(
+    profile.auth_state.header_for_origin("https://api.example.com"),
+    content="None",
+  )
+}
+
+///|
+test "crater.listOriginAuthorizations returns origins without values" {
+  let proto = make_test_bidi_protocol()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{}}}",
+  )
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer secret-token\"}}",
+  )
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://auth.example.com\",\"headerValue\":\"Bearer another-secret\"}}",
+  )
+  let response = proto.process_message(
+    "{\"id\":4,\"method\":\"crater.listOriginAuthorizations\",\"params\":{}}",
+  )
+  assert_true(response.contains("https://api.example.com"))
+  assert_true(response.contains("https://auth.example.com"))
+  // Header values MUST NOT appear in the response.
+  assert_true(!response.contains("secret-token"))
+  assert_true(!response.contains("another-secret"))
+}
+```
+
+If `make_test_bidi_protocol` is the wrong helper name, look at `bidi_emulation_profile_wbtest.mbt` for the actual fixture-construction pattern in this codebase and adapt.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `moon test -p mizchi/crater-webdriver-bidi/webdriver`
+Expected: FAIL — handlers do not exist; dispatch routes nothing for `crater.setOriginAuthorization`.
+
+- [ ] **Step 3: Implement bidi_authorization.mbt**
+
+Create `webdriver/webdriver/bidi_authorization.mbt`:
+
+```moonbit
+///|
+/// Maximum length in bytes for a stored Authorization header value.
+/// Real-world JWTs are typically under 4 KB; 8 KB leaves headroom
+/// without making it cheap to wedge unbounded state.
+const AUTH_HEADER_VALUE_LIMIT : Int = 8192
+
+///|
+/// Normalize an origin per the spec: only http/https, no path/query/
+/// fragment, lowercased scheme and host, default port stripped, no
+/// trailing slash.
+fn normalize_origin(input : String) -> Result[String, String] {
+  let trimmed = input.trim()
+  let scheme_end = match trimmed.find("://") {
+    Some(idx) => idx
+    None => return Err("origin must be a valid URL (scheme://host[:port])")
+  }
+  let scheme = trimmed.unsafe_substring(start=0, end=scheme_end).to_ascii_lower()
+  if scheme != "http" && scheme != "https" {
+    return Err("origin must use http or https scheme")
+  }
+  let host_start = scheme_end + 3
+  let rest = trimmed.unsafe_substring(start=host_start, end=trimmed.length())
+  // Reject path / query / fragment
+  for sep in ['/', '?', '#'] {
+    if rest.contains_char(sep) {
+      return Err("origin must not contain path / query / fragment")
+    }
+  }
+  if rest.length() == 0 {
+    return Err("origin must include a host")
+  }
+  let lowered_host = rest.to_ascii_lower()
+  // Strip default port
+  let normalized_host_port = if scheme == "http" && lowered_host.has_suffix(":80") {
+    lowered_host.unsafe_substring(start=0, end=lowered_host.length() - 3)
+  } else if scheme == "https" && lowered_host.has_suffix(":443") {
+    lowered_host.unsafe_substring(start=0, end=lowered_host.length() - 4)
+  } else {
+    lowered_host
+  }
+  Ok(scheme + "://" + normalized_host_port)
+}
+
+///|
+/// Validate a candidate header value. Reject empty, oversized, or
+/// values containing control characters / ANSI escape sequences.
+fn validate_header_value(value : String) -> Result[Unit, String] {
+  if value.length() == 0 {
+    return Err("headerValue must not be empty")
+  }
+  if value.length() > AUTH_HEADER_VALUE_LIMIT {
+    return Err("headerValue exceeds 8KB limit")
+  }
+  // Check for control characters (anything < 0x20 except tab) and ANSI ESC.
+  let chars = value.to_array()
+  for i = 0; i < chars.length(); i = i + 1 {
+    let code = chars[i].to_int()
+    if code < 0x20 && code != 0x09 {
+      return Err("headerValue must not contain control characters")
+    }
+    if code == 0x1b {
+      return Err("headerValue must not contain ANSI escape sequences")
+    }
+  }
+  Ok(())
+}
+
+///|
+fn BidiProtocol::handle_crater_set_origin_authorization(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let map = match params {
+    Some(Object(m)) => m
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "params must be an object",
+      )
+      return
+    }
+  }
+  let raw_origin = match map.get("origin") {
+    Some(String(o)) => o
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "origin must be a string",
+      )
+      return
+    }
+  }
+  let header_value = match map.get("headerValue") {
+    Some(String(v)) => v
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "headerValue must be a string",
+      )
+      return
+    }
+  }
+  let normalized = match normalize_origin(raw_origin) {
+    Ok(o) => o
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  match validate_header_value(header_value) {
+    Ok(_) => ()
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  let ctx_id = self.resolve_authorization_context(map, request_id)
+  guard ctx_id is Some(ctx) else { return }
+  let profile = match self.profile_for_session(ctx) {
+    Some(p) => p
+    None => {
+      self.send_error(
+        request_id, "no such frame", "Unknown context: " + ctx,
+      )
+      return
+    }
+  }
+  profile.auth_state.set_origin_header(normalized, header_value)
+  self.push_authorization_snapshot(ctx)
+  self.send_success(request_id, Some(make_object({})))
+}
+
+///|
+fn BidiProtocol::handle_crater_clear_origin_authorization(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let map = match params {
+    Some(Object(m)) => m
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "params must be an object",
+      )
+      return
+    }
+  }
+  let raw_origin = match map.get("origin") {
+    Some(String(o)) => o
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "origin must be a string",
+      )
+      return
+    }
+  }
+  let normalized = match normalize_origin(raw_origin) {
+    Ok(o) => o
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  let ctx_id = self.resolve_authorization_context(map, request_id)
+  guard ctx_id is Some(ctx) else { return }
+  let profile = match self.profile_for_session(ctx) {
+    Some(p) => p
+    None => {
+      self.send_error(
+        request_id, "no such frame", "Unknown context: " + ctx,
+      )
+      return
+    }
+  }
+  profile.auth_state.clear_origin_header(normalized)
+  self.push_authorization_snapshot(ctx)
+  self.send_success(request_id, Some(make_object({})))
+}
+
+///|
+fn BidiProtocol::handle_crater_list_origin_authorizations(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let map = match params {
+    Some(Object(m)) => m
+    _ => make_object({})
+  }
+  let ctx_id = self.resolve_authorization_context(map, request_id)
+  guard ctx_id is Some(ctx) else { return }
+  let profile = match self.profile_for_session(ctx) {
+    Some(p) => p
+    None => {
+      self.send_error(
+        request_id, "no such frame", "Unknown context: " + ctx,
+      )
+      return
+    }
+  }
+  let origins_json = []
+  for origin in profile.auth_state.list_origins() {
+    origins_json.push(make_object({ "origin": Json::string(origin) }))
+  }
+  self.send_success(
+    request_id,
+    Some(make_object({ "origins": Json::array(origins_json) })),
+  )
+}
+
+///|
+/// Resolve the target context: explicit `context` param wins; otherwise
+/// fall back to the active context. Returns None and sends an error
+/// when the context argument is malformed.
+fn BidiProtocol::resolve_authorization_context(
+  self : BidiProtocol,
+  map : Map[String, Json],
+  request_id : Int,
+) -> String? {
+  match map.get("context") {
+    Some(String(ctx)) => {
+      if !self.manager.has_session(ctx) {
+        self.send_error(
+          request_id, "no such frame", "Unknown context: " + ctx,
+        )
+        return None
+      }
+      Some(ctx)
+    }
+    Some(_) => {
+      self.send_error(
+        request_id, "invalid argument", "context must be a string",
+      )
+      None
+    }
+    None => self.default_context_id
+  }
+}
+
+///|
+/// Serialize the partition's origin_headers as a JSON object suitable
+/// for pushing into globalThis.__bidiContextAuth[ctxId].
+pub fn BidiProtocol::serialize_auth_snapshot_for_runtime(
+  self : BidiProtocol,
+  ctx_id : String,
+) -> String {
+  match self.profile_for_session(ctx_id) {
+    Some(profile) => {
+      let entries : Map[String, Json] = Map::new()
+      for origin in profile.auth_state.list_origins() {
+        match profile.auth_state.header_for_origin(origin) {
+          Some(value) => entries[origin] = Json::string(value)
+          None => ()
+        }
+      }
+      Json::object(entries).stringify()
+    }
+    None => "{}"
+  }
+}
+
+///|
+fn BidiProtocol::push_authorization_snapshot(
+  self : BidiProtocol,
+  ctx_id : String,
+) -> Unit {
+  let snapshot = self.serialize_auth_snapshot_for_runtime(ctx_id)
+  set_runtime_context_authorization(ctx_id, snapshot)
+}
+```
+
+`set_runtime_context_authorization` is added in Task 5. Place a TODO comment on the call site so Task 5 lands the bridge.
+
+Adapt any of the calls above to the actual MoonBit APIs in this codebase:
+- `Map::new()` vs `{}` literal — match what `bidi_storage.mbt` uses.
+- `Json::object(map).stringify()` vs `make_object(map)` — match the project's prevalent pattern.
+- `self.send_error` / `self.send_success` / `make_object` — these are the established helpers; use them.
+
+- [ ] **Step 4: Wire dispatch**
+
+Find the existing dispatch entry point that routes `crater.*` commands (`grep -n 'crater\\.' webdriver/webdriver/bidi_protocol_dispatch*.mbt`). Add the three new cases:
+
+```moonbit
+"crater.setOriginAuthorization" => {
+  self.handle_crater_set_origin_authorization(request.id, request.params)
+  return Ok(())
+}
+"crater.clearOriginAuthorization" => {
+  self.handle_crater_clear_origin_authorization(request.id, request.params)
+  return Ok(())
+}
+"crater.listOriginAuthorizations" => {
+  self.handle_crater_list_origin_authorizations(request.id, request.params)
+  return Ok(())
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass and commit**
+
+Run: `moon test -p mizchi/crater-webdriver-bidi/webdriver`
+Expected: PASS — 8 new handler tests pass. The two `push_authorization_snapshot` callers will fail at link time until Task 5 lands `set_runtime_context_authorization`. To make Task 3 commit-ready in isolation, **define a temporary stub** in `bidi_runtime_context.mbt`:
+
+```moonbit
+///|
+/// Temporary stub; real extern js install lands in Task 5.
+fn set_runtime_context_authorization(_ctx_id : String, _json : String) -> Unit {
+  ()
+}
+```
+
+Run tests again — should pass.
+
+```bash
+git add http/profile/auth.mbt http/profile/auth_wbtest.mbt webdriver/webdriver/bidi_authorization.mbt webdriver/webdriver/bidi_authorization_wbtest.mbt webdriver/webdriver/bidi_runtime_context.mbt webdriver/webdriver/bidi_protocol_dispatch_*.mbt webdriver/webdriver/pkg.generated.mbti
+git commit -m "Add crater.setOriginAuthorization / clear / list BiDi handlers
+
+Three new crater.* extension commands let WebDriver clients register
+per-origin Authorization header values on the per-session Profile.
+Input validation rejects non-http/https schemes, path/query/fragment
+in origin, empty/oversized/CRLF/ANSI header values. Origin is
+normalized (lowercase, default port stripped, trailing slash
+stripped). listOriginAuthorizations exposes origins only — header
+values are never serialized into BiDi responses.
+
+A temporary set_runtime_context_authorization stub keeps the
+snapshot push compilable; the real extern js bridge lands in the
+next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Add set_runtime_context_authorization extern js bridge + install __bidiResolveAuth
+
+**Files:**
+- Modify: `webdriver/webdriver/bidi_runtime_context.mbt`
+- Create: `webdriver/webdriver/bidi_runtime_authorization_bridge_wbtest.mbt`
+
+- [ ] **Step 1: Write failing bridge tests**
+
+Create `webdriver/webdriver/bidi_runtime_authorization_bridge_wbtest.mbt`:
+
+```moonbit
+///|
+test "__bidiResolveAuth returns null when nothing registered" {
+  let _ = reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  set_runtime_context_authorization("session-1", "{}")
+  let result = evaluate_js(
+    "(globalThis.__bidiCurrentContext = \"session-1\", globalThis.__bidiResolveAuth(\"https://api.example.com/x\"))",
+  )
+  inspect(result, content="null")
+}
+
+///|
+test "__bidiResolveAuth returns header for matching origin" {
+  let _ = reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  set_runtime_context_authorization(
+    "session-1",
+    "{\"https://api.example.com\":\"Bearer abc123\"}",
+  )
+  let result = evaluate_js(
+    "(globalThis.__bidiCurrentContext = \"session-1\", globalThis.__bidiResolveAuth(\"https://api.example.com/v1/me\"))",
+  )
+  inspect(result, content="\"Bearer abc123\"")
+}
+
+///|
+test "__bidiResolveAuth strips default https port when matching" {
+  let _ = reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  set_runtime_context_authorization(
+    "session-1",
+    "{\"https://api.example.com\":\"Bearer abc123\"}",
+  )
+  let result = evaluate_js(
+    "(globalThis.__bidiCurrentContext = \"session-1\", globalThis.__bidiResolveAuth(\"https://api.example.com:443/v1/me\"))",
+  )
+  inspect(result, content="\"Bearer abc123\"")
+}
+
+///|
+test "__bidiResolveAuth returns null for mismatched origin" {
+  let _ = reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  set_runtime_context_authorization(
+    "session-1",
+    "{\"https://api.example.com\":\"Bearer abc123\"}",
+  )
+  let result = evaluate_js(
+    "(globalThis.__bidiCurrentContext = \"session-1\", globalThis.__bidiResolveAuth(\"https://other.com/x\"))",
+  )
+  inspect(result, content="null")
+}
+```
+
+`evaluate_js` / `reset_runtime_js_state` already exist — see `bidi_runtime_set_cookie_ingest_wbtest.mbt` for the helper-usage pattern.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `moon test -p mizchi/crater-webdriver-bidi/webdriver`
+Expected: FAIL — `__bidiResolveAuth` undefined.
+
+- [ ] **Step 3: Implement extern js + replace the Task 3 stub**
+
+In `webdriver/webdriver/bidi_runtime_context.mbt`, remove the stub from Task 3 and add:
+
+```moonbit
+///|
+/// Push the per-context Authorization snapshot into the JS realm. The
+/// snapshot is consumed by the auto-installed globalThis.__bidiResolveAuth
+/// helper that the fetch shim calls before dispatching each outbound
+/// request. Mirror of set_runtime_context_cookies.
+pub extern "js" fn js_set_runtime_context_authorization(
+  ctx_id : String,
+  auth_json : String,
+) -> Unit =
+  #| (ctxId, authJson) => {
+  #|   if (!globalThis.__bidiContextAuth) globalThis.__bidiContextAuth = {};
+  #|   try {
+  #|     globalThis.__bidiContextAuth[ctxId] = JSON.parse(authJson);
+  #|   } catch (_e) {
+  #|     globalThis.__bidiContextAuth[ctxId] = {};
+  #|   }
+  #|   if (typeof globalThis.__bidiResolveAuth !== 'function') {
+  #|     globalThis.__bidiResolveAuth = function(url) {
+  #|       const ctx = String(globalThis.__bidiCurrentContext || 'default-context');
+  #|       const map = (globalThis.__bidiContextAuth || {})[ctx] || {};
+  #|       try {
+  #|         const u = new URL(url);
+  #|         let origin = u.protocol + '//' + u.hostname;
+  #|         if (
+  #|           (u.protocol === 'http:'  && u.port && u.port !== '80') ||
+  #|           (u.protocol === 'https:' && u.port && u.port !== '443')
+  #|         ) origin += ':' + u.port;
+  #|         return map[origin] || null;
+  #|       } catch (_e) { return null; }
+  #|     };
+  #|   }
+  #| }
+
+///|
+fn set_runtime_context_authorization(
+  ctx_id : String,
+  auth_json : String,
+) -> Unit {
+  js_set_runtime_context_authorization(ctx_id, auth_json)
+}
+```
+
+Drop the stub added at the end of Task 3.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `moon test -p mizchi/crater-webdriver-bidi/webdriver`
+Expected: PASS — 4 new bridge tests pass, all prior tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webdriver/webdriver/bidi_runtime_context.mbt webdriver/webdriver/bidi_runtime_authorization_bridge_wbtest.mbt webdriver/webdriver/pkg.generated.mbti
+git commit -m "Add set_runtime_context_authorization extern js + __bidiResolveAuth bridge
+
+Mirror of set_runtime_context_cookies: pushes the per-context auth
+snapshot into globalThis.__bidiContextAuth and lazily installs
+globalThis.__bidiResolveAuth(url) which extracts the request origin
+(http/https only, default-port-stripped) and looks up the registered
+header value. Drops the stub from the previous commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Wire snapshot push from apply_effective_viewport_to_runtime_context
+
+**Files:**
+- Modify: `webdriver/webdriver/bidi_protocol_context_lifecycle.mbt`
+
+- [ ] **Step 1: Write the test**
+
+Add to `bidi_authorization_wbtest.mbt`:
+
+```moonbit
+///|
+test "apply_effective_viewport_to_runtime_context pushes auth snapshot" {
+  let proto = make_test_bidi_protocol()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{}}}",
+  )
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer abc\"}}",
+  )
+  // Force a viewport apply (would happen naturally before script.evaluate).
+  proto.apply_effective_viewport_to_runtime_context("session-1", "session-1")
+  let result = evaluate_js(
+    "(globalThis.__bidiCurrentContext = \"session-1\", globalThis.__bidiResolveAuth(\"https://api.example.com/me\"))",
+  )
+  inspect(result, content="\"Bearer abc\"")
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `moon test -p mizchi/crater-webdriver-bidi/webdriver`
+Expected: FAIL — `apply_effective_viewport_to_runtime_context` doesn't yet push the auth snapshot.
+
+- [ ] **Step 3: Wire the push**
+
+Edit `bidi_protocol_context_lifecycle.mbt` `apply_effective_viewport_to_runtime_context`. After the existing `set_runtime_context_cookies(...)` call (around line 51), append:
+
+```moonbit
+  // Push the partition Authorization snapshot so the runtime fetch
+  // shim's __bidiResolveAuth bridge can attach Authorization headers
+  // to outbound requests for registered origins. Resolves
+  // protocol.bidi-origin-authorization-injection.
+  let auth_json = self.serialize_auth_snapshot_for_runtime(logical_ctx_id)
+  set_runtime_context_authorization(runtime_ctx_id, auth_json)
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `moon test -p mizchi/crater-webdriver-bidi/webdriver`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webdriver/webdriver/bidi_protocol_context_lifecycle.mbt webdriver/webdriver/bidi_authorization_wbtest.mbt
+git commit -m "Push auth snapshot in apply_effective_viewport_to_runtime_context
+
+Mirrors the existing cookie snapshot push; runs at every script.evaluate
+boundary so script-side fetches see the latest registered values.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Wire Authorization attach in fetch shim
+
+**Files:**
+- Modify: `webdriver/webdriver/bidi_runtime_eval.mbt`
+
+- [ ] **Step 1: Write the integration test**
+
+Append to `webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt`:
+
+```moonbit
+///|
+test "fetch shim attaches Authorization for matching origin" {
+  let _ = reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  set_runtime_context_authorization(
+    "session-1",
+    "{\"https://api.example.com\":\"Bearer abc123\"}",
+  )
+  let result = evaluate_js(
+    "(async () => {" +
+    "  globalThis.__bidiCurrentContext = \"session-1\";" +
+    "  let captured = null;" +
+    "  globalThis.__rawFetch = async (url, opts) => {" +
+    "    captured = (opts && opts.headers && (opts.headers.get ? opts.headers.get('Authorization') : opts.headers.Authorization)) || null;" +
+    "    return new Response('ok', { status: 200, headers: { 'access-control-allow-origin': 'https://app.example.com' } });" +
+    "  };" +
+    "  globalThis.__pageUrl = 'https://app.example.com';" +
+    "  await globalThis.fetch('https://api.example.com/me');" +
+    "  return captured;" +
+    "})()",
+  )
+  inspect(result, content="\"Bearer abc123\"")
+}
+
+///|
+test "fetch shim respects caller-provided Authorization over bridge" {
+  let _ = reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  set_runtime_context_authorization(
+    "session-1",
+    "{\"https://api.example.com\":\"Bearer driver-token\"}",
+  )
+  let result = evaluate_js(
+    "(async () => {" +
+    "  globalThis.__bidiCurrentContext = \"session-1\";" +
+    "  let captured = null;" +
+    "  globalThis.__rawFetch = async (url, opts) => {" +
+    "    captured = (opts && opts.headers && (opts.headers.get ? opts.headers.get('Authorization') : opts.headers.Authorization)) || null;" +
+    "    return new Response('ok', { status: 200, headers: { 'access-control-allow-origin': 'https://app.example.com' } });" +
+    "  };" +
+    "  globalThis.__pageUrl = 'https://app.example.com';" +
+    "  await globalThis.fetch('https://api.example.com/me', { headers: { Authorization: 'Bearer page-token' } });" +
+    "  return captured;" +
+    "})()",
+  )
+  inspect(result, content="\"Bearer page-token\"")
+}
+
+///|
+test "fetch shim skips Authorization for non-matching origin" {
+  let _ = reset_runtime_js_state()
+  let _ = evaluate_js("0")
+  set_runtime_context_authorization(
+    "session-1",
+    "{\"https://api.example.com\":\"Bearer abc\"}",
+  )
+  let result = evaluate_js(
+    "(async () => {" +
+    "  globalThis.__bidiCurrentContext = \"session-1\";" +
+    "  let captured = \"<unset>\";" +
+    "  globalThis.__rawFetch = async (url, opts) => {" +
+    "    captured = (opts && opts.headers && (opts.headers.get ? opts.headers.get('Authorization') : opts.headers.Authorization)) || null;" +
+    "    return new Response('ok', { status: 200, headers: { 'access-control-allow-origin': 'https://app.example.com' } });" +
+    "  };" +
+    "  globalThis.__pageUrl = 'https://app.example.com';" +
+    "  await globalThis.fetch('https://other.com/x');" +
+    "  return captured;" +
+    "})()",
+  )
+  inspect(result, content="null")
+}
+```
+
+If the existing fetch wbtests pattern uses `@async.Promise::wait` to flush microtasks, adapt the new tests to match — copy the structure from `bidi_runtime_fetch_wbtest.mbt`'s top-most test.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `moon test -p mizchi/crater-webdriver-bidi/webdriver`
+Expected: FAIL — Authorization never gets attached because the fetch shim doesn't read `__bidiResolveAuth` yet.
+
+- [ ] **Step 3: Wire the attach**
+
+In `webdriver/webdriver/bidi_runtime_eval.mbt`, locate the `fetchWithPolicy` cookie-attach block (around line 3315, after `__bidiResolveCookies` is consulted). Insert the Authorization attach block right after:
+
+```javascript
+  #|         // Attach partition Authorization header if registered for
+  #|         // this origin and caller has not already supplied one.
+  #|         if (
+  #|           typeof globalThis.__bidiResolveAuth === 'function' &&
+  #|           !headers.has('Authorization')
+  #|         ) {
+  #|           try {
+  #|             const authValue = globalThis.__bidiResolveAuth(resolvedUrl);
+  #|             if (authValue) {
+  #|               headers.set('Authorization', authValue);
+  #|             }
+  #|           } catch (_e) { /* swallow — fail open with no header */ }
+  #|         }
+```
+
+The exact insertion point is just after the existing Cookie-attach `if` block. Find that block by grepping `__bidiResolveCookies` in the file.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `moon test -p mizchi/crater-webdriver-bidi/webdriver`
+Expected: PASS — all three new attach tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add webdriver/webdriver/bidi_runtime_eval.mbt webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt
+git commit -m "Attach Authorization header in fetch shim for matching origins
+
+Caller-supplied Authorization headers survive; the bridge only fires
+when headers.has('Authorization') is false. Same skip-if-set policy
+as the cookie attach block.
+
+Closes protocol.bidi-origin-authorization-injection.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Approve pkspec scenario with smoke
+
+**Files:**
+- Modify: `specs/crater.pkl`
+- Modify: `specs/tasks.Test.pkl`
+
+- [ ] **Step 1: Write the smoke test failure**
+
+Append the new pkspec smoke test to `specs/tasks.Test.pkl` (mirror the shape of `bidi_runtime_fetch_partition_cookie_bridge_wired`):
+
+```pkl
+  new {
+    name = "bidi_origin_authorization_injection_wired"
+    description =
+      "The BiDi runtime accepts crater.setOriginAuthorization / clearOriginAuthorization / listOriginAuthorizations commands, normalizes origins, redacts header values in Show output and list responses, and attaches Authorization headers to outgoing fetches for matching origins via the __bidiResolveAuth bridge. Caller-supplied Authorization survives."
+    tags { "bidi"; "auth"; "runtime" }
+    specRef { "protocol.bidi-origin-authorization-injection" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f http/profile/auth.mbt; grep -Fq -- \"fn AuthState::set_origin_header\" http/profile/auth.mbt; grep -Fq -- \"<redacted>\" http/profile/auth.mbt; test -f webdriver/webdriver/bidi_authorization.mbt; grep -Fq -- \"handle_crater_set_origin_authorization\" webdriver/webdriver/bidi_authorization.mbt; grep -Fq -- \"normalize_origin\" webdriver/webdriver/bidi_authorization.mbt; grep -Fq -- \"\\\"crater.setOriginAuthorization\\\"\" webdriver/webdriver/bidi_protocol_dispatch_script.mbt webdriver/webdriver/bidi_protocol_dispatch_storage.mbt webdriver/webdriver/bidi_protocol_dispatch_network.mbt webdriver/webdriver/bidi_protocol_dispatch_browsing_context.mbt 2>/dev/null || grep -rFq -- \"\\\"crater.setOriginAuthorization\\\"\" webdriver/webdriver/; grep -Fq -- \"globalThis.__bidiResolveAuth\" webdriver/webdriver/bidi_runtime_context.mbt; grep -Fq -- \"globalThis.__bidiResolveAuth\" webdriver/webdriver/bidi_runtime_eval.mbt; test -f webdriver/webdriver/bidi_authorization_wbtest.mbt; grep -Fq -- \"crater.setOriginAuthorization stores per-origin header\" webdriver/webdriver/bidi_authorization_wbtest.mbt; grep -Fq -- \"crater.setOriginAuthorization rejects CRLF in headerValue\" webdriver/webdriver/bidi_authorization_wbtest.mbt; test -f webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt; grep -Fq -- \"fetch shim attaches Authorization for matching origin\" webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt; grep -Fq -- \"fetch shim respects caller-provided Authorization over bridge\" webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt'"
+  }
+```
+
+The grep targets where `crater.setOriginAuthorization` is routed needs to match the actual dispatch file. Adjust the `grep -rFq` fallback to be the only check if there's no single dispatch file to grep.
+
+- [ ] **Step 2: Run spec-test to confirm failure**
+
+Run: `pkf run spec-check`
+Expected: FAIL — `protocol.bidi-origin-authorization-injection` scenario isn't declared.
+
+- [ ] **Step 3: Add the approved scenario**
+
+Append to `specs/crater.pkl` in the appropriate `bug.*` / `protocol.*` cluster:
+
+```pkl
+  new {
+    id = "protocol.bidi-origin-authorization-injection"
+    name = "BiDi clients can inject Authorization headers per origin"
+    description =
+      "Three BiDi extension commands let WebDriver clients register Authorization header values scoped to a single scheme://host[:port] origin: crater.setOriginAuthorization sets, crater.clearOriginAuthorization removes, crater.listOriginAuthorizations returns the set of registered origins (header values intentionally NOT exposed). The runtime fetch shim attaches the registered header to outgoing requests for matching origins; the caller-wins policy from PR #136 / #140 still applies — if the caller has already set Authorization, the bridge does not overwrite. Origin normalization lowercases scheme and host and strips default ports. Header value validation rejects empty / CRLF / control / ANSI / oversized inputs. Stored credentials are redacted in Show output and absent from list responses."
+    tags { "bidi"; "auth"; "runtime"; "protocol" }
+    severity = "major"
+    reviewStatus = "approved"
+    contributes { "goal.protocol-compat"; "goal.dom-compat" }
+  }
+```
+
+- [ ] **Step 4: Run gates**
+
+Run:
+- `pkf run spec-check` — all declared scenarios have impls.
+- `pkf run spec-lint` — clean.
+- `pkf run spec-test` — should now pass the new `bidi_origin_authorization_injection_wired` smoke.
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add specs/crater.pkl specs/tasks.Test.pkl
+git commit -m "Approve protocol.bidi-origin-authorization-injection scenario
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+- AuthState extension → Task 1.
+- Origin normalization → Task 2 (folded into Task 3).
+- `crater.setOriginAuthorization` / `clear` / `list` handlers → Task 3.
+- Validation rejections (CRLF / ANSI / empty / oversized / scheme / path) → Task 3 tests.
+- Origin normalization round-trip → Task 3 test (`https://Example.COM:443` → `https://example.com`).
+- Snapshot bridge + `__bidiResolveAuth` install → Task 4.
+- Snapshot push from lifecycle hook → Task 5.
+- Fetch shim Authorization attach + caller-wins → Task 6.
+- Origin mismatch → Task 6 test.
+- pkspec scenario + smoke → Task 7.
+
+Spec mentions preflight (cross-origin POST should not carry Authorization on the OPTIONS request, only on the actual POST). The existing preflight implementation builds its own headers via `Headers` constructor without copying `Authorization` from the original request — verify in Task 6 by adding a test if scope allows; if it complicates things, file as a follow-up draft.
+
+**2. Placeholder scan:** No TBD / TODO / "similar to" / "add appropriate error handling" patterns. Validation contracts are spelled out. Test code present in every step.
+
+**3. Type consistency:**
+
+- `AuthState { origin_headers : Map[String, String] }` — same shape in Tasks 1, 3, 5.
+- `set_origin_header` / `clear_origin_header` / `header_for_origin` / `list_origins` — same signatures across tasks.
+- `serialize_auth_snapshot_for_runtime` returns `String` (JSON) — consistent in Tasks 3, 5.
+- `set_runtime_context_authorization(ctx_id, json)` signature — same in Tasks 3 (stub), 4 (real), 5 (caller).
+- `__bidiContextAuth` / `__bidiResolveAuth` / `__bidiCurrentContext` — consistent global names across Tasks 4, 5, 6.
+- `protocol.bidi-origin-authorization-injection` scenario id matches between spec smoke and approval (Task 7).
+
+No drift detected.

--- a/docs/superpowers/specs/2026-05-18-bidi-origin-authorization-design.md
+++ b/docs/superpowers/specs/2026-05-18-bidi-origin-authorization-design.md
@@ -1,0 +1,468 @@
+# BiDi Origin-Scoped Authorization Injection
+
+## Overview
+
+Extend Crater's BiDi runtime so WebDriver clients can register an
+`Authorization` header value per origin, and have the BiDi runtime
+fetch shim attach that header automatically to matching outgoing
+requests. Cover the common Bearer / JWT case and the broader
+"WebDriver supplies the credential, page-script forgets to send it"
+ergonomic.
+
+This is Phase 1 of the auth-extension follow-up to the
+[browser auth + CORS plan](./2026-05-17-browser-auth-cors-design.md).
+Phase 2 (HTTP Basic 401 challenge handling, `network.continueWithAuth`)
+is a separate spec.
+
+## Goals
+
+- WebDriver clients can call a new `crater.setOriginAuthorization
+  ({origin, headerValue})` BiDi command to register an Authorization
+  value scoped to a single `scheme://host[:port]` origin.
+- The BiDi runtime fetch shim automatically attaches the registered
+  header to outgoing requests whose URL matches the origin, unless the
+  caller has already set `Authorization` on the request (caller wins,
+  same policy as PR #136 cookies).
+- `crater.clearOriginAuthorization({origin})` removes a registered
+  entry; `crater.listOriginAuthorizations()` returns the registered
+  origins (without exposing the header values).
+- Header values are sanitized at the input boundary so CRLF / control
+  characters cannot inject downstream log lines or extra HTTP headers.
+- Stored credentials never leak to logs or list responses — the
+  `AuthState` `Show` impl renders `<redacted>` for each entry, and the
+  list response surfaces origins only.
+
+## Non-Goals
+
+- HTTP Basic / Digest 401 challenge handling
+  (`network.continueWithAuth`). Phase 2, separate scenario.
+- BiDi standard `network.continueRequest` header-override flow. Phase 2.
+- OAuth / SSO redirect chains, JWT signing / verification, refresh
+  token plumbing. Out of scope — caller supplies a pre-baked header
+  value.
+- Persistent storage of credentials across sessions. The registered
+  state lives on the per-session `Profile.auth_state` and is dropped on
+  `browsingContext.close` along with the profile.
+- Per-URL-prefix or wildcard matching. Origin-only scope keeps the
+  surface minimal; URL-prefix matching is filed as a follow-up draft if
+  the need arises.
+
+---
+
+## Architecture
+
+```
+            WebDriver client
+                │
+   crater.setOriginAuthorization({origin, headerValue})
+   crater.clearOriginAuthorization({origin})
+   crater.listOriginAuthorizations()
+                │
+        ┌───────▼───────────────────┐
+        │  webdriver/webdriver       │
+        │  bidi_authorization.mbt    │  ← new: handler + serializer
+        │  (dispatch routes to it)   │
+        └───────┬───────────────────┘
+                │ mutates per-session profile
+        ┌───────▼───────────────────┐
+        │  http/profile/auth.mbt    │  ← AuthState extended
+        │  origin_headers : Map     │
+        └───────┬───────────────────┘
+                │ snapshot push (mirrors cookies)
+        ┌───────▼───────────────────┐
+        │  bidi_runtime_context.mbt │
+        │  set_runtime_context_     │
+        │    authorization          │
+        │  → globalThis.__bidi      │
+        │      ContextAuth          │
+        │  → globalThis.__bidi      │
+        │      ResolveAuth(url)     │
+        └───────┬───────────────────┘
+                │
+        ┌───────▼───────────────────┐
+        │  bidi_runtime_eval.mbt    │
+        │  fetchWithPolicy:         │
+        │  attach Authorization     │
+        │  if !caller-supplied      │
+        └───────────────────────────┘
+```
+
+### Boundaries
+
+- One new MoonBit file: `webdriver/webdriver/bidi_authorization.mbt`.
+- `http/profile/auth.mbt` upgrades from an empty placeholder to a real
+  struct with `origin_headers : Map[String, String]`.
+- `webdriver/webdriver/bidi_runtime_context.mbt` gains a parallel
+  `set_runtime_context_authorization` extern js mirroring the existing
+  cookie snapshot push.
+- `webdriver/webdriver/bidi_runtime_eval.mbt` adds Authorization attach
+  inside the existing `fetchWithPolicy` header-construction block.
+- `bidi_protocol_context_lifecycle.mbt` calls the new snapshot pusher
+  alongside the cookie push.
+- `bidi_protocol_dispatch.mbt` (or the appropriate `dispatch_*.mbt`)
+  routes the three `crater.*` command names to the new handler.
+
+---
+
+## Components
+
+### `http/profile/auth.mbt` (extended)
+
+```moonbit
+pub(all) struct AuthState {
+  mut origin_headers : Map[String, String]
+} derive(Debug)
+
+pub impl Show for AuthState with output(self, logger) {
+  logger.write_string("{")
+  let mut first = true
+  for origin, _ in self.origin_headers {
+    if !first { logger.write_string(", ") }
+    first = false
+    logger.write_string(origin + ": <redacted>")
+  }
+  logger.write_string("}")
+}
+
+pub fn AuthState::default() -> AuthState {
+  AuthState::{ origin_headers: {} }
+}
+
+pub fn AuthState::set_origin_header(
+  self : AuthState,
+  origin : String,
+  header_value : String,
+) -> Unit
+
+pub fn AuthState::clear_origin_header(
+  self : AuthState,
+  origin : String,
+) -> Unit
+
+pub fn AuthState::header_for_origin(
+  self : AuthState,
+  origin : String,
+) -> String?
+
+pub fn AuthState::list_origins(self : AuthState) -> Array[String]
+```
+
+`Show` redacts every header value. Stored credentials cannot leak via
+`println` / panic stack traces / structural debugging.
+
+### `webdriver/webdriver/bidi_authorization.mbt` (new)
+
+Handler functions for the three `crater.*` commands plus a
+`serialize_auth_snapshot_for_runtime(ctx_id) -> String` helper that
+emits a JSON object `{origin: header_value, ...}` for the runtime
+bridge.
+
+Input validation rejects:
+
+- Missing or non-string `origin` / `headerValue`.
+- `origin` whose scheme is not `http://` or `https://`.
+- `origin` containing path / query / fragment.
+- `origin` parse failure.
+- Empty `headerValue`.
+- `headerValue` containing CR, LF, NUL, or ANSI CSI escape (`\x1b[`).
+- `headerValue` exceeding 8 KB.
+- Unknown `context` argument.
+
+Origin normalization:
+
+- Scheme and host lowercased.
+- Default port (`:80` for http, `:443` for https) stripped.
+- Trailing slash on the origin URL stripped.
+
+`listOriginAuthorizations` returns `{origins: [{origin: "..."}]}` —
+header values are deliberately not exposed.
+
+### `webdriver/webdriver/bidi_runtime_context.mbt` (modified)
+
+New extern js `js_set_runtime_context_authorization(ctx_id, auth_json)`
+and a thin MoonBit wrapper. The JS body:
+
+```javascript
+(ctxId, authJson) => {
+  if (!globalThis.__bidiContextAuth) globalThis.__bidiContextAuth = {};
+  try {
+    globalThis.__bidiContextAuth[ctxId] = JSON.parse(authJson);
+  } catch (_e) {
+    globalThis.__bidiContextAuth[ctxId] = {};  // fail-safe
+  }
+  if (typeof globalThis.__bidiResolveAuth !== 'function') {
+    globalThis.__bidiResolveAuth = function(url) {
+      const ctx = String(globalThis.__bidiCurrentContext || 'default-context');
+      const map = (globalThis.__bidiContextAuth || {})[ctx] || {};
+      try {
+        const u = new URL(url);
+        let origin = u.protocol + '//' + u.hostname;
+        if (
+          (u.protocol === 'http:'  && u.port && u.port !== '80') ||
+          (u.protocol === 'https:' && u.port && u.port !== '443')
+        ) origin += ':' + u.port;
+        return map[origin] || null;
+      } catch (_e) { return null; }
+    };
+  }
+}
+```
+
+The install-once pattern follows PR #136's `__bidiResolveCookies`.
+
+### `webdriver/webdriver/bidi_protocol_context_lifecycle.mbt` (modified)
+
+`apply_effective_viewport_to_runtime_context` already pushes the cookie
+snapshot. The auth snapshot push happens right after:
+
+```moonbit
+flush_pending_cookie_ingest()
+set_runtime_context_cookies(ctx_id, cookie_snapshot)
+let auth_snapshot = self.serialize_auth_snapshot_for_runtime(ctx_id)
+set_runtime_context_authorization(ctx_id, auth_snapshot)
+```
+
+### `webdriver/webdriver/bidi_runtime_eval.mbt` (modified, fetch shim)
+
+In `fetchWithPolicy`, immediately after the cookie attach block:
+
+```javascript
+if (
+  typeof globalThis.__bidiResolveAuth === 'function' &&
+  !headers.has('Authorization')
+) {
+  try {
+    const authValue = globalThis.__bidiResolveAuth(resolvedUrl);
+    if (authValue) headers.set('Authorization', authValue);
+  } catch (_e) { /* swallow — fail open with no header attached */ }
+}
+```
+
+`headers.has('Authorization')` is the caller-wins guard. The block
+mirrors the cookie-attach skip-if-set pattern from PR #136.
+
+### Dispatch routing
+
+Three new entries in the existing BiDi dispatch switch:
+
+- `"crater.setOriginAuthorization"` → `handle_crater_set_origin_authorization`
+- `"crater.clearOriginAuthorization"` → `handle_crater_clear_origin_authorization`
+- `"crater.listOriginAuthorizations"` → `handle_crater_list_origin_authorizations`
+
+### Lifecycle
+
+`session_profiles.remove(ctx_id)` in
+`close_context_and_cleanup` already drops the `Profile` (which owns
+`auth_state`). No separate auth cleanup needed.
+
+---
+
+## Data Flow
+
+### 1. Bearer / JWT injection (the happy path)
+
+```
+WebDriver client
+  │
+  │ crater.setOriginAuthorization({
+  │   origin: "https://api.example.com",
+  │   headerValue: "Bearer eyJhbGc..."
+  │ })
+  ▼
+handle_crater_set_origin_authorization
+  │  validate + normalize origin → "https://api.example.com"
+  │  validate headerValue (no CRLF / ANSI / oversized)
+  │  profile.auth_state.set_origin_header(origin, value)
+  │  set_runtime_context_authorization(ctx_id, snapshot_json)
+  │    → globalThis.__bidiContextAuth["ctx-1"] =
+  │       {"https://api.example.com": "Bearer eyJhbGc..."}
+  │  send_success({})
+  │
+  │ script.evaluate("fetch('https://api.example.com/me')")
+  ▼
+fetchWithPolicy
+  │  __bidiResolveAuth(url) → "Bearer eyJhbGc..."
+  │  headers.has('Authorization') → false
+  │  headers.set('Authorization', 'Bearer eyJhbGc...')
+  │  classify_request → Allow (simple GET cross-origin)
+  │  fetch → 200 JSON
+  │  validate_actual_response → Ok
+  │  return to page
+```
+
+### 2. Caller wins
+
+```
+script.evaluate("fetch('https://api.example.com/me', {
+  headers: { Authorization: 'Bearer page-token' }
+})")
+
+fetchWithPolicy
+  │  headers seeded with caller's 'Bearer page-token'
+  │  __bidiResolveAuth(url) → 'Bearer driver-token'
+  │  headers.has('Authorization') → true
+  │  → skip; driver token discarded for this request
+  │  fetch with caller value
+```
+
+### 3. List / clear
+
+```
+crater.clearOriginAuthorization({
+  origin: "https://api.example.com"
+})
+  → auth_state.clear_origin_header(origin)
+  → __bidiContextAuth["ctx-1"] no longer has that origin
+  → next fetch to that origin: __bidiResolveAuth returns null
+  → no Authorization attached
+
+crater.listOriginAuthorizations({})
+  → response: {origins: [{origin: "https://api.example.com"}]}
+  → header values are NOT in the response
+```
+
+---
+
+## Error Handling
+
+### Input-side rejection (`crater.setOriginAuthorization`)
+
+| Input | BiDi error |
+|---|---|
+| `params` not an object | `invalid argument` "params must be an object" |
+| Missing `origin` | `invalid argument` "origin must be a string" |
+| Non-http/https scheme | `invalid argument` "origin must use http or https scheme" |
+| Path / query / fragment present | `invalid argument` "origin must not contain path / query / fragment" |
+| Missing `headerValue` | `invalid argument` "headerValue must be a string" |
+| Empty `headerValue` | `invalid argument` "headerValue must not be empty" |
+| CRLF / NUL / control char in `headerValue` | `invalid argument` "headerValue must not contain control characters" |
+| ANSI CSI escape in `headerValue` | `invalid argument` "headerValue must not contain ANSI escape sequences" |
+| `headerValue` > 8192 bytes | `invalid argument` "headerValue exceeds 8KB limit" |
+| Unknown `context` | `no such frame` "Unknown context: ..." |
+
+### Runtime-side fail-open
+
+`__bidiResolveAuth` swallows URL parse failures, snapshot key
+mismatches, and missing-context cases by returning `null`. The fetch
+proceeds without an Authorization header.
+
+Snapshot JSON parse failure resets `__bidiContextAuth[ctx_id]` to `{}`
+instead of leaving a stale value (fail-safe).
+
+### Secret leak prevention
+
+- `Show` impl on `AuthState` writes `<redacted>` for each entry.
+- `listOriginAuthorizations` returns origins only — header values are
+  never serialized into BiDi responses.
+- `headerValue` rejection of CR/LF prevents Set-Cookie-style or extra-
+  header injection that could exfiltrate via log shippers.
+
+### Race / concurrency
+
+MoonBit BiDi handlers run on a single-task async runtime. Set / clear
+/ list / fetch attach all execute serially. No locking needed.
+
+---
+
+## Testing Strategy
+
+### Unit tests
+
+`http/profile/auth_wbtest.mbt` (new):
+
+- `AuthState::default()` has empty `origin_headers`.
+- `set_origin_header` then `header_for_origin` round-trips.
+- Set overwrites prior value for the same origin.
+- `clear_origin_header` removes the entry.
+- `list_origins` returns sorted origins.
+- `Show` impl prints `origin: <redacted>` for each entry; never the
+  header value.
+
+### BiDi handler tests
+
+`webdriver/webdriver/bidi_authorization_wbtest.mbt` (new):
+
+- `crater.setOriginAuthorization` happy path — `profile_for_session
+  ("ctx-1").auth_state.header_for_origin(origin)` reads the value.
+- Re-set on the same origin overwrites.
+- `crater.clearOriginAuthorization` removes the entry.
+- `crater.listOriginAuthorizations` returns origins only; no header
+  values appear anywhere in the response.
+- Validation errors for each rejection in the table above.
+- Origin normalization: setting
+  `https://Example.COM:443` and `https://example.com` are observed as
+  the same key.
+
+### Snapshot bridge tests
+
+`webdriver/webdriver/bidi_runtime_authorization_bridge_wbtest.mbt` (new):
+
+- After set, `evaluate_js("globalThis.__bidiResolveAuth(...)")` returns
+  the header value.
+- After clear, `__bidiResolveAuth` returns `null`.
+- URL with path / query resolves against the origin part only.
+- Default-port URLs (`:443` / `:80`) match origins set without the
+  port.
+
+### Fetch shim integration tests
+
+`bidi_runtime_fetch_wbtest.mbt` (extended):
+
+- Authorization auto-attach on cross-origin GET to the registered
+  origin — captured fetch sees `Authorization: Bearer ...`.
+- Caller-wins: page-provided `Authorization` survives; driver value is
+  discarded for that request.
+- Origin mismatch: registered for origin A, fetch to origin B → no
+  Authorization on the outgoing request.
+- Coexistence with PR #140 Set-Cookie ingest: a single fetch can both
+  send Authorization outbound and ingest Set-Cookie inbound.
+- Preflight: cross-origin POST with custom header → OPTIONS preflight
+  does NOT carry Authorization (per spec, preflight is credentialless);
+  the actual POST does.
+
+### pkspec scenario
+
+One new scenario, approved with smoke:
+
+- `protocol.bidi-origin-authorization-injection` (`goal.protocol-compat`)
+  - WebDriver can set, list, and clear per-origin Authorization values
+    via three `crater.*` commands.
+  - The BiDi runtime fetch shim attaches the value to outgoing
+    requests for matching origins.
+  - Caller-supplied `Authorization` headers survive.
+  - Header values are redacted from `Show` output and absent from
+    `listOriginAuthorizations` responses.
+  - Implementing tests: the four wbtest files above.
+
+Smoke `cmd` (grep-based) verifies:
+- `fn AuthState::set_origin_header` in `http/profile/auth.mbt`
+- `"crater.setOriginAuthorization"` literal in the dispatch routing
+- `__bidiResolveAuth` literal in both `bidi_runtime_context.mbt` and
+  `bidi_runtime_eval.mbt`
+- `<redacted>` literal in `auth.mbt`
+
+### Optional end-to-end (deferred)
+
+`scripts/fixtures/auth-server.ts` gains a `GET /api/protected`
+endpoint that requires `Authorization: Bearer test-jwt-token`. A new
+test case in `tests/auth-flow-via-bidi.test.ts` drives the full BiDi
+flow: set → fetch protected → expect 200 with welcome data. The e2e
+case ships only after all wbtests pass — Phase 5 e2e has known
+form-shape gaps documented in PR #138 drafts, so the integration test
+must work around them with the cookie-injection-style pattern.
+
+---
+
+## Sequencing
+
+1. `AuthState` struct expansion + unit tests.
+2. BiDi handler + dispatch routing + handler-side wbtests.
+3. Snapshot bridge + `__bidiResolveAuth` install + bridge wbtest.
+4. Fetch shim Authorization attach + integration wbtests.
+5. pkspec scenario `protocol.bidi-origin-authorization-injection`
+   flipped from draft to approved with smoke.
+6. (Optional) e2e fixture endpoint and test case.
+
+Each step is a separate commit. Steps 2-4 can each be their own PR if
+review load is heavy; otherwise one PR covering 1-5 with separate
+commits is fine.

--- a/http/profile/auth.mbt
+++ b/http/profile/auth.mbt
@@ -5,7 +5,7 @@
 /// already supplied an `Authorization` header.
 pub(all) struct AuthState {
   mut origin_headers : Map[String, String]
-} derive(Debug)
+}
 
 ///|
 /// Show impl deliberately redacts header values; only origins are

--- a/http/profile/auth.mbt
+++ b/http/profile/auth.mbt
@@ -1,14 +1,65 @@
 ///|
-/// Placeholder for HTTP auth credentials carried by a Profile.
-/// P1: empty. Future expansion: basic_credentials, bearer_tokens.
-pub(all) struct AuthState {} derive(Debug)
+/// Per-origin Authorization header storage carried by a Profile.
+/// Header values are written via WebDriver `crater.setOriginAuthorization`
+/// and attached by the BiDi runtime fetch shim when the caller has not
+/// already supplied an `Authorization` header.
+pub(all) struct AuthState {
+  mut origin_headers : Map[String, String]
+} derive(Debug)
 
 ///|
-pub impl Show for AuthState with output(_self, logger) {
-  logger.write_string("{}")
+/// Show impl deliberately redacts header values; only origins are
+/// rendered. Prevents secret leaks via panic stack traces or
+/// structural debugging.
+pub impl Show for AuthState with output(self, logger) {
+  logger.write_string("AuthState{")
+  let origins = self.list_origins()
+  for i = 0; i < origins.length(); i = i + 1 {
+    if i > 0 {
+      logger.write_string(", ")
+    }
+    logger.write_string(origins[i])
+    logger.write_string(": <redacted>")
+  }
+  logger.write_string("}")
 }
 
 ///|
 pub fn AuthState::default() -> AuthState {
-  AuthState::{  }
+  AuthState::{ origin_headers: Map([], capacity=0) }
+}
+
+///|
+pub fn AuthState::set_origin_header(
+  self : AuthState,
+  origin : String,
+  header_value : String,
+) -> Unit {
+  self.origin_headers[origin] = header_value
+}
+
+///|
+pub fn AuthState::clear_origin_header(
+  self : AuthState,
+  origin : String,
+) -> Unit {
+  self.origin_headers.remove(origin)
+}
+
+///|
+pub fn AuthState::header_for_origin(
+  self : AuthState,
+  origin : String,
+) -> String? {
+  self.origin_headers.get(origin)
+}
+
+///|
+pub fn AuthState::list_origins(self : AuthState) -> Array[String] {
+  let result = []
+  for origin, _ in self.origin_headers {
+    result.push(origin)
+  }
+  result.sort()
+  result
 }

--- a/http/profile/auth_wbtest.mbt
+++ b/http/profile/auth_wbtest.mbt
@@ -1,0 +1,60 @@
+///|
+test "AuthState::default has empty origin_headers" {
+  let state = AuthState::default()
+  inspect(state.origin_headers.length(), content="0")
+}
+
+///|
+test "set_origin_header round-trips through header_for_origin" {
+  let state = AuthState::default()
+  state.set_origin_header("https://api.example.com", "Bearer abc123")
+  inspect(
+    state.header_for_origin("https://api.example.com"),
+    content="Some(Bearer abc123)",
+  )
+  inspect(state.header_for_origin("https://other.com"), content="None")
+}
+
+///|
+test "set_origin_header overwrites prior value for same origin" {
+  let state = AuthState::default()
+  state.set_origin_header("https://api.example.com", "Bearer first")
+  state.set_origin_header("https://api.example.com", "Bearer second")
+  inspect(
+    state.header_for_origin("https://api.example.com"),
+    content="Some(Bearer second)",
+  )
+}
+
+///|
+test "clear_origin_header removes the entry" {
+  let state = AuthState::default()
+  state.set_origin_header("https://api.example.com", "Bearer abc")
+  state.clear_origin_header("https://api.example.com")
+  inspect(state.header_for_origin("https://api.example.com"), content="None")
+}
+
+///|
+test "list_origins returns sorted origins" {
+  let state = AuthState::default()
+  state.set_origin_header("https://b.example.com", "Bearer b")
+  state.set_origin_header("https://a.example.com", "Bearer a")
+  state.set_origin_header("https://c.example.com", "Bearer c")
+  let origins = state.list_origins()
+  inspect(
+    origins,
+    content="[https://a.example.com, https://b.example.com, https://c.example.com]",
+  )
+}
+
+///|
+test "Show impl redacts header values" {
+  let state = AuthState::default()
+  state.set_origin_header("https://api.example.com", "Bearer secret-token")
+  let buf = StringBuilder::new()
+  state.output(buf)
+  let rendered = buf.to_string()
+  inspect(rendered.contains("secret-token"), content="false")
+  inspect(rendered.contains("<redacted>"), content="true")
+  inspect(rendered.contains("https://api.example.com"), content="true")
+}

--- a/http/profile/auth_wbtest.mbt
+++ b/http/profile/auth_wbtest.mbt
@@ -48,6 +48,17 @@ test "list_origins returns sorted origins" {
 }
 
 ///|
+test "AuthState cannot be debug-printed with secrets exposed" {
+  let state = AuthState::default()
+  state.set_origin_header("https://api.example.com", "Bearer secret-token")
+  // Verify the type does not have a Debug derive that would dump origin_headers verbatim.
+  // The Show impl is the only way to render AuthState; it redacts.
+  let buf = StringBuilder::new()
+  state.output(buf)
+  inspect(buf.to_string().contains("secret-token"), content="false")
+}
+
+///|
 test "Show impl redacts header values" {
   let state = AuthState::default()
   state.set_origin_header("https://api.example.com", "Bearer secret-token")

--- a/http/profile/pkg.generated.mbti
+++ b/http/profile/pkg.generated.mbti
@@ -5,7 +5,6 @@ import {
   "mizchi/crater-browser-http/cache",
   "mizchi/crater-browser-http/cookie_jar",
   "mizchi/crater-browser-http/cors",
-  "moonbitlang/core/debug",
 }
 
 // Values
@@ -15,7 +14,7 @@ import {
 // Types and methods
 pub(all) struct AuthState {
   mut origin_headers : Map[String, String]
-} derive(@debug.Debug)
+}
 pub fn AuthState::clear_origin_header(Self, String) -> Unit
 pub fn AuthState::default() -> Self
 pub fn AuthState::header_for_origin(Self, String) -> String?

--- a/http/profile/pkg.generated.mbti
+++ b/http/profile/pkg.generated.mbti
@@ -14,8 +14,13 @@ import {
 
 // Types and methods
 pub(all) struct AuthState {
+  mut origin_headers : Map[String, String]
 } derive(@debug.Debug)
+pub fn AuthState::clear_origin_header(Self, String) -> Unit
 pub fn AuthState::default() -> Self
+pub fn AuthState::header_for_origin(Self, String) -> String?
+pub fn AuthState::list_origins(Self) -> Array[String]
+pub fn AuthState::set_origin_header(Self, String, String) -> Unit
 pub impl Show for AuthState
 
 pub(all) struct Profile {

--- a/http/profile/profile_wbtest.mbt
+++ b/http/profile/profile_wbtest.mbt
@@ -4,7 +4,7 @@ test "AuthState::default is empty" {
   inspect(
     state,
     content=(
-      #|{}
+      #|AuthState{}
     ),
   )
 }

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -943,6 +943,17 @@ scenarios {
     reviewStatus = "approved"
     contributes { "goal.protocol-compat" }
   }
+  // -- Protocol: BiDi origin-Authorization injection (Phase 7) -----------------
+  new {
+    id = "protocol.bidi-origin-authorization-injection"
+    name = "BiDi clients can inject Authorization headers per origin"
+    description =
+      "Three BiDi extension commands let WebDriver clients register Authorization header values scoped to a single scheme://host[:port] origin: crater.setOriginAuthorization sets, crater.clearOriginAuthorization removes, crater.listOriginAuthorizations returns the set of registered origins (header values intentionally NOT exposed). The runtime fetch shim attaches the registered header to outgoing requests for matching origins; the caller-wins policy from PR #136 / #140 still applies — if the caller has already set Authorization, the bridge does not overwrite. Origin normalization lowercases scheme and host and strips default ports. Header value validation rejects empty / CRLF / control / ANSI / oversized inputs. Stored credentials are redacted in Show output and absent from list responses."
+    tags { "bidi"; "auth"; "runtime"; "protocol" }
+    severity = "major"
+    reviewStatus = "approved"
+    contributes { "goal.protocol-compat"; "goal.dom-compat" }
+  }
   new {
     id = "bug.runtime.cookie-url-filter-parity"
     name = "JS-side cookie URL filter mirrors MoonBit without static guard"

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -516,6 +516,16 @@ tests {
       "bash -lc 'set -e; test -f webdriver/webdriver/bidi_runtime_context.mbt; grep -Fq -- \"delete globalThis.__bidiFetchShimInstalled\" webdriver/webdriver/bidi_runtime_context.mbt; grep -Fq -- \"delete globalThis.__rawFetch\" webdriver/webdriver/bidi_runtime_context.mbt; grep -Fq -- \"delete globalThis.__bidiPreflightCache\" webdriver/webdriver/bidi_runtime_context.mbt; test -f webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt; grep -Fq -- \"reset_runtime_js_state lets next bootstrap rebind __rawFetch to the realm fetch\" webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt'"
   }
   new {
+    name = "bidi_origin_authorization_injection_wired"
+    description =
+      "The BiDi runtime accepts crater.setOriginAuthorization / clearOriginAuthorization / listOriginAuthorizations commands, normalizes origins, redacts header values in Show output and list responses, and attaches Authorization headers to outgoing fetches for matching origins via the __bidiResolveAuth bridge. Caller-supplied Authorization survives."
+    tags { "bidi"; "auth"; "runtime" }
+    specRef { "protocol.bidi-origin-authorization-injection" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f http/profile/auth.mbt; grep -Fq -- \"fn AuthState::set_origin_header\" http/profile/auth.mbt; grep -Fq -- \"<redacted>\" http/profile/auth.mbt; test -f webdriver/webdriver/bidi_authorization.mbt; grep -Fq -- \"handle_crater_set_origin_authorization\" webdriver/webdriver/bidi_authorization.mbt; grep -Fq -- \"normalize_origin\" webdriver/webdriver/bidi_authorization.mbt; grep -rFq -- \"crater.setOriginAuthorization\" webdriver/webdriver/; grep -Fq -- \"globalThis.__bidiResolveAuth\" webdriver/webdriver/bidi_runtime_context.mbt; grep -Fq -- \"globalThis.__bidiResolveAuth\" webdriver/webdriver/bidi_runtime_eval.mbt; test -f webdriver/webdriver/bidi_authorization_wbtest.mbt; grep -Fq -- \"crater.setOriginAuthorization stores per-origin header\" webdriver/webdriver/bidi_authorization_wbtest.mbt; grep -Fq -- \"crater.setOriginAuthorization rejects CRLF in headerValue\" webdriver/webdriver/bidi_authorization_wbtest.mbt; test -f webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt; grep -Fq -- \"fetch shim attaches Authorization for matching origin\" webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt; grep -Fq -- \"fetch shim respects caller-provided Authorization over bridge\" webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt'"
+  }
+  new {
     name = "bidi_runtime_cookie_url_filter_parity_guarded"
     description =
       "webdriver/webdriver/bidi_runtime_cookie_parity_wbtest.mbt runs 10 representative cookie + request URL inputs through BOTH __bidiResolveCookies (JS, bidi_runtime_context.mbt) and storage_cookie_matches_request_url (MoonBit, bidi_storage.mbt) and asserts they agree. Coverage: domain + path agreement (exact host, cross-site, subdomain matching dot-prefixed domain, path prefix, path mismatch, trailing-slash path, name-prefix boundary, sibling subdomain). Scheme-vs-Secure filtering is intentionally out of scope per the catch-drift-don't-unify plan."

--- a/webdriver/webdriver/bidi_authorization.mbt
+++ b/webdriver/webdriver/bidi_authorization.mbt
@@ -1,0 +1,307 @@
+///|
+/// Maximum length in bytes for a stored Authorization header value.
+/// Real-world JWTs are typically under 4 KB; 8 KB leaves headroom
+/// without making it cheap to wedge unbounded state.
+const AUTH_HEADER_VALUE_LIMIT : Int = 8192
+
+///|
+/// Normalize an origin per the spec: only http/https, no path/query/
+/// fragment, lowercased scheme and host, default port stripped.
+fn normalize_origin(input : String) -> Result[String, String] {
+  let trimmed = input.trim().to_owned()
+  let scheme_end = match trimmed.find("://") {
+    Some(idx) => idx
+    None => return Err("origin must be a valid URL (scheme://host[:port])")
+  }
+  let scheme = trimmed.unsafe_substring(start=0, end=scheme_end).to_lower()
+  if scheme != "http" && scheme != "https" {
+    return Err("origin must use http or https scheme")
+  }
+  let host_start = scheme_end + 3
+  let rest = trimmed.unsafe_substring(start=host_start, end=trimmed.length())
+  // Reject path / query / fragment
+  if rest.contains("/") || rest.contains("?") || rest.contains("#") {
+    return Err("origin must not contain path / query / fragment")
+  }
+  if rest.length() == 0 {
+    return Err("origin must include a host")
+  }
+  let lowered_host = rest.to_lower()
+  // Strip default port
+  let normalized_host_port = if scheme == "http" &&
+    lowered_host.has_suffix(":80") {
+    lowered_host.unsafe_substring(start=0, end=lowered_host.length() - 3)
+  } else if scheme == "https" && lowered_host.has_suffix(":443") {
+    lowered_host.unsafe_substring(start=0, end=lowered_host.length() - 4)
+  } else {
+    lowered_host
+  }
+  Ok(scheme + "://" + normalized_host_port)
+}
+
+///|
+/// Validate a candidate header value. Reject empty, oversized, or
+/// values containing control characters / ANSI escape sequences. Tab
+/// (0x09) is allowed because it is sometimes legitimately used inside
+/// scheme parameters.
+fn validate_header_value(value : String) -> Result[Unit, String] {
+  if value.length() == 0 {
+    return Err("headerValue must not be empty")
+  }
+  if value.length() > AUTH_HEADER_VALUE_LIMIT {
+    return Err("headerValue exceeds 8KB limit")
+  }
+  let chars = value.to_array()
+  for i = 0; i < chars.length(); i = i + 1 {
+    let code = chars[i].to_int()
+    if code == 0x1b {
+      return Err("headerValue must not contain ANSI escape sequences")
+    }
+    if code < 0x20 && code != 0x09 {
+      return Err("headerValue must not contain control characters")
+    }
+  }
+  Ok(())
+}
+
+///|
+/// Resolve the target context: explicit `context` param wins; otherwise
+/// fall back to the active context. Returns None and sends an error
+/// when the context argument is malformed or unknown.
+fn BidiProtocol::resolve_authorization_context(
+  self : BidiProtocol,
+  map : Map[String, Json],
+  request_id : Int,
+) -> String? {
+  match map.get("context") {
+    Some(String(ctx)) =>
+      if !self.manager.has_session(ctx) {
+        self.send_error(request_id, "no such frame", "Unknown context: " + ctx)
+        None
+      } else {
+        Some(ctx)
+      }
+    Some(_) => {
+      self.send_error(
+        request_id, "invalid argument", "context must be a string",
+      )
+      None
+    }
+    None =>
+      match self.default_context_id {
+        Some(ctx) => Some(ctx)
+        None => {
+          self.send_error(
+            request_id, "no such frame", "No active browsing context",
+          )
+          None
+        }
+      }
+  }
+}
+
+///|
+/// Handle `crater.setOriginAuthorization`. Persists a header value on
+/// the per-session profile under a normalized origin key.
+fn BidiProtocol::handle_crater_set_origin_authorization(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let map = match params {
+    Some(Object(m)) => m
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "params must be an object",
+      )
+      return
+    }
+  }
+  let raw_origin = match map.get("origin") {
+    Some(String(o)) => o
+    _ => {
+      self.send_error(request_id, "invalid argument", "origin must be a string")
+      return
+    }
+  }
+  let header_value = match map.get("headerValue") {
+    Some(String(v)) => v
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "headerValue must be a string",
+      )
+      return
+    }
+  }
+  let normalized = match normalize_origin(raw_origin) {
+    Ok(o) => o
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  match validate_header_value(header_value) {
+    Ok(_) => ()
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  let ctx_id = self.resolve_authorization_context(map, request_id)
+  guard ctx_id is Some(ctx) else { return }
+  let profile = match self.profile_for_session(ctx) {
+    Some(p) => p
+    None => {
+      self.send_error(request_id, "no such frame", "Unknown context: " + ctx)
+      return
+    }
+  }
+  profile.auth_state.set_origin_header(normalized, header_value)
+  self.push_authorization_snapshot(ctx)
+  self.send_success(request_id, Some(make_object({})))
+}
+
+///|
+/// Handle `crater.clearOriginAuthorization`. Removes any stored header
+/// for the normalized origin from the per-session profile.
+fn BidiProtocol::handle_crater_clear_origin_authorization(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let map = match params {
+    Some(Object(m)) => m
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "params must be an object",
+      )
+      return
+    }
+  }
+  let raw_origin = match map.get("origin") {
+    Some(String(o)) => o
+    _ => {
+      self.send_error(request_id, "invalid argument", "origin must be a string")
+      return
+    }
+  }
+  let normalized = match normalize_origin(raw_origin) {
+    Ok(o) => o
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  let ctx_id = self.resolve_authorization_context(map, request_id)
+  guard ctx_id is Some(ctx) else { return }
+  let profile = match self.profile_for_session(ctx) {
+    Some(p) => p
+    None => {
+      self.send_error(request_id, "no such frame", "Unknown context: " + ctx)
+      return
+    }
+  }
+  profile.auth_state.clear_origin_header(normalized)
+  self.push_authorization_snapshot(ctx)
+  self.send_success(request_id, Some(make_object({})))
+}
+
+///|
+/// Handle `crater.listOriginAuthorizations`. Returns the set of
+/// registered origins without exposing any header values.
+fn BidiProtocol::handle_crater_list_origin_authorizations(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let map : Map[String, Json] = match params {
+    Some(Object(m)) => m
+    _ => Map([], capacity=0)
+  }
+  let ctx_id = self.resolve_authorization_context(map, request_id)
+  guard ctx_id is Some(ctx) else { return }
+  let profile = match self.profile_for_session(ctx) {
+    Some(p) => p
+    None => {
+      self.send_error(request_id, "no such frame", "Unknown context: " + ctx)
+      return
+    }
+  }
+  let origins_json : Array[Json] = []
+  for origin in profile.auth_state.list_origins() {
+    origins_json.push(make_object({ "origin": Json::string(origin) }))
+  }
+  self.send_success(
+    request_id,
+    Some(make_object({ "origins": Json::array(origins_json) })),
+  )
+}
+
+///|
+/// Serialize the partition's origin_headers as a JSON object suitable
+/// for pushing into globalThis.__bidiContextAuth[ctxId]. Header values
+/// only cross the JS bridge — the WebDriver-facing surface (list /
+/// events) never serializes them.
+fn BidiProtocol::serialize_auth_snapshot_for_runtime(
+  self : BidiProtocol,
+  ctx_id : String,
+) -> String {
+  match self.profile_for_session(ctx_id) {
+    Some(profile) => {
+      let entries : Map[String, Json] = Map([], capacity=0)
+      for origin in profile.auth_state.list_origins() {
+        match profile.auth_state.header_for_origin(origin) {
+          Some(value) => entries[origin] = Json::string(value)
+          None => ()
+        }
+      }
+      make_object(entries).stringify()
+    }
+    None => "{}"
+  }
+}
+
+///|
+/// Push the per-context Authorization snapshot to the JS runtime so
+/// the fetch shim can attach the header on outbound requests.
+fn BidiProtocol::push_authorization_snapshot(
+  self : BidiProtocol,
+  ctx_id : String,
+) -> Unit {
+  let snapshot = self.serialize_auth_snapshot_for_runtime(ctx_id)
+  set_runtime_context_authorization(ctx_id, snapshot)
+}
+
+///|
+/// Dispatch crater.* extension commands. Currently scoped to the
+/// origin-Authorization injection surface (set / clear / list); other
+/// crater.* extensions live as separate dispatch branches today and
+/// can be folded in if a second command lands here.
+fn BidiProtocol::dispatch_crater(
+  self : BidiProtocol,
+  request : BidiRequest,
+  action : String,
+) -> Result[Unit, String] {
+  match action {
+    "setOriginAuthorization" => {
+      self.handle_crater_set_origin_authorization(request.id, request.params)
+      Ok(())
+    }
+    "clearOriginAuthorization" => {
+      self.handle_crater_clear_origin_authorization(request.id, request.params)
+      Ok(())
+    }
+    "listOriginAuthorizations" => {
+      self.handle_crater_list_origin_authorizations(request.id, request.params)
+      Ok(())
+    }
+    _ => {
+      self.send_error(
+        request.id,
+        "unknown command",
+        "Unknown method: " + request.method_name,
+      )
+      Ok(())
+    }
+  }
+}

--- a/webdriver/webdriver/bidi_authorization_wbtest.mbt
+++ b/webdriver/webdriver/bidi_authorization_wbtest.mbt
@@ -1,0 +1,167 @@
+///|
+/// Verifies that `crater.setOriginAuthorization` stores the supplied
+/// header value on the per-session profile's AuthState under the
+/// requested origin.
+test "crater.setOriginAuthorization stores per-origin header" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer abc123\"}}",
+  )
+  ignore(proto.take_messages())
+  let profile = proto.profile_for_session("session-1").unwrap()
+  inspect(
+    profile.auth_state.header_for_origin("https://api.example.com"),
+    content="Some(Bearer abc123)",
+  )
+}
+
+///|
+/// Origin is normalized before storage: uppercase host is lowercased and
+/// the default port (443 for https, 80 for http) is stripped. The
+/// original casing must NOT match the stored entry.
+test "crater.setOriginAuthorization normalizes origin" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://Example.COM:443\",\"headerValue\":\"Bearer abc\"}}",
+  )
+  ignore(proto.take_messages())
+  let profile = proto.profile_for_session("session-1").unwrap()
+  inspect(
+    profile.auth_state.header_for_origin("https://example.com"),
+    content="Some(Bearer abc)",
+  )
+  inspect(
+    profile.auth_state.header_for_origin("https://Example.COM:443"),
+    content="None",
+  )
+}
+
+///|
+/// Missing headerValue must produce `invalid argument` with a message
+/// that names the offending field.
+test "crater.setOriginAuthorization rejects missing headerValue" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\"}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"error\":\"invalid argument\""))
+  assert_true(json.contains("headerValue"))
+}
+
+///|
+/// CRLF / control characters in the header value must be rejected so the
+/// stored value cannot be smuggled into a subsequent header line.
+test "crater.setOriginAuthorization rejects CRLF in headerValue" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer abc\\r\\nX-Spoof: evil\"}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"error\":\"invalid argument\""))
+  assert_true(json.contains("control"))
+}
+
+///|
+/// Non-http(s) schemes are rejected outright.
+test "crater.setOriginAuthorization rejects non-http scheme" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"ftp://example.com\",\"headerValue\":\"Bearer abc\"}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"error\":\"invalid argument\""))
+}
+
+///|
+/// An origin with a path component is malformed; only scheme + host
+/// [+ port] is allowed.
+test "crater.setOriginAuthorization rejects path in origin" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://example.com/api\",\"headerValue\":\"Bearer abc\"}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"error\":\"invalid argument\""))
+}
+
+///|
+/// `crater.clearOriginAuthorization` removes a previously-registered
+/// entry. A subsequent `header_for_origin` lookup must return None.
+test "crater.clearOriginAuthorization removes the entry" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer abc\"}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"crater.clearOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\"}}",
+  )
+  ignore(proto.take_messages())
+  let profile = proto.profile_for_session("session-1").unwrap()
+  inspect(
+    profile.auth_state.header_for_origin("https://api.example.com"),
+    content="None",
+  )
+}
+
+///|
+/// `crater.listOriginAuthorizations` returns the registered origins
+/// without leaking the header values into the BiDi response payload.
+test "crater.listOriginAuthorizations returns origins without values" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer secret-token\"}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://auth.example.com\",\"headerValue\":\"Bearer another-secret\"}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":4,\"method\":\"crater.listOriginAuthorizations\",\"params\":{}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("https://api.example.com"))
+  assert_true(json.contains("https://auth.example.com"))
+  // Header values MUST NOT appear in the response.
+  assert_true(!json.contains("secret-token"))
+  assert_true(!json.contains("another-secret"))
+}

--- a/webdriver/webdriver/bidi_authorization_wbtest.mbt
+++ b/webdriver/webdriver/bidi_authorization_wbtest.mbt
@@ -138,6 +138,50 @@ test "crater.clearOriginAuthorization removes the entry" {
 }
 
 ///|
+/// `apply_effective_viewport_to_runtime_context` re-pushes the auth snapshot
+/// at every `script.evaluate` boundary, so the JS-side `__bidiResolveAuth`
+/// bridge sees the latest registered values even if the runtime state was
+/// cleared between evaluations. The test deliberately wipes `__bidiContextAuth`
+/// inside the first evaluate, then confirms the second evaluate re-installs
+/// the snapshot via the lifecycle hook.
+test "apply_effective_viewport_to_runtime_context pushes auth snapshot" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  // Register an Authorization header for a test origin.
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":\"https://api.example.com\",\"headerValue\":\"Bearer lifecycle-test\"}}",
+  )
+  ignore(proto.take_messages())
+  // First evaluate: deliberately wipe the auth map to simulate a fresh
+  // runtime state (e.g. after a page navigation that resets globals).
+  // This proves that the lifecycle hook — not the setOriginAuthorization
+  // push — is what makes the value available in the second evaluate.
+  let wipe_expr = "delete globalThis.__bidiContextAuth; delete globalThis.__bidiResolveAuth; 'wiped'"
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"script.evaluate\",\"params\":{\"expression\":" +
+    Json::string(wipe_expr).stringify() +
+    ",\"target\":{\"context\":\"session-1\"},\"awaitPromise\":false}}",
+  )
+  ignore(proto.take_messages())
+  // Second evaluate: apply_effective_viewport_to_runtime_context runs and
+  // re-pushes the auth snapshot before the expression body executes.
+  let check_expr = "(function(){ var r = (typeof globalThis.__bidiResolveAuth === 'function') ? globalThis.__bidiResolveAuth('https://api.example.com/x') : '<no-fn>'; return r === null || r === undefined ? '<null>' : r; })()"
+  let _ = proto.process_message(
+    "{\"id\":4,\"method\":\"script.evaluate\",\"params\":{\"expression\":" +
+    Json::string(check_expr).stringify() +
+    ",\"target\":{\"context\":\"session-1\"},\"awaitPromise\":false}}",
+  )
+  let msgs = proto.take_messages()
+  let resp = msgs[0].to_json()
+  // The lifecycle hook must have re-pushed the auth snapshot so the bridge
+  // can return the exact header value registered above.
+  assert_true(resp.contains("Bearer lifecycle-test"))
+}
+
+///|
 /// `crater.listOriginAuthorizations` returns the registered origins
 /// without leaking the header values into the BiDi response payload.
 test "crater.listOriginAuthorizations returns origins without values" {

--- a/webdriver/webdriver/bidi_protocol_context_lifecycle.mbt
+++ b/webdriver/webdriver/bidi_protocol_context_lifecycle.mbt
@@ -49,6 +49,12 @@ fn BidiProtocol::apply_effective_viewport_to_runtime_context(
   // fetches. Resolves bug.runtime.fetch-no-partition-cookies.
   let cookies = self.cookies_for_context_full_json(logical_ctx_id)
   set_runtime_context_cookies(runtime_ctx_id, Json::array(cookies).stringify())
+  // Push the partition Authorization snapshot so the runtime fetch
+  // shim's __bidiResolveAuth bridge can attach Authorization headers
+  // to outbound requests for registered origins. Resolves
+  // protocol.bidi-origin-authorization-injection.
+  let auth_json = self.serialize_auth_snapshot_for_runtime(logical_ctx_id)
+  set_runtime_context_authorization(runtime_ctx_id, auth_json)
 }
 
 ///|

--- a/webdriver/webdriver/bidi_protocol_dispatch.mbt
+++ b/webdriver/webdriver/bidi_protocol_dispatch.mbt
@@ -50,6 +50,7 @@ fn BidiProtocol::dispatch(
     "permissions" => self.dispatch_permissions(request, action)
     "storage" => self.dispatch_storage(request, action)
     "webExtension" => self.dispatch_web_extension(request, action)
+    "crater" => self.dispatch_crater(request, action)
     "log" => self.dispatch_log(request, action)
     _ => {
       self.send_error(

--- a/webdriver/webdriver/bidi_runtime_authorization_bridge_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_authorization_bridge_wbtest.mbt
@@ -1,0 +1,72 @@
+///|
+/// Tests for the BiDi runtime authorization bridge installed by
+/// `set_runtime_context_authorization`. The bridge is the mirror of the
+/// outbound cookie bridge (`__bidiResolveCookies`): it pushes the
+/// per-context Authorization header snapshot into
+/// `globalThis.__bidiContextAuth[ctxId]` and lazily installs
+/// `globalThis.__bidiResolveAuth(url)` which the fetch shim calls to
+/// attach an `Authorization` header on outbound requests that target a
+/// registered origin.
+///
+/// These pin the JS-side semantics:
+/// 1. With an empty snapshot the resolver returns null for any URL.
+/// 2. A registered origin returns the exact header value for a request
+///    whose URL parses to that origin.
+/// 3. Default ports (`:443` https / `:80` http) are stripped during
+///    origin extraction so they match a snapshot keyed without a port.
+/// 4. A non-registered origin returns null.
+///
+/// We drive the bridge directly via `evaluate_js` rather than going
+/// through a `script.evaluate` round-trip because the bridge is a pure
+/// JS function; the BiDi handlers that feed it are exercised in
+/// `bidi_authorization_wbtest.mbt`.
+
+///|
+/// Helper: install the auth snapshot for the default context and
+/// evaluate `__bidiResolveAuth(url)`, returning the raw JS-stringified
+/// result. The current context is left at its default
+/// ("default-context"), matching what `reset_runtime_js_state` seeds.
+fn install_and_resolve_auth(
+  snapshot_json : String,
+  request_url : String,
+) -> String {
+  reset_runtime_js_state()
+  set_runtime_context_authorization("default-context", snapshot_json)
+  // The resolver returns null or a string; coerce to a sentinel so the
+  // test inspection is unambiguous regardless of how the JS bridge
+  // surface stringifies a bare `null`.
+  let expr = "(function(){ const r = globalThis.__bidiResolveAuth(" +
+    Json::string(request_url).stringify() +
+    "); return r === null || r === undefined ? \"<null>\" : r; })()"
+  evaluate_js(expr)
+}
+
+///|
+test "__bidiResolveAuth returns null when nothing registered" {
+  let result = install_and_resolve_auth("{}", "https://api.example.com/x")
+  assert_true(result.contains("<null>"))
+}
+
+///|
+test "__bidiResolveAuth returns header for matching origin" {
+  let result = install_and_resolve_auth(
+    "{\"https://api.example.com\":\"Bearer abc123\"}", "https://api.example.com/x",
+  )
+  assert_true(result.contains("Bearer abc123"))
+}
+
+///|
+test "__bidiResolveAuth strips default https port when matching" {
+  let result = install_and_resolve_auth(
+    "{\"https://api.example.com\":\"Bearer abc123\"}", "https://api.example.com:443/x",
+  )
+  assert_true(result.contains("Bearer abc123"))
+}
+
+///|
+test "__bidiResolveAuth returns null for mismatched origin" {
+  let result = install_and_resolve_auth(
+    "{\"https://api.example.com\":\"Bearer abc123\"}", "https://other.com/x",
+  )
+  assert_true(result.contains("<null>"))
+}

--- a/webdriver/webdriver/bidi_runtime_context.mbt
+++ b/webdriver/webdriver/bidi_runtime_context.mbt
@@ -1794,9 +1794,43 @@ pub fn get_runtime_href_at_point(x : Double, y : Double) -> String? {
 }
 
 ///|
-/// Temporary stub; real extern js install lands in Task 4 of the
-/// origin-Authorization plan. Keeps the snapshot push call site
-/// compilable while the BiDi handlers ship in isolation.
-fn set_runtime_context_authorization(_ctx_id : String, _json : String) -> Unit {
-  ()
+/// Push the per-context Authorization snapshot into the JS realm. The
+/// snapshot is consumed by the auto-installed globalThis.__bidiResolveAuth
+/// helper that the fetch shim calls before dispatching each outbound
+/// request. Mirror of set_runtime_context_cookies.
+pub extern "js" fn js_set_runtime_context_authorization(
+  ctx_id : String,
+  auth_json : String,
+) -> Unit =
+  #| (ctxId, authJson) => {
+  #|   if (!globalThis.__bidiContextAuth) globalThis.__bidiContextAuth = {};
+  #|   try {
+  #|     globalThis.__bidiContextAuth[ctxId] = JSON.parse(authJson);
+  #|   } catch (_e) {
+  #|     globalThis.__bidiContextAuth[ctxId] = {};
+  #|   }
+  #|   if (typeof globalThis.__bidiResolveAuth !== 'function') {
+  #|     globalThis.__bidiResolveAuth = function(url) {
+  #|       const ctx = String(globalThis.__bidiCurrentContext || 'default-context');
+  #|       const map = (globalThis.__bidiContextAuth || {})[ctx] || {};
+  #|       try {
+  #|         const u = new URL(url);
+  #|         let origin = u.protocol + '//' + u.hostname;
+  #|         if (
+  #|           (u.protocol === 'http:'  && u.port && u.port !== '80') ||
+  #|           (u.protocol === 'https:' && u.port && u.port !== '443')
+  #|         ) origin += ':' + u.port;
+  #|         return map[origin] || null;
+  #|       } catch (_e) { return null; }
+  #|     };
+  #|   }
+  #| }
+
+///|
+/// Push the per-context Authorization snapshot for `ctx_id` into the JS realm.
+fn set_runtime_context_authorization(
+  ctx_id : String,
+  auth_json : String,
+) -> Unit {
+  js_set_runtime_context_authorization(ctx_id, auth_json)
 }

--- a/webdriver/webdriver/bidi_runtime_context.mbt
+++ b/webdriver/webdriver/bidi_runtime_context.mbt
@@ -1792,3 +1792,11 @@ extern "js" fn js_runtime_href_at_point(x : Double, y : Double) -> String? =
 pub fn get_runtime_href_at_point(x : Double, y : Double) -> String? {
   js_runtime_href_at_point(x, y)
 }
+
+///|
+/// Temporary stub; real extern js install lands in Task 4 of the
+/// origin-Authorization plan. Keeps the snapshot push call site
+/// compilable while the BiDi handlers ship in isolation.
+fn set_runtime_context_authorization(_ctx_id : String, _json : String) -> Unit {
+  ()
+}

--- a/webdriver/webdriver/bidi_runtime_cookie_parity_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_cookie_parity_wbtest.mbt
@@ -34,12 +34,12 @@ priv struct ParityCase {
 /// the fields they care about so cases stay short.
 fn make_stored(
   name~ : String,
-  value~ : String = "v",
+  value? : String = "v",
   domain~ : String,
-  path~ : String = "/",
-  secure~ : Bool = false,
-  same_site~ : String = "lax",
-  expiry~ : Int? = None,
+  path? : String = "/",
+  secure? : Bool = false,
+  same_site? : String = "lax",
+  expiry? : Int? = None,
 ) -> StoredCookie {
   {
     name,
@@ -68,7 +68,6 @@ fn seed_parity_cookie(proto : BidiProtocol, cookie_json : String) -> Unit {
     ",\"partition\":{\"type\":\"context\",\"context\":\"session-1\"}}}"
   let _ = proto.process_message(payload)
   let _ = proto.take_messages()
-
 }
 
 ///|
@@ -221,11 +220,15 @@ test "cookie URL filter parity: 10 representative cases" {
     seed_parity_cookie(proto, case.cookie_json)
     // JS side
     let js_matches = js_bridge_matches(
-      proto, 3, case.stored_cookie.name, case.request_url,
+      proto,
+      3,
+      case.stored_cookie.name,
+      case.request_url,
     )
     // MoonBit side
     let moonbit_matches = storage_cookie_matches_request_url(
-      case.stored_cookie, Some(case.request_url),
+      case.stored_cookie,
+      Some(case.request_url),
     )
     // Both sides must agree with the expected outcome AND with each other.
     if js_matches != case.expected || moonbit_matches != case.expected {

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -3512,6 +3512,19 @@ extern "js" fn js_evaluate_expression(
   #|             }
   #|           } catch (_e) { /* swallow — no cookies attached */ }
   #|         }
+  #|         // Attach partition Authorization header if registered for
+  #|         // this origin and caller has not already supplied one.
+  #|         if (
+  #|           typeof globalThis.__bidiResolveAuth === 'function' &&
+  #|           !headers.has('Authorization')
+  #|         ) {
+  #|           try {
+  #|             const authValue = globalThis.__bidiResolveAuth(resolvedUrl);
+  #|             if (authValue) {
+  #|               headers.set('Authorization', authValue);
+  #|             }
+  #|           } catch (_e) { /* swallow — fail open with no header */ }
+  #|         }
   #|         reqOptions = { ...reqOptions, headers };
   #|         if (!isNavigation && enforceCors && (mode === 'cors' || mode === 'same-origin') && sourceOrigin && targetOrigin && sourceOrigin !== targetOrigin) {
   #|           if (!headers.has('Origin')) headers.set('Origin', sourceOrigin);

--- a/webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt
@@ -504,3 +504,106 @@ async test "reset_runtime_js_state lets next bootstrap rebind __rawFetch to the 
   )
   assert_true(rebound.contains("rebound"))
 }
+
+///|
+/// Seed an Authorization header for the given origin scoped to session-1.
+fn seed_origin_authorization(
+  proto : BidiProtocol,
+  request_id : Int,
+  origin : String,
+  header_value : String,
+) -> Unit {
+  let payload = "{\"id\":" +
+    request_id.to_string() +
+    ",\"method\":\"crater.setOriginAuthorization\",\"params\":{\"origin\":" +
+    Json::string(origin).stringify() +
+    ",\"headerValue\":" +
+    Json::string(header_value).stringify() +
+    ",\"context\":\"session-1\"}}"
+  let _ = proto.process_message(payload)
+  let _ = proto.take_messages()
+}
+
+///|
+/// Same-origin fetch must attach the registered Authorization header for
+/// the resolved origin when the caller did not provide one. Pins the
+/// origin-Authorization injection bridge wiring inside the fetch shim.
+test "fetch shim attaches Authorization for matching origin" {
+  let proto = make_proto_with_session()
+  seed_origin_authorization(proto, 2, "http://localhost", "Bearer abc123")
+  let setup =
+    #|globalThis.__pageUrl = 'http://localhost/';
+    #|globalThis.__lastAuthCaptured = '<unset>';
+    #|globalThis.__rawFetch = (url, options) => {
+    #|  const h = new Headers((options && options.headers) || {});
+    #|  const v = h.get('Authorization');
+    #|  globalThis.__lastAuthCaptured = v === null || v === undefined ? '<null>' : String(v);
+    #|  return Promise.resolve({ status: 200, headers: { get: () => '*' }, text: () => Promise.resolve('') });
+    #|};
+    #|globalThis.fetch('/api/me');
+    #|null
+  run_sync_in_context(proto, 3, setup)
+  let resp = read_global_string(proto, 4, "__lastAuthCaptured")
+  assert_true(resp.contains("Bearer abc123"))
+}
+
+///|
+/// A caller-supplied Authorization header must win over the bridge — the
+/// shim must never silently overwrite an explicit per-request token.
+test "fetch shim respects caller-provided Authorization over bridge" {
+  let proto = make_proto_with_session()
+  seed_origin_authorization(proto, 2, "http://localhost", "Bearer driver-token")
+  let setup =
+    #|globalThis.__pageUrl = 'http://localhost/';
+    #|globalThis.__lastAuthCaptured = '<unset>';
+    #|globalThis.__rawFetch = (url, options) => {
+    #|  const h = new Headers((options && options.headers) || {});
+    #|  const v = h.get('Authorization');
+    #|  globalThis.__lastAuthCaptured = v === null || v === undefined ? '<null>' : String(v);
+    #|  return Promise.resolve({ status: 200, headers: { get: () => '*' }, text: () => Promise.resolve('') });
+    #|};
+    #|globalThis.fetch('/api/me', { headers: { Authorization: 'Bearer page-token' } });
+    #|null
+  run_sync_in_context(proto, 3, setup)
+  let resp = read_global_string(proto, 4, "__lastAuthCaptured")
+  assert_true(resp.contains("Bearer page-token"))
+  assert_false(resp.contains("driver-token"))
+}
+
+///|
+/// An Authorization registered for one origin must not leak to a fetch
+/// targeting a different origin. The shim resolves per-request via
+/// __bidiResolveAuth which already filters by origin; this pins the
+/// end-to-end wiring through the shim's attach block.
+async test "fetch shim skips Authorization for non-matching origin" {
+  let proto = make_proto_with_session()
+  seed_origin_authorization(
+    proto, 2, "https://api.example.com", "Bearer abc123",
+  )
+  let setup =
+    #|globalThis.__pageUrl = 'http://localhost/';
+    #|globalThis.__setRequestSandbox({ mode: 'open' });
+    #|globalThis.__lastAuthCaptured = '<unset>';
+    #|globalThis.__rawFetch = (url, options) => {
+    #|  const h = new Headers((options && options.headers) || {});
+    #|  const v = h.get('Authorization');
+    #|  globalThis.__lastAuthCaptured = v === null || v === undefined ? '<null>' : String(v);
+    #|  return Promise.resolve({
+    #|    status: 200,
+    #|    headers: {
+    #|      get: (name) => String(name).toLowerCase() === 'access-control-allow-origin' ? '*' : null,
+    #|    },
+    #|    text: () => Promise.resolve(''),
+    #|  });
+    #|};
+    #|globalThis.fetch('https://other.test/v1').catch(() => {});
+    #|null
+  run_sync_in_context(proto, 3, setup)
+  @async.sleep(10)
+  let resp = read_global_string(proto, 4, "__lastAuthCaptured")
+  run_sync_in_context(
+    proto, 5, "globalThis.__setRequestSandbox({ mode: 'same-origin' });",
+  )
+  assert_true(resp.contains("<null>"))
+  assert_false(resp.contains("Bearer"))
+}

--- a/webdriver/webdriver/pkg.generated.mbti
+++ b/webdriver/webdriver/pkg.generated.mbti
@@ -95,6 +95,8 @@ pub fn input_now_ms() -> Double
 
 pub fn input_set_pointer_event_properties(Double, Double, Double, Double, Double, Double, Double) -> Unit
 
+pub fn js_set_runtime_context_authorization(String, String) -> Unit
+
 pub fn navigate_and_send_async(@core.Any, Int, String, String, String) -> Unit
 
 pub fn parse_data_url(String) -> (String, String)?


### PR DESCRIPTION
## Summary

Phase 1 of the auth-extension follow-up to the [auth + CORS spec](https://github.com/mizchi/crater/blob/main/docs/superpowers/specs/2026-05-17-browser-auth-cors-design.md). Three new BiDi extension commands let WebDriver clients register `Authorization` header values scoped to a single `scheme://host[:port]` origin; the BiDi runtime fetch shim attaches the value to outgoing requests for matching origins. **Caller wins** — if the page-script has already set `Authorization`, the bridge does not overwrite (same policy as PR #136/#140 cookies).

Phase 2 (HTTP Basic 401 challenge, `network.continueWithAuth`) is a separate spec, not in this PR.

## BiDi commands added

| Command | Effect |
|---|---|
| `crater.setOriginAuthorization({origin, headerValue, context?})` | Register a header value for an origin on the per-session Profile. |
| `crater.clearOriginAuthorization({origin, context?})` | Remove the registration. |
| `crater.listOriginAuthorizations({context?})` | Return the set of registered origins. **Header values are never exposed in the response.** |

## Files

| File | Change |
|---|---|
| `http/profile/auth.mbt` | `AuthState` extended with `origin_headers : Map[String, String]`, accessor methods, redacting `Show` impl. `derive(Debug)` dropped to close the secret-exposure path. |
| `http/profile/auth_wbtest.mbt` | 7 unit tests including the redaction lock. |
| `webdriver/webdriver/bidi_authorization.mbt` | 3 BiDi handlers + `normalize_origin` + `validate_header_value` + `serialize_auth_snapshot_for_runtime`. |
| `webdriver/webdriver/bidi_authorization_wbtest.mbt` | 9 handler + validation + lifecycle integration tests. |
| `webdriver/webdriver/bidi_runtime_context.mbt` | `set_runtime_context_authorization` extern js bridge + auto-installed `globalThis.__bidiResolveAuth` resolver. |
| `webdriver/webdriver/bidi_runtime_authorization_bridge_wbtest.mbt` | 4 resolver tests (null / match / port-strip / mismatch). |
| `webdriver/webdriver/bidi_protocol_context_lifecycle.mbt` | Lifecycle hook pushes the auth snapshot alongside the cookie snapshot. |
| `webdriver/webdriver/bidi_runtime_eval.mbt` | Fetch shim attaches `Authorization` when caller hasn't set it. |
| `webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt` | 3 integration tests (attach / caller-wins / origin-mismatch). |
| `webdriver/webdriver/bidi_protocol_dispatch.mbt` | New `crater` BiDi domain routes 3 commands via `dispatch_crater`. |
| `specs/crater.pkl` | Scenario `protocol.bidi-origin-authorization-injection` (approved). |
| `specs/tasks.Test.pkl` | pkspec smoke `bidi_origin_authorization_injection_wired`. |

## Security posture

- **Input validation** at the BiDi command boundary rejects: non-http/https schemes, path/query/fragment in origin, empty / oversized (>8 KB) / CRLF / control / ANSI-escape header values.
- **Origin normalization**: scheme + host lowercased, default port stripped (`:80` / `:443`).
- **Redaction**: `AuthState`'s `Show` impl prints `<redacted>` for every entry; `listOriginAuthorizations` returns origins only.
- **`derive(Debug)` dropped** so `debug_inspect` can't bypass the Show redaction.
- **Caller-wins**: page-script-provided `Authorization` overrides the bridge for that request.

## Test counts

| Suite | Before | After |
|---|---|---|
| `webdriver/webdriver` | 336 | 351 |
| `pkf run spec-test` | 43 | 44 |

## What this unblocks

Phase 5 e2e (PR #132 → #140) was scoped to cookies. With this PR a similar pattern works for Bearer/JWT auth: WebDriver registers the token once per origin, page-script `fetch(url)` calls go out with `Authorization` attached automatically. The fixture's `auth-server.ts` could add a `GET /api/protected` endpoint requiring `Authorization: Bearer ...` to exercise the full flow end-to-end. Deferred as the spec's optional Section 5.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)