### PR TITLE
Phase 2 PR B: continueResponse / provideResponse / failRequest spec dispatch

### DIFF
--- a/scripts/crater_bidi_modules.py
+++ b/scripts/crater_bidi_modules.py
@@ -388,20 +388,26 @@ class NetworkModule(_CommandProxy):
 
     async def continue_response(self, request: str, **kwargs):
         request_id = self._validate_request_id(request)
-        params: dict[str, Any] = {
-            "request": request_id,
-            "mode": "continueResponse",
-        }
+        # Phase 2 PR B: send the spec-conformant method name. The server now
+        # routes `network.continueResponse` to the shared
+        # `handle_network_continue_blocked_response` handler with
+        # `mode: "continueResponse"` injected.
+        params: dict[str, Any] = {"request": request_id}
         for key, value in kwargs.items():
             params[key] = value
-        await self._command("network.continueBlockedResponse", params)
+        await self._command("network.continueResponse", params)
         return {}
 
     async def fail_request(self, request: str):
         request_id = self._validate_request_id(request)
+        # Phase 2 PR B: send the spec-conformant method name. The server now
+        # routes `network.failRequest` to the same handler as the internal
+        # alias `network.failBlockedRequest`. The handler defaults
+        # `errorText` to `"Request failed"` when omitted, so the spec call
+        # site can leave it out (matching the spec).
         await self._session.command(
-            "network.failBlockedRequest",
-            {"request": request_id, "errorText": "Request failed"},
+            "network.failRequest",
+            {"request": request_id},
         )
         return {}
 
@@ -417,14 +423,15 @@ class NetworkModule(_CommandProxy):
 
     async def provide_response(self, request: str, **kwargs):
         request_id = self._validate_request_id(request)
-        params: dict[str, Any] = {
-            "request": request_id,
-            "mode": "provideResponse",
-        }
+        # Phase 2 PR B: send the spec-conformant method name. The server now
+        # routes `network.provideResponse` to the shared
+        # `handle_network_continue_blocked_response` handler with
+        # `mode: "provideResponse"` injected.
+        params: dict[str, Any] = {"request": request_id}
         for key, value in kwargs.items():
             params[key] = value
 
-        await self._command("network.continueBlockedResponse", params)
+        await self._command("network.provideResponse", params)
         return {}
 
     async def add_data_collector(self, **kwargs):

--- a/webdriver/webdriver/bidi_network_intercept_commands.mbt
+++ b/webdriver/webdriver/bidi_network_intercept_commands.mbt
@@ -113,6 +113,64 @@ fn BidiProtocol::prepare_navigation_request_internal(
 }
 
 ///|
+/// Phase 2 PR B: spec-conformant `network.continueResponse`.
+/// Injects `mode: "continueResponse"` into the caller params and delegates
+/// to the shared `handle_network_continue_blocked_response` handler so the
+/// spec name and the internal alias share a single implementation.
+fn BidiProtocol::handle_network_continue_response(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let forwarded = match params {
+    Some(Object(map)) => {
+      let copy : Map[String, Json] = {}
+      for key, value in map {
+        copy[key] = value
+      }
+      copy["mode"] = Json::string("continueResponse")
+      Some(Json::object(copy))
+    }
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "params must be an object",
+      )
+      return
+    }
+  }
+  self.handle_network_continue_blocked_response(request_id, forwarded)
+}
+
+///|
+/// Phase 2 PR B: spec-conformant `network.provideResponse`.
+/// Injects `mode: "provideResponse"` into the caller params and delegates
+/// to the shared `handle_network_continue_blocked_response` handler so the
+/// spec name and the internal alias share a single implementation.
+fn BidiProtocol::handle_network_provide_response(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let forwarded = match params {
+    Some(Object(map)) => {
+      let copy : Map[String, Json] = {}
+      for key, value in map {
+        copy[key] = value
+      }
+      copy["mode"] = Json::string("provideResponse")
+      Some(Json::object(copy))
+    }
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "params must be an object",
+      )
+      return
+    }
+  }
+  self.handle_network_continue_blocked_response(request_id, forwarded)
+}
+
+///|
 fn BidiProtocol::handle_network_fail_blocked_request(
   self : BidiProtocol,
   request_id : Int,

--- a/webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt
+++ b/webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt
@@ -64,3 +64,76 @@ test "bidi network.continueWithAuth (spec name) provideCredentials resolves bloc
   assert_false(continue_json.contains("unknown command"))
   assert_true(continue_json.contains("\"consumed\":true"))
 }
