### PR TITLE
Verify Authorization stripped on cross-origin redirect

### DIFF
--- a/scripts/fixtures/auth-server.test.ts
+++ b/scripts/fixtures/auth-server.test.ts
@@ -207,3 +207,48 @@ test("cross-origin /api/me requires ACA-Origin and ACA-Credentials", async () =>
     await apiStop();
   }
 });
+
+test("cross-origin redirect strips Authorization per Fetch spec", async () => {
+  // Per https://fetch.spec.whatwg.org/#http-redirect-fetch step 13: when a
+  // redirect crosses origins, CORS non-wildcard request-header names —
+  // including Authorization — must be deleted from the request before the
+  // follow-up fetch. Node's undici implementation follows this.
+  //
+  // Setup: app server's /redirect-cross-origin returns 302 to the api
+  // server's /api/echo-auth. The echo endpoint reports back the headers
+  // it actually saw, so we can assert that Authorization was dropped on
+  // the redirect hop.
+  const { url, stop, apiStop } = await startAuthServer();
+  try {
+    const response = await fetch(`${url}/redirect-cross-origin`, {
+      headers: { authorization: "Bearer should-be-stripped" },
+      redirect: "follow",
+    });
+    expect(response.status).toBe(200);
+    const echoed = (await response.json()) as { authorization: string | null };
+    // The api server saw no Authorization — Node/undici stripped it across origins.
+    expect(echoed.authorization).toBeNull();
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("same-origin redirect preserves Authorization", async () => {
+  // Companion to the cross-origin strip test: when the redirect target is
+  // on the SAME origin, Authorization must survive. Confirms the strip is
+  // origin-scoped, not blanket.
+  const { url, stop, apiStop } = await startAuthServer();
+  try {
+    const response = await fetch(`${url}/redirect-same-origin`, {
+      headers: { authorization: "Bearer survives-same-origin" },
+      redirect: "follow",
+    });
+    expect(response.status).toBe(200);
+    const echoed = (await response.json()) as { authorization: string | null };
+    expect(echoed.authorization).toBe("Bearer survives-same-origin");
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});

--- a/scripts/fixtures/auth-server.ts
+++ b/scripts/fixtures/auth-server.ts
@@ -85,12 +85,30 @@ function handleApp(
   req: IncomingMessage,
   res: ServerResponse,
   sessions: Map<string, string>,
+  apiUrl: string,
 ): Promise<void> {
   return (async () => {
     const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
     if (url.pathname === "/login" && req.method === "GET") {
       res.writeHead(200, { "content-type": "text/html" });
       res.end(loginPageHtml());
+      return;
+    }
+    if (url.pathname === "/redirect-cross-origin") {
+      res.writeHead(302, { location: `${apiUrl}/api/echo-auth` });
+      res.end();
+      return;
+    }
+    if (url.pathname === "/redirect-same-origin") {
+      res.writeHead(302, { location: "/app-echo-auth" });
+      res.end();
+      return;
+    }
+    if (url.pathname === "/app-echo-auth") {
+      const auth = req.headers["authorization"] ?? "";
+      const cookie = req.headers["cookie"] ?? "";
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ authorization: String(auth), cookie: String(cookie) }));
       return;
     }
     if (url.pathname === "/login" && req.method === "POST") {
@@ -313,19 +331,24 @@ export async function startAuthServer(opts: StartOptions = {}): Promise<StartRes
   // startAuthServer call so parallel tests can't leak revocation state.
   const expiredTokens = new Set<string>();
 
-  const appServer = http.createServer((req, res) => {
-    handleApp(req, res, sessions).catch(() => res.end());
-  });
-  await new Promise<void>(r => appServer.listen(opts.port ?? 0, "127.0.0.1", r));
-  const appPort = (appServer.address() as AddressInfo).port;
-  const appUrl = `http://127.0.0.1:${appPort}`;
-
+  // Start the API server FIRST so its URL is known before the app server's
+  // /redirect-cross-origin handler is wired up.
+  const expiredTokensRef = expiredTokens;
+  let appUrlForApi = ""; // bound after appServer listens
   const apiServer = http.createServer((req, res) =>
-    handleApi(req, res, appUrl, sessions, expiredTokens),
+    handleApi(req, res, appUrlForApi, sessions, expiredTokensRef),
   );
   await new Promise<void>(r => apiServer.listen(opts.apiPort ?? 0, "127.0.0.1", r));
   const apiPort = (apiServer.address() as AddressInfo).port;
   const apiUrl = `http://127.0.0.1:${apiPort}`;
+
+  const appServer = http.createServer((req, res) => {
+    handleApp(req, res, sessions, apiUrl).catch(() => res.end());
+  });
+  await new Promise<void>(r => appServer.listen(opts.port ?? 0, "127.0.0.1", r));
+  const appPort = (appServer.address() as AddressInfo).port;
+  const appUrl = `http://127.0.0.1:${appPort}`;
+  appUrlForApi = appUrl;
 
   // The shadow server is only spun up when a test passes `shadowPort`
   // (including `0` for ephemeral). Tests that don't need a 3rd origin get

--- a/tests/auth-flow-via-bidi.test.ts
+++ b/tests/auth-flow-via-bidi.test.ts
@@ -583,6 +583,88 @@ test.describe("auth flow via BiDi (Cookie + Authorization coexistence)", () => {
   });
 });
 
+test.describe("auth flow via BiDi (cross-origin redirect strips Authorization)", () => {
+  test("Authorization is dropped when a redirect crosses origins", async () => {
+    // Fetch spec §4.4.4 step 13 deletes CORS non-wildcard request-headers
+    // (including Authorization) when an HTTP redirect crosses origins. The
+    // fixture-level vitest at scripts/fixtures/auth-server.test.ts proves
+    // undici does the right thing in isolation; this case proves Crater's
+    // BiDi runtime fetch shim doesn't accidentally undo that — i.e. the
+    // header registered via crater.setOriginAuthorization for the app
+    // origin must NOT travel along on the api-origin hop after the 302.
+    const fixture = await startAuthServer();
+    const session = await connectCraterBidi();
+    try {
+      const rememberResp = await session.raw.send(
+        "script.rememberSyntheticLocationHref",
+        { context: session.contextId, href: `${fixture.url}/login` },
+      );
+      expect(
+        rememberResp.type,
+        `rememberSyntheticLocationHref: ${rememberResp.error ?? rememberResp.message}`,
+      ).toBe("success");
+
+      // Register a Bearer for the APP origin only. After the 302 to the api
+      // origin, undici must strip it; no api-origin Bearer is registered,
+      // so the api server's /api/echo-auth should see authorization=null.
+      const setAuthResp = await session.raw.send(
+        "crater.setOriginAuthorization",
+        {
+          origin: fixture.url,
+          // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+          headerValue: "Bearer should-be-stripped-on-redirect",
+          context: session.contextId,
+        },
+      );
+      expect(
+        setAuthResp.type,
+        `crater.setOriginAuthorization: ${setAuthResp.error ?? setAuthResp.message}`,
+      ).toBe("success");
+
+      await session.script.evaluate({
+        expression: `globalThis.__setRequestSandbox({ mode: 'open' }); null`,
+        awaitPromise: false,
+      });
+
+      // Fetch the app's /redirect-cross-origin endpoint, which 302s to
+      // ${api}/api/echo-auth. The echo endpoint reports back what it saw.
+      const echoJson = await session.script.evaluate<string>({
+        expression: `(async () => {
+          const r = await fetch(${JSON.stringify(`${fixture.url}/redirect-cross-origin`)});
+          const body = await r.text();
+          return JSON.stringify({ status: r.status, body });
+        })()`,
+        awaitPromise: true,
+      });
+      const echo = JSON.parse(echoJson) as { status: number; body: string };
+      expect(
+        echo.status,
+        `redirect echo response: ${JSON.stringify(echo)}`,
+      ).toBe(200);
+      const echoBody = JSON.parse(echo.body) as {
+        cookie: string | null;
+        authorization: string | null;
+      };
+      expect(
+        echoBody.authorization,
+        `expected api origin to see no Authorization after redirect, got ${JSON.stringify(echoBody)}`,
+      ).toBeNull();
+    } finally {
+      try {
+        await session.script.evaluate({
+          expression: `globalThis.__setRequestSandbox({ mode: 'same-origin' }); null`,
+          awaitPromise: false,
+        });
+      } catch {
+        // ignore
+      }
+      await session.end();
+      await fixture.stop();
+      await fixture.apiStop();
+    }
+  });
+});
+
 test.describe("auth flow via BiDi (token expiration recovery)", () => {
   test("Token expiration: detect 401 and re-register", async () => {
     // Mark the registered Bearer as expired on the server, fetch and see


### PR DESCRIPTION
## Summary

Adds regression lock that Authorization is dropped when an HTTP redirect crosses origins. Implementation already passes (undici handles this per Fetch spec §4.4.4 step 13, and Crater's runtime fetch shim inherits the behavior), but there was no test pinning it down — easy to regress when the shim grows.

- Fixture (`scripts/fixtures/auth-server.ts`): adds `/redirect-cross-origin`, `/redirect-same-origin`, `/app-echo-auth`. App server is now passed the api URL at construction so it can 302 across origins.
- Vitest (`scripts/fixtures/auth-server.test.ts`): cross-origin redirect drops Authorization; same-origin redirect preserves it.
- Playwright BiDi e2e (`tests/auth-flow-via-bidi.test.ts`): registers Authorization for the app origin via `crater.setOriginAuthorization`, fetches `/redirect-cross-origin` from inside the BiDi context, asserts the api origin saw \`null\` Authorization. Confirms the Crater shim doesn't accidentally re-attach the header after the redirect.

Part of the auth follow-up scope (HTTP Digest / OAuth refresh-token / multi-origin coexistence) — the multi-origin + Cookie+Auth + token-expiration e2e cases shipped in #169; this PR is the cross-origin redirect strip piece.

## Test plan

- [x] \`pnpm exec vitest run scripts/fixtures/auth-server.test.ts\` — 12/12 pass
- [ ] CI runs the Playwright BiDi e2e (\`auth flow via BiDi (cross-origin redirect strips Authorization)\`)