### PR TITLE
Bearer flow e2e using crater.setOriginAuthorization

### DIFF
--- a/scripts/fixtures/auth-server.test.ts
+++ b/scripts/fixtures/auth-server.test.ts
@@ -43,6 +43,54 @@ test("recordSession seeds a session id that /dashboard accepts", async () => {
   }
 });
 
+test("GET /api/protected returns 200 + JSON with correct Bearer token", async () => {
+  const { url, stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    const ok = await fetch(`${apiUrl}/api/protected`, {
+      headers: {
+        // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+        authorization: "Bearer test-jwt-token",
+        origin: url,
+      },
+    });
+    expect(ok.status).toBe(200);
+    expect(ok.headers.get("content-type")).toContain("application/json");
+    expect(ok.headers.get("access-control-allow-origin")).toBe(url);
+    const body = (await ok.json()) as { user: string; protected: boolean };
+    expect(body).toEqual({ user: "alice", protected: true });
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("GET /api/protected returns 401 without Authorization header", async () => {
+  const { stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    const res = await fetch(`${apiUrl}/api/protected`);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("missing or invalid token");
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("GET /api/protected returns 401 with wrong Bearer token", async () => {
+  const { stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    const res = await fetch(`${apiUrl}/api/protected`, {
+      // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+      headers: { authorization: "Bearer wrong-token" },
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("missing or invalid token");
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
 test("cross-origin /api/me requires ACA-Origin and ACA-Credentials", async () => {
   const { url, stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
   try {

--- a/scripts/fixtures/auth-server.ts
+++ b/scripts/fixtures/auth-server.ts
@@ -102,6 +102,22 @@ function handleApp(
   })();
 }
 
+// secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+const PROTECTED_BEARER_TOKEN = "Bearer test-jwt-token"; // test fixture only
+
+function corsHeadersForOrigin(
+  origin: string,
+  appOrigin: string,
+): Record<string, string> {
+  if (origin === appOrigin) {
+    return {
+      "access-control-allow-origin": appOrigin,
+      "access-control-allow-credentials": "true",
+    };
+  }
+  return {};
+}
+
 function handleApi(
   req: IncomingMessage,
   res: ServerResponse,
@@ -137,6 +153,35 @@ function handleApi(
       // (M5 in PR #131 security review.)
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ user: "alice" }));
+    }
+    return;
+  }
+  if (url.pathname === "/api/protected") {
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, {
+        "access-control-allow-origin": appOrigin,
+        "access-control-allow-methods": "GET",
+        "access-control-allow-headers": "authorization, content-type",
+        "access-control-allow-credentials": "true",
+        "access-control-max-age": "600",
+      });
+      res.end();
+      return;
+    }
+    const auth = req.headers["authorization"];
+    const corsHeaders = corsHeadersForOrigin(origin, appOrigin);
+    if (auth === PROTECTED_BEARER_TOKEN) {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        ...corsHeaders,
+      });
+      res.end(JSON.stringify({ user: "alice", protected: true }));
+    } else {
+      res.writeHead(401, {
+        "content-type": "text/plain",
+        ...corsHeaders,
+      });
+      res.end("missing or invalid token");
     }
     return;
   }

--- a/tests/auth-flow-via-bidi.test.ts
+++ b/tests/auth-flow-via-bidi.test.ts
@@ -164,3 +164,139 @@ test.describe("auth flow via BiDi (cookie injection)", () => {
     }
   });
 });
+
+test.describe("auth flow via BiDi (Bearer header injection)", () => {
+  test("Bearer flow via crater.setOriginAuthorization", async () => {
+    // Phase 1 e2e for PR #146 (#148): the runtime fetch shim must attach
+    // the registered Authorization header on script-side fetch() to a
+    // matching origin, without the page ever touching the token.
+    const fixture = await startAuthServer();
+    const session = await connectCraterBidi();
+    try {
+      // 1. Pin the active origin to the fixture app server so the runtime
+      //    fetch shim has a non-empty source origin. (Same workaround as the
+      //    cookie test above — browsingContext.navigate doesn't reliably
+      //    fetch the HTML document on the JS target, so we use the synthetic
+      //    location instead. This still drives the runtime down the same
+      //    __bidiResolveAuth path.)
+      const fixtureLandingHref = `${fixture.url}/login`;
+      const rememberResp = await session.raw.send(
+        "script.rememberSyntheticLocationHref",
+        { context: session.contextId, href: fixtureLandingHref },
+      );
+      expect(
+        rememberResp.type,
+        `rememberSyntheticLocationHref: ${rememberResp.error ?? rememberResp.message}`,
+      ).toBe("success");
+
+      // 2. Register the per-origin Authorization header for the API origin
+      //    via raw BiDi. The crater-bidi helper has no typed wrapper for
+      //    this method yet; we send the JSON-RPC frame directly. Shape
+      //    matches webdriver/webdriver/bidi_authorization.mbt
+      //    handle_crater_set_origin_authorization.
+      const setAuthResp = await session.raw.send(
+        "crater.setOriginAuthorization",
+        {
+          origin: fixture.apiUrl,
+          // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+          headerValue: "Bearer test-jwt-token",
+          context: session.contextId,
+        },
+      );
+      expect(
+        setAuthResp.type,
+        `crater.setOriginAuthorization: ${setAuthResp.error ?? setAuthResp.message}`,
+      ).toBe("success");
+
+      // 3. Confirm the registration surfaces via crater.listOriginAuthorizations
+      //    without leaking the header value (spec §5.3).
+      const listResp = await session.raw.send(
+        "crater.listOriginAuthorizations",
+        { context: session.contextId },
+      );
+      expect(
+        listResp.type,
+        `crater.listOriginAuthorizations: ${listResp.error ?? listResp.message}`,
+      ).toBe("success");
+      const listed = (listResp.result as { origins?: Array<{ origin: string }> }).origins ?? [];
+      expect(
+        listed.some((o) => o.origin === fixture.apiUrl),
+        `expected fixture API origin in listOriginAuthorizations, got ${JSON.stringify(listed)}`,
+      ).toBe(true);
+
+      // 4. Open the request sandbox for cross-origin fetch (app:apiPort is a
+      //    different origin from app:appPort). Without `mode: 'open'` the
+      //    runtime fetch shim blocks cross-origin requests at the preflight
+      //    stage. This mirrors the Playwright adapter, which calls
+      //    __setRequestSandbox({mode:'open'}) on every navigated context
+      //    (see webdriver/playwright/adapter.ts ~3257).
+      await session.script.evaluate({
+        expression: `globalThis.__setRequestSandbox({ mode: 'open' }); null`,
+        awaitPromise: false,
+      });
+
+      // 5. Issue a script-side fetch to the protected endpoint WITHOUT
+      //    setting Authorization in JS. If the shim is wired correctly, the
+      //    header gets attached by __bidiResolveAuth before the request
+      //    hits the network.
+      const protectedJson = await session.script.evaluate<string>({
+        expression: `(async () => {
+          const r = await fetch(${JSON.stringify(`${fixture.apiUrl}/api/protected`)});
+          const body = await r.text();
+          return JSON.stringify({ status: r.status, body });
+        })()`,
+        awaitPromise: true,
+      });
+      const parsed = JSON.parse(protectedJson) as { status: number; body: string };
+      expect(
+        parsed.status,
+        `protected response: ${JSON.stringify(parsed)}`,
+      ).toBe(200);
+      const decoded = JSON.parse(parsed.body) as { user: string; protected: boolean };
+      expect(decoded.user).toBe("alice");
+      expect(decoded.protected).toBe(true);
+
+      // 6. Negative control: after clearing the registration, the same
+      //    fetch must fail with 401. This proves the 200 above was driven
+      //    by the bridge, not by an ambient header.
+      const clearResp = await session.raw.send(
+        "crater.clearOriginAuthorization",
+        { origin: fixture.apiUrl, context: session.contextId },
+      );
+      expect(
+        clearResp.type,
+        `crater.clearOriginAuthorization: ${clearResp.error ?? clearResp.message}`,
+      ).toBe("success");
+      const unauthJson = await session.script.evaluate<string>({
+        expression: `(async () => {
+          const r = await fetch(${JSON.stringify(`${fixture.apiUrl}/api/protected`)});
+          const body = await r.text();
+          return JSON.stringify({ status: r.status, body });
+        })()`,
+        awaitPromise: true,
+      });
+      const unauth = JSON.parse(unauthJson) as { status: number; body: string };
+      expect(
+        unauth.status,
+        `protected response after clear: ${JSON.stringify(unauth)}`,
+      ).toBe(401);
+      expect(unauth.body).toContain("missing or invalid token");
+    } finally {
+      // Reset sandbox mode so subsequent tests on a reused server aren't
+      // affected. The contextId is unique per-test (browsingContext.create
+      // in connectCraterBidi), but the install-once fetch shim flags
+      // persist across contexts.
+      try {
+        await session.script.evaluate({
+          expression: `globalThis.__setRequestSandbox({ mode: 'same-origin' }); null`,
+          awaitPromise: false,
+        });
+      } catch {
+        // ignore — session may already be closing
+      }
+      await session.end();
+      await fixture.stop();
+      await fixture.apiStop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #148. Validates Phase 1 of the auth extension (PR #146) end-to-end against a live HTTP server, complementing the existing cookie-injection test from Phase 5.

## Changes

- **\`scripts/fixtures/auth-server.ts\`** — adds \`GET /api/protected\` on the API port: requires \`Authorization: Bearer test-jwt-token\`. Returns 200 + JSON \`{user: "alice", protected: true}\` on match, 401 otherwise. ACA headers echo \`appOrigin\` when the request origin matches; omitted otherwise (per existing \`/api/me\` policy).
- **\`scripts/fixtures/auth-server.test.ts\`** — 3 new vitest cases pinning the endpoint behavior (correct token, missing header, wrong token).
- **\`tests/auth-flow-via-bidi.test.ts\`** — new test \`"Bearer flow via crater.setOriginAuthorization"\`:
  - Registers the token via raw BiDi \`crater.setOriginAuthorization\`
  - Confirms a script-side \`fetch('/api/protected')\` (no explicit Authorization header) returns 200 — proving the \`__bidiResolveAuth\` bridge auto-attached the header
  - Negative control: \`crater.clearOriginAuthorization\` → same fetch returns 401
  - Verifies \`crater.listOriginAuthorizations\` exposes the origin without leaking the value (spec §5.3)

The existing cookie-injection test is untouched.

## Test counts

| Suite | Before | After |
|---|---|---|
| vitest \`scripts/fixtures/auth-server.test.ts\` | 3 | 6 |
| Playwright \`tests/auth-flow-via-bidi.test.ts\` | 1 | 2 |

## Notes

- The Playwright BiDi helper has no typed wrapper for \`crater.*\` commands; the test sends raw BiDi messages, mirroring how \`storage.setCookie\` is sent in the existing cookie test.
- Cross-origin fetch from app port → API port required \`globalThis.__setRequestSandbox({mode:'open'})\` (same pattern as \`webdriver/playwright/adapter.ts:3257\`).
- Hardcoded test token gated by \`secretlint-disable-next-line\` comments at three sites.

## Test plan

- [x] \`pnpm exec vitest run scripts/fixtures/auth-server.test.ts\` — 6/6
- [x] \`pnpm exec playwright test tests/auth-flow-via-bidi.test.ts\` — 2/2
- [x] \`tsc --noEmit\` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)