### PR TITLE
Phase 2 PR A: network.continueWithAuth + addIntercept spec-conformant dispatch

### DIFF
--- a/scripts/crater_bidi_modules.py
+++ b/scripts/crater_bidi_modules.py
@@ -358,7 +358,14 @@ class NetworkModule(_CommandProxy):
             if value is None:
                 continue
             params[key] = value
-        return await self._command("network.addInterceptId", params)
+        # Phase 2 PR A: send the spec-conformant method name. The server now
+        # routes `network.addIntercept` to the spec response shape
+        # `{ intercept: "<id>" }`. WPT callers expect a raw id string, so
+        # we extract it here to preserve the existing fixture contract.
+        result = await self._command("network.addIntercept", params)
+        if isinstance(result, Mapping) and "intercept" in result:
+            return result["intercept"]
+        return result
 
     async def remove_intercept(self, intercept: str):
         return await self._command("network.removeIntercept", {"intercept": intercept})
@@ -402,7 +409,10 @@ class NetworkModule(_CommandProxy):
         params = {"request": request, "action": action}
         if credentials is not None:
             params["credentials"] = credentials
-        await self._command("network.continueAuthRequest", params)
+        # Phase 2 PR A: send the spec-conformant method name directly.
+        # The server now routes `network.continueWithAuth` to the same
+        # handler as the internal alias `network.continueAuthRequest`.
+        await self._command("network.continueWithAuth", params)
         return {}
 
     async def provide_response(self, request: str, **kwargs):

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -954,6 +954,17 @@ scenarios {
     reviewStatus = "approved"
     contributes { "goal.protocol-compat"; "goal.dom-compat" }
   }