+
+///|
+/// Phase 2 PR B: probe the three remaining spec-conformant names so that
+/// native BiDi clients can drive `continueResponse`, `provideResponse`,
+/// and `failRequest` without going through the WPT shim's rename layer.
+
+///|
+test "bidi network.continueResponse (spec name) resolves blocked response" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"network.rememberBlockedRequest\",\"params\":{\"request\":\"request-spec-alias-3\",\"blockedRequest\":{\"phase\":\"responseStarted\",\"context_id\":\"session-1\",\"url\":\"http://localhost:8000/webdriver/tests/support/echo.py\",\"method\":\"GET\",\"request_headers\":{\"x-test\":\"ok\"},\"response_headers\":[{\"name\":\"content-type\",\"value\":{\"type\":\"string\",\"value\":\"text/plain\"}}],\"response_status\":200,\"response_status_text\":\"OK\"}}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"network.continueResponse\",\"params\":{\"request\":\"request-spec-alias-3\"}}",
+  )
+  let json = proto.take_messages()[0].to_json()
+  assert_true(json.contains("\"type\":\"success\""))
+  assert_false(json.contains("unknown command"))
+  // The shared continueBlockedResponse handler emits a synthetic
+  // responseCompleted event and marks the request as consumed.
+  assert_true(json.contains("\"responseCompletedEvent\""))
+  assert_true(json.contains("\"consumed\":true"))
+}
+
+///|
+test "bidi network.provideResponse (spec name) resolves blocked request" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"network.rememberBlockedRequest\",\"params\":{\"request\":\"request-spec-alias-4\",\"blockedRequest\":{\"phase\":\"beforeRequestSent\",\"context_id\":\"session-1\",\"url\":\"http://localhost:8000/webdriver/tests/support/echo.py\",\"method\":\"GET\",\"request_headers\":{\"x-test\":\"ok\"}}}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"network.provideResponse\",\"params\":{\"request\":\"request-spec-alias-4\",\"statusCode\":204,\"reasonPhrase\":\"No Content\"}}",
+  )
+  let json = proto.take_messages()[0].to_json()
+  assert_true(json.contains("\"type\":\"success\""))
+  assert_false(json.contains("unknown command"))
+  // provideResponse should emit a synthesised response event with the
+  // overridden status / reason and mark the request as consumed.
+  assert_true(json.contains("\"responseCompletedEvent\""))
+  assert_true(json.contains("\"consumed\":true"))
+  assert_true(json.contains("\"statusCode\":204"))
+}
+
+///|
+test "bidi network.failRequest (spec name) fails blocked request" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"network.rememberBlockedRequest\",\"params\":{\"request\":\"request-spec-alias-5\",\"blockedRequest\":{\"phase\":\"beforeRequestSent\",\"context_id\":\"session-1\",\"url\":\"http://localhost:8000/webdriver/tests/support/echo.py\",\"method\":\"GET\",\"request_headers\":{\"x-test\":\"ok\"}}}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"network.failRequest\",\"params\":{\"request\":\"request-spec-alias-5\"}}",
+  )
+  let json = proto.take_messages()[0].to_json()
+  assert_true(json.contains("\"type\":\"success\""))
+  assert_false(json.contains("unknown command"))
+  // failRequest emits a synthetic fetchError event.
+  assert_true(json.contains("\"event\""))
+}

--- a/webdriver/webdriver/bidi_protocol_dispatch_network.mbt
+++ b/webdriver/webdriver/bidi_protocol_dispatch_network.mbt
@@ -110,6 +110,19 @@ fn BidiProtocol::dispatch_network(
       self.handle_network_build_headers_echo_payload(request.id, request.params)
       Ok(())
     }