+  // -- Protocol: BiDi network.continueWithAuth + addIntercept spec names ----
+  new {
+    id = "protocol.bidi-network-continue-with-auth"
+    name = "BiDi network.continueWithAuth and addIntercept use spec-conformant method names"
+    description =
+      "WebDriver BiDi clients can drive Crater's authRequired interception flow using the spec-conformant method names `network.continueWithAuth` and `network.addIntercept` directly over the wire. Before PR #147 (Phase 2 PR A) only the internal aliases `network.continueAuthRequest` and `network.addInterceptId` were routed; the scripts/crater_bidi_modules.py shim hid the gap from the WPT suite by rewriting the spec names before sending. After this change, bidi_protocol_dispatch_network.mbt routes `network.continueWithAuth` to handle_network_continue_auth_request and keeps `network.addIntercept` returning the spec response shape `{ intercept: \"<id>\" }`; the internal aliases stay as backwards-compat. The shim now sends the spec names directly. See GitHub issue #147 / Source: docs/superpowers/specs/2026-05-18-phase2-auth-baseline.md."
+    tags { "bidi"; "auth"; "network"; "protocol" }
+    severity = "major"
+    reviewStatus = "approved"
+    contributes { "goal.protocol-compat" }
+  }
   new {
     id = "bug.runtime.cookie-url-filter-parity"
     name = "JS-side cookie URL filter mirrors MoonBit without static guard"

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -526,6 +526,16 @@ tests {
       "bash -lc 'set -e; test -f http/profile/auth.mbt; grep -Fq -- \"fn AuthState::set_origin_header\" http/profile/auth.mbt; grep -Fq -- \"<redacted>\" http/profile/auth.mbt; test -f webdriver/webdriver/bidi_authorization.mbt; grep -Fq -- \"handle_crater_set_origin_authorization\" webdriver/webdriver/bidi_authorization.mbt; grep -Fq -- \"normalize_origin\" webdriver/webdriver/bidi_authorization.mbt; grep -rFq -- \"crater.setOriginAuthorization\" webdriver/webdriver/; grep -Fq -- \"globalThis.__bidiResolveAuth\" webdriver/webdriver/bidi_runtime_context.mbt; grep -Fq -- \"globalThis.__bidiResolveAuth\" webdriver/webdriver/bidi_runtime_eval.mbt; test -f webdriver/webdriver/bidi_authorization_wbtest.mbt; grep -Fq -- \"crater.setOriginAuthorization stores per-origin header\" webdriver/webdriver/bidi_authorization_wbtest.mbt; grep -Fq -- \"crater.setOriginAuthorization rejects CRLF in headerValue\" webdriver/webdriver/bidi_authorization_wbtest.mbt; test -f webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt; grep -Fq -- \"fetch shim attaches Authorization for matching origin\" webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt; grep -Fq -- \"fetch shim respects caller-provided Authorization over bridge\" webdriver/webdriver/bidi_runtime_fetch_wbtest.mbt'"
   }
   new {
+    name = "bidi_network_continue_with_auth_spec_aliases_routed"
+    description =
+      "bidi_protocol_dispatch_network.mbt routes the spec-conformant names `network.continueWithAuth` (Phase 2 PR A) and `network.addIntercept` to the existing handlers, alongside the internal aliases `network.continueAuthRequest` and `network.addInterceptId`. scripts/crater_bidi_modules.py sends the spec names directly. New wbtests in webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt probe the spec names without going through the shim."
+    tags { "bidi"; "auth"; "network"; "protocol" }
+    specRef { "protocol.bidi-network-continue-with-auth" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f webdriver/webdriver/bidi_protocol_dispatch_network.mbt; grep -Fq -- \"\\\"continueWithAuth\\\" =>\" webdriver/webdriver/bidi_protocol_dispatch_network.mbt; grep -Fq -- \"\\\"addIntercept\\\" =>\" webdriver/webdriver/bidi_protocol_dispatch_network.mbt; test -f webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt; grep -Fq -- \"network.continueWithAuth\" webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt; grep -Fq -- \"network.addIntercept\" webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt; test -f scripts/crater_bidi_modules.py; grep -Fq -- \"network.continueWithAuth\" scripts/crater_bidi_modules.py; grep -Fq -- \"network.addIntercept\\\",\" scripts/crater_bidi_modules.py'"
+  }
+  new {
     name = "bidi_runtime_cookie_url_filter_parity_guarded"
     description =
       "webdriver/webdriver/bidi_runtime_cookie_parity_wbtest.mbt runs 10 representative cookie + request URL inputs through BOTH __bidiResolveCookies (JS, bidi_runtime_context.mbt) and storage_cookie_matches_request_url (MoonBit, bidi_storage.mbt) and asserts they agree. Coverage: domain + path agreement (exact host, cross-site, subdomain matching dot-prefixed domain, path prefix, path mismatch, trailing-slash path, name-prefix boundary, sibling subdomain). Scheme-vs-Secure filtering is intentionally out of scope per the catch-drift-don't-unify plan."

--- a/webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt
+++ b/webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt
@@ -1,0 +1,66 @@
+///|
+/// Phase 2 PR A: ensure spec-conformant WebDriver BiDi method names are
+/// routed by Crater's dispatcher. These tests probe the spec names
+/// directly (without going through the `crater_bidi_modules.py` shim).
+///
+/// Tracking issue: #147
+
+///|
+test "bidi network.addIntercept (spec name) returns intercept object" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"network.addIntercept\",\"params\":{\"phases\":[\"authRequired\"]}}",
+  )
+  let msgs = proto.take_messages()
+  assert_eq(msgs.length(), 1)
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"type\":\"success\""))
+  // Spec response shape: { "intercept": "<id>" }
+  assert_true(json.contains("\"intercept\":\""))
+  // No "unknown command" error
+  assert_false(json.contains("unknown command"))
+}
+
+///|
+test "bidi network.continueWithAuth (spec name) cancel resolves blocked request" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"network.rememberBlockedRequest\",\"params\":{\"request\":\"request-spec-alias-1\",\"blockedRequest\":{\"phase\":\"authRequired\",\"context_id\":\"session-1\",\"url\":\"http://localhost:8000/webdriver/tests/support/authentication.py?realm=secure&username=user&password=pass\",\"method\":\"GET\",\"request_headers\":{\"x-test\":\"ok\"},\"response_headers\":[{\"name\":\"www-authenticate\",\"value\":{\"type\":\"string\",\"value\":\"Basic realm=\\\"secure\\\"\"}}],\"response_status\":401,\"response_status_text\":\"Unauthorized\"}}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"network.continueWithAuth\",\"params\":{\"request\":\"request-spec-alias-1\",\"action\":\"cancel\"}}",
+  )
+  let continue_json = proto.take_messages()[0].to_json()
+  assert_true(continue_json.contains("\"type\":\"success\""))
+  assert_false(continue_json.contains("unknown command"))
+  assert_true(continue_json.contains("\"consumed\":true"))
+}
+
+///|
+test "bidi network.continueWithAuth (spec name) provideCredentials resolves blocked request" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"network.rememberBlockedRequest\",\"params\":{\"request\":\"request-spec-alias-2\",\"blockedRequest\":{\"phase\":\"authRequired\",\"context_id\":\"session-1\",\"url\":\"http://localhost:8000/webdriver/tests/support/authentication.py?realm=secure&username=u&password=p\",\"method\":\"GET\",\"request_headers\":{\"x-test\":\"ok\"},\"response_headers\":[{\"name\":\"www-authenticate\",\"value\":{\"type\":\"string\",\"value\":\"Basic realm=\\\"secure\\\"\"}}],\"response_status\":401,\"response_status_text\":\"Unauthorized\"}}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"network.continueWithAuth\",\"params\":{\"request\":\"request-spec-alias-2\",\"action\":\"provideCredentials\",\"credentials\":{\"type\":\"password\",\"username\":\"u\",\"password\":\"p\"}}}",
+  )
+  let continue_json = proto.take_messages()[0].to_json()
+  assert_true(continue_json.contains("\"type\":\"success\""))
+  assert_false(continue_json.contains("unknown command"))
+  assert_true(continue_json.contains("\"consumed\":true"))
+}