+    // Spec-conformant name from WebDriver BiDi specification.
+    // Routes to the same handler as the internal alias `failBlockedRequest`.
+    // The handler defaults `errorText` to `"Request failed"` when omitted,
+    // matching the spec's behaviour for native callers that supply only
+    // `{ request }`.
+    "failRequest" => {
+      self.handle_network_fail_blocked_request(request.id, request.params)
+      Ok(())
+    }
+    // Internal alias kept for backwards-compat with the WPT shim
+    // (`scripts/crater_bidi_modules.py::NetworkModule.fail_request`) and
+    // existing wbtests. Retire once the shim drops its rename and
+    // dependent wbtests migrate to the spec name.
     "failBlockedRequest" => {
       self.handle_network_fail_blocked_request(request.id, request.params)
       Ok(())
@@ -132,6 +145,25 @@ fn BidiProtocol::dispatch_network(
       self.handle_network_continue_blocked_request(request.id, request.params)
       Ok(())
     }
+    // Spec-conformant name from WebDriver BiDi specification.
+    // Injects `mode: "continueResponse"` and delegates to the shared
+    // `handle_network_continue_blocked_response` handler.
+    "continueResponse" => {
+      self.handle_network_continue_response(request.id, request.params)
+      Ok(())
+    }
+    // Spec-conformant name from WebDriver BiDi specification.
+    // Injects `mode: "provideResponse"` and delegates to the shared
+    // `handle_network_continue_blocked_response` handler.
+    "provideResponse" => {
+      self.handle_network_provide_response(request.id, request.params)
+      Ok(())
+    }
+    // Internal alias kept for backwards-compat with the WPT shim
+    // (`scripts/crater_bidi_modules.py::NetworkModule.continue_response` /
+    // `provide_response`) and existing wbtests. The shim folds both spec
+    // commands into this single mode-tagged route; retire once the shim
+    // drops its rename and dependent wbtests migrate to the spec names.
     "continueBlockedResponse" => {
       self.handle_network_continue_blocked_response(request.id, request.params)
       Ok(())


### PR DESCRIPTION
## Summary

Completes the Phase 2 dispatch rename started in #166. After this PR, all 5 spec-conformant \`network.*\` commands route natively (no shim rename required): \`addIntercept\`, \`continueWithAuth\`, \`continueResponse\`, \`provideResponse\`, \`failRequest\`.

Native Playwright / Selenium / raw WS clients can now drive Crater's full network-interception surface, including the \`authRequired\` / \`responseStarted\` / \`beforeRequestSent\` phases.

Part of #147 (Phase 2 PR B). Closes the dispatch-rename gap end-to-end.

## Spec → internal alias mapping

| Spec name (new route) | Internal alias (kept) | Handler |
|---|---|---|
| \`network.continueResponse\` | \`network.continueBlockedResponse\` | new wrapper → existing handler with \`mode\` injected |
| \`network.provideResponse\` | \`network.continueBlockedResponse\` | new wrapper → same |
| \`network.failRequest\` | \`network.failBlockedRequest\` | shared handler |

Internal aliases preserved as backwards-compat for one release.

## Files

- \`webdriver/webdriver/bidi_protocol_dispatch_network.mbt\` — 3 new dispatch entries.
- \`webdriver/webdriver/bidi_network_intercept_commands.mbt\` — 2 wrapper handlers (\`handle_network_continue_response\`, \`handle_network_provide_response\`).
- \`webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt\` — 3 new wbtests probing spec names.
- \`scripts/crater_bidi_modules.py\` — harness shim no longer renames these 3 names.

## Test counts

| Suite | Before | After |
|---|---|---|
| \`webdriver/webdriver\` | 354 | 357 |
| WPT auth profile | 56/56 (via PR A spec names + shim renames) | 56/56 (fully native) |

## Test plan

- [x] \`moon test -p mizchi/crater-webdriver-bidi/webdriver\` — 357/357
- [x] \`npx tsx scripts/wpt-webdriver-runner.ts --profile auth\` — 56/56 (after \`moon -C webdriver build bidi_main --target js --release\`)
- [ ] CI green on this PR

## Follow-up

- \`continueRequest\` (the non-auth interception command) still uses the internal name in the shim. If full spec parity is wanted, a follow-up PR could rename it too. Out of scope for #147 (Phase 2 was scoped to auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)