--- a/webdriver/webdriver/bidi_protocol_dispatch_network.mbt
+++ b/webdriver/webdriver/bidi_protocol_dispatch_network.mbt
@@ -6,10 +6,15 @@ fn BidiProtocol::dispatch_network(
   action : String,
 ) -> Result[Unit, String] {
   match action {
+    // Spec-conformant name from WebDriver BiDi specification.
+    // Returns `{ intercept: "<id>" }` as required by the spec.
     "addIntercept" => {
       self.handle_network_add_intercept(request.id, request.params)
       Ok(())
     }
+    // Internal alias returning the raw id string (no wrapping object).
+    // Kept for backwards-compat with existing wbtests; may be retired once
+    // all callers migrate to the spec name `addIntercept`.
     "addInterceptId" => {
       self.handle_network_add_intercept_id(request.id, request.params)
       Ok(())
@@ -109,6 +114,16 @@ fn BidiProtocol::dispatch_network(
       self.handle_network_fail_blocked_request(request.id, request.params)
       Ok(())
     }
+    // Spec-conformant name from WebDriver BiDi specification.
+    // Routes to the same handler as the internal alias `continueAuthRequest`.
+    "continueWithAuth" => {
+      self.handle_network_continue_auth_request(request.id, request.params)
+      Ok(())
+    }
+    // Internal alias kept for backwards-compat with the WPT shim
+    // (`scripts/crater_bidi_modules.py::NetworkModule.continue_with_auth`)
+    // and existing wbtests. Retire once the shim drops its rename and
+    // dependent wbtests migrate to the spec name.
     "continueAuthRequest" => {
       self.handle_network_continue_auth_request(request.id, request.params)
       Ok(())


### PR DESCRIPTION
## Summary

Closes the spec-conformance gap discovered in PR #165's baseline inventory. Native WebDriver BiDi clients (Playwright, Selenium, raw WS) can now drive Crater's auth flow directly — previously only the WPT harness shim (\`scripts/crater_bidi_modules.py\`) could, because it rewrote spec method names to Crater's internal action names.

Part of #147 (Phase 2 of auth extension).

## Changes

| Spec name | Internal alias (kept) | Handler |
|---|---|---|
| \`network.continueWithAuth\` | \`network.continueAuthRequest\` | \`handle_network_continue_auth_request\` |
| \`network.addIntercept\` (returns \`{intercept: id}\`) | \`network.addInterceptId\` (returns raw id) | \`handle_network_add_intercept\` / \`_id\` |

The implementation (synthetic fetch pause on 401, \`network.authRequired\` event emission, resume with \`Authorization: Basic ...\`) was already there in \`bidi_network_intercept_commands.mbt\`. This PR only adds the spec-conformant dispatch route. Internal aliases are preserved as backwards-compat for one release.

## Files

- \`webdriver/webdriver/bidi_protocol_dispatch_network.mbt\` — added \`"continueWithAuth"\` route + back-compat comments
- \`webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt\` — new, 3 wbtests probing spec names directly
- \`scripts/crater_bidi_modules.py\` — shim now sends spec names instead of internal aliases (\`continueWithAuth\` direct; \`addIntercept\` unwraps \`result["intercept"]\` for fixture contract)
- \`specs/crater.pkl\` — \`protocol.bidi-network-continue-with-auth\` approved
- \`specs/tasks.Test.pkl\` — \`bidi_network_continue_with_auth_spec_aliases_routed\` pkspec smoke

## Test counts

| Suite | Before | After |
|---|---|---|
| \`webdriver/webdriver\` | 351 | 354 |
| \`pkf run spec-test\` | 44 | 45 |
| WPT \`auth\` profile | 56 (via rename shim) | 56 (via spec names) |

Direct WebSocket probe (the smoke test pattern):
- Before: \`network.continueWithAuth\` → \`{"error": "unknown command"}\`
- After: \`network.continueWithAuth\` → \`{"result": ...}\` (consumed)

## Follow-up

PR B (next): \`network.continueResponse\` / \`provideResponse\` / \`failRequest\` aliases for the remaining 4 tests under \`network/continue_response/credentials.py\`.

## Test plan

- [x] \`moon test -p mizchi/crater-webdriver-bidi/webdriver\` — 354/354
- [x] \`pkf run spec-test\` — 45/45
- [x] \`npx tsx scripts/wpt-webdriver-runner.ts --profile auth\` — 56/56
- [x] Direct WS probe confirms native dispatch works
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)