### PR TITLE
Add OAuth refresh-token flow + network.continueRequest spec alias

### DIFF
--- a/scripts/fixtures/auth-server.test.ts
+++ b/scripts/fixtures/auth-server.test.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "vitest";
-import { startAuthServer } from "./auth-server.ts";
+import {
+  REFRESHED_ACCESS_TOKEN,
+  REFRESH_TOKEN,
+  startAuthServer,
+} from "./auth-server.ts";
 
 test("login + dashboard round-trip", async () => {
   const { url, stop } = await startAuthServer({ port: 0 });
@@ -231,6 +235,98 @@ test("cross-origin redirect strips Authorization per Fetch spec", async () => {
   } finally {
     await stop();
     await apiStop();
+  }
+});
+
+test("/oauth/token rejects bogus refresh_token with invalid_grant", async () => {
+  const { stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    const res = await fetch(`${apiUrl}/oauth/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: "not-the-real-token",
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "invalid_grant" });
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("/oauth/token exchanges valid refresh_token for a fresh Bearer", async () => {
+  const { stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    const res = await fetch(`${apiUrl}/oauth/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: REFRESH_TOKEN,
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = (await res.json()) as {
+      access_token: string;
+      token_type: string;
+      expires_in: number;
+    };
+    expect(body.token_type).toBe("Bearer");
+    expect(`Bearer ${body.access_token}`).toBe(REFRESHED_ACCESS_TOKEN);
+    expect(body.expires_in).toBeGreaterThan(0);
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("refresh-token round-trip: expired Bearer -> refresh -> retry succeeds", async () => {
+  // End-to-end shape: simulate a client whose Bearer was revoked. The
+  // server marks the original token as expired, the client posts to
+  // /oauth/token to get a fresh Bearer, and the retry succeeds with the
+  // new header. Models the full "401 -> refresh -> 200" loop a real
+  // OAuth client would run.
+  const fixture = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+    const staleBearer = "Bearer test-jwt-token";
+    fixture.recordExpiredToken(staleBearer);
+
+    const stale = await fetch(`${fixture.apiUrl}/api/protected`, {
+      headers: { authorization: staleBearer, origin: fixture.url },
+    });
+    expect(stale.status).toBe(401);
+    expect(stale.headers.get("www-authenticate")).toContain("invalid_token");
+    expect(await stale.json()).toEqual({ error: "token_expired" });
+
+    const refreshed = await fetch(`${fixture.apiUrl}/oauth/token`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        origin: fixture.url,
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: REFRESH_TOKEN,
+      }),
+    });
+    expect(refreshed.status).toBe(200);
+    const refreshedBody = (await refreshed.json()) as { access_token: string };
+    const freshBearer = `Bearer ${refreshedBody.access_token}`;
+    expect(freshBearer).toBe(REFRESHED_ACCESS_TOKEN);
+
+    const retry = await fetch(`${fixture.apiUrl}/api/protected`, {
+      headers: { authorization: freshBearer, origin: fixture.url },
+    });
+    expect(retry.status).toBe(200);
+    expect(await retry.json()).toEqual({ user: "alice", protected: true });
+  } finally {
+    await fixture.stop();
+    await fixture.apiStop();
   }
 });
 

--- a/scripts/fixtures/auth-server.ts
+++ b/scripts/fixtures/auth-server.ts
@@ -150,6 +150,15 @@ function handleApp(
 // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
 const PROTECTED_BEARER_TOKEN = "Bearer test-jwt-token"; // test fixture only
 
+// Models a single canonical refresh token mapped to a single fresh access
+// token. Tests should mark `PROTECTED_BEARER_TOKEN` as expired (via
+// `recordExpiredToken`) and exchange this refresh token through
+// `/oauth/token` to drive the refresh flow.
+// secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+export const REFRESH_TOKEN = "rt-test-refresh"; // test fixture only
+// secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+export const REFRESHED_ACCESS_TOKEN = "Bearer test-jwt-token-refreshed"; // test fixture only
+
 function corsHeadersForOrigin(
   origin: string,
   appOrigin: string,
@@ -228,7 +237,7 @@ function handleApi(
       res.end(JSON.stringify({ error: "token_expired" }));
       return;
     }
-    if (auth === PROTECTED_BEARER_TOKEN) {
+    if (auth === PROTECTED_BEARER_TOKEN || auth === REFRESHED_ACCESS_TOKEN) {
       res.writeHead(200, {
         "content-type": "application/json",
         ...corsHeaders,
@@ -273,6 +282,71 @@ function handleApi(
         authorization: typeof authHeader === "string" ? authHeader : null,
       }),
     );
+    return;
+  }
+  // OAuth-style refresh token exchange.
+  //
+  // Request:  POST /oauth/token   application/x-www-form-urlencoded
+  //           grant_type=refresh_token&refresh_token=<token>
+  // Response: 200 application/json { access_token, token_type, expires_in }
+  //           or 400 { error: "invalid_grant" } on bad refresh_token.
+  //
+  // The fresh access token is `REFRESHED_ACCESS_TOKEN` — `/api/protected`
+  // accepts BOTH `PROTECTED_BEARER_TOKEN` and `REFRESHED_ACCESS_TOKEN`, so
+  // a test driving the "expired token → refresh → retry" flow can:
+  //   1. recordExpiredToken(PROTECTED_BEARER_TOKEN)
+  //   2. fetch /api/protected with PROTECTED_BEARER_TOKEN  → 401 token_expired
+  //   3. POST /oauth/token with REFRESH_TOKEN              → 200 access_token
+  //   4. fetch /api/protected with REFRESHED_ACCESS_TOKEN  → 200
+  // This is *not* a full OAuth implementation — there's no client_id, no
+  // PKCE, no token rotation, no scope handling. It's the minimum surface
+  // that makes the refresh round-trip exerciseable end-to-end.
+  if (url.pathname === "/oauth/token") {
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, {
+        "access-control-allow-origin": appOrigin,
+        "access-control-allow-methods": "POST",
+        "access-control-allow-headers": "content-type",
+        "access-control-allow-credentials": "true",
+        "access-control-max-age": "600",
+      });
+      res.end();
+      return;
+    }
+    if (req.method !== "POST") {
+      res.writeHead(405);
+      res.end();
+      return;
+    }
+    const corsHeaders = corsHeadersForOrigin(origin, appOrigin);
+    readBody(req).then(body => {
+      const params = new URLSearchParams(body);
+      const grant = params.get("grant_type");
+      const refresh = params.get("refresh_token");
+      if (grant !== "refresh_token" || refresh !== REFRESH_TOKEN) {
+        res.writeHead(400, {
+          "content-type": "application/json",
+          ...corsHeaders,
+        });
+        res.end(JSON.stringify({ error: "invalid_grant" }));
+        return;
+      }
+      // Strip the "Bearer " prefix in the response body — clients reattach
+      // it themselves when setting the Authorization header. This mirrors
+      // RFC 6749 §5.1.
+      const access = REFRESHED_ACCESS_TOKEN.replace(/^Bearer /, "");
+      res.writeHead(200, {
+        "content-type": "application/json",
+        ...corsHeaders,
+      });
+      res.end(
+        JSON.stringify({
+          access_token: access,
+          token_type: "Bearer",
+          expires_in: 3600,
+        }),
+      );
+    });
     return;
   }
   void sessions; // sessions available for future authenticated /api/* routes

--- a/tests/auth-flow-via-bidi.test.ts
+++ b/tests/auth-flow-via-bidi.test.ts
@@ -32,7 +32,11 @@
  */
 
 import { expect, test } from "@playwright/test";
-import { startAuthServer } from "../scripts/fixtures/auth-server.ts";
+import {
+  REFRESHED_ACCESS_TOKEN,
+  REFRESH_TOKEN,
+  startAuthServer,
+} from "../scripts/fixtures/auth-server.ts";
 import { connectCraterBidi } from "./helpers/crater-bidi.ts";
 
 const SESSION_ID = "s_test";
@@ -776,6 +780,141 @@ test.describe("auth flow via BiDi (token expiration recovery)", () => {
     } finally {
       try {
         fixture.forgetExpiredToken(expiredToken);
+      } catch {
+        // ignore
+      }
+      try {
+        await session.script.evaluate({
+          expression: `globalThis.__setRequestSandbox({ mode: 'same-origin' }); null`,
+          awaitPromise: false,
+        });
+      } catch {
+        // ignore
+      }
+      await session.end();
+      await fixture.stop();
+      await fixture.apiStop();
+    }
+  });
+});
+
+test.describe("auth flow via BiDi (OAuth refresh-token flow)", () => {
+  test("expired Bearer -> refresh via /oauth/token -> re-register -> retry succeeds", async () => {
+    // End-to-end OAuth-style refresh round-trip driven entirely from
+    // inside the BiDi runtime:
+    //   1. Register a Bearer for the api origin and mark it expired
+    //      server-side.
+    //   2. From page-side JS, fetch /api/protected — gets 401 token_expired.
+    //   3. From page-side JS, POST /oauth/token with the refresh token —
+    //      gets a fresh access_token.
+    //   4. Re-register the fresh Bearer via crater.setOriginAuthorization
+    //      (the driver-side analogue of the page updating its in-memory
+    //      Authorization header).
+    //   5. Retry /api/protected — now succeeds with the refreshed token
+    //      attached by the runtime fetch shim.
+    // This proves the full refresh chain composes cleanly with Crater's
+    // per-origin Authorization injection, including the case where the
+    // driver rotates the registered header value mid-session.
+    const fixture = await startAuthServer();
+    // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+    const staleBearer = "Bearer test-jwt-token";
+
+    const session = await connectCraterBidi();
+    try {
+      const rememberResp = await session.raw.send(
+        "script.rememberSyntheticLocationHref",
+        { context: session.contextId, href: `${fixture.url}/login` },
+      );
+      expect(
+        rememberResp.type,
+        `rememberSyntheticLocationHref: ${rememberResp.error ?? rememberResp.message}`,
+      ).toBe("success");
+
+      const setStaleResp = await session.raw.send(
+        "crater.setOriginAuthorization",
+        {
+          origin: fixture.apiUrl,
+          headerValue: staleBearer,
+          context: session.contextId,
+        },
+      );
+      expect(
+        setStaleResp.type,
+        `crater.setOriginAuthorization (stale): ${setStaleResp.error ?? setStaleResp.message}`,
+      ).toBe("success");
+      fixture.recordExpiredToken(staleBearer);
+
+      await session.script.evaluate({
+        expression: `globalThis.__setRequestSandbox({ mode: 'open' }); null`,
+        awaitPromise: false,
+      });
+
+      const firstJson = await session.script.evaluate<string>({
+        expression: `(async () => {
+          const r = await fetch(${JSON.stringify(`${fixture.apiUrl}/api/protected`)});
+          const body = await r.text();
+          return JSON.stringify({ status: r.status, body });
+        })()`,
+        awaitPromise: true,
+      });
+      const first = JSON.parse(firstJson) as { status: number; body: string };
+      expect(first.status, `first attempt: ${JSON.stringify(first)}`).toBe(401);
+      expect(JSON.parse(first.body)).toEqual({ error: "token_expired" });
+
+      // Page-side refresh exchange. /oauth/token is gated on the
+      // refresh_token grant only — no Authorization required, so it
+      // works as a recovery path AFTER the Bearer expired.
+      const refreshJson = await session.script.evaluate<string>({
+        expression: `(async () => {
+          const r = await fetch(${JSON.stringify(`${fixture.apiUrl}/oauth/token`)}, {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+              grant_type: 'refresh_token',
+              refresh_token: ${JSON.stringify(REFRESH_TOKEN)},
+            }).toString(),
+          });
+          const body = await r.text();
+          return JSON.stringify({ status: r.status, body });
+        })()`,
+        awaitPromise: true,
+      });
+      const refresh = JSON.parse(refreshJson) as { status: number; body: string };
+      expect(refresh.status, `refresh response: ${JSON.stringify(refresh)}`).toBe(200);
+      const refreshBody = JSON.parse(refresh.body) as { access_token: string };
+      const freshBearer = `Bearer ${refreshBody.access_token}`;
+      expect(freshBearer).toBe(REFRESHED_ACCESS_TOKEN);
+
+      // Driver-side rotation — replace the registered Authorization with
+      // the freshly-issued Bearer.
+      const setFreshResp = await session.raw.send(
+        "crater.setOriginAuthorization",
+        {
+          origin: fixture.apiUrl,
+          headerValue: freshBearer,
+          context: session.contextId,
+        },
+      );
+      expect(
+        setFreshResp.type,
+        `crater.setOriginAuthorization (fresh): ${setFreshResp.error ?? setFreshResp.message}`,
+      ).toBe("success");
+
+      // Retry — runtime fetch shim now attaches the fresh Bearer.
+      const retryJson = await session.script.evaluate<string>({
+        expression: `(async () => {
+          const r = await fetch(${JSON.stringify(`${fixture.apiUrl}/api/protected`)});
+          const body = await r.text();
+          return JSON.stringify({ status: r.status, body });
+        })()`,
+        awaitPromise: true,
+      });
+      const retry = JSON.parse(retryJson) as { status: number; body: string };
+      expect(retry.status, `retry response: ${JSON.stringify(retry)}`).toBe(200);
+      expect(JSON.parse(retry.body)).toEqual({ user: "alice", protected: true });
+    } finally {
+      try {
+        fixture.forgetExpiredToken(staleBearer);
       } catch {
         // ignore
       }

--- a/webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt
+++ b/webdriver/webdriver/bidi_network_spec_aliases_wbtest.mbt
@@ -118,6 +118,29 @@ test "bidi network.provideResponse (spec name) resolves blocked request" {
 }
 
 ///|
+test "bidi network.continueRequest (spec name) applies header override" {
+  // Spec name routes to handle_network_continue_blocked_request; this exercise
+  // also confirms the `headers` override path is reachable through the
+  // spec-conformant entry point (used by OAuth refresh-token clients).
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"network.rememberBlockedRequest\",\"params\":{\"request\":\"request-spec-alias-6\",\"blockedRequest\":{\"phase\":\"beforeRequestSent\",\"context_id\":\"session-1\",\"url\":\"http://localhost:8000/api/protected\",\"method\":\"GET\",\"request_headers\":{\"authorization\":\"Bearer stale\"}}}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"network.continueRequest\",\"params\":{\"request\":\"request-spec-alias-6\",\"headers\":[{\"name\":\"authorization\",\"value\":{\"type\":\"string\",\"value\":\"Bearer fresh\"}}]}}",
+  )
+  let json = proto.take_messages()[0].to_json()
+  assert_true(json.contains("\"type\":\"success\""))
+  assert_false(json.contains("unknown command"))
+  assert_true(json.contains("\"consumed\":true"))
+}
+
+///|
 test "bidi network.failRequest (spec name) fails blocked request" {
   let proto = BidiProtocol::new()
   let _ = proto.process_message(

--- a/webdriver/webdriver/bidi_protocol_dispatch_network.mbt
+++ b/webdriver/webdriver/bidi_protocol_dispatch_network.mbt
@@ -141,6 +141,17 @@ fn BidiProtocol::dispatch_network(
       self.handle_network_continue_auth_request(request.id, request.params)
       Ok(())
     }
+    // Spec-conformant name from WebDriver BiDi specification.
+    // Routes to the same handler as the internal alias `continueBlockedRequest`.
+    // Per spec, params may include `headers`, `method`, `url`, `body`, `cookies`
+    // overrides for an intercepted request paused at `beforeRequestSent`.
+    "continueRequest" => {
+      self.handle_network_continue_blocked_request(request.id, request.params)
+      Ok(())
+    }
+    // Internal alias kept for backwards-compat with the WPT shim and existing
+    // wbtests. Retire once the shim drops its rename and dependent wbtests
+    // migrate to the spec name `continueRequest`.
     "continueBlockedRequest" => {
       self.handle_network_continue_blocked_request(request.id, request.params)
       Ok(())


### PR DESCRIPTION
## Summary

Stands up the OAuth refresh-token round-trip end-to-end on top of the existing per-origin Authorization injection.

- **Spec alias** \`network.continueRequest\` in \`bidi_protocol_dispatch_network.mbt\`. Routes to the existing \`handle_network_continue_blocked_request\` handler — which already supports \`headers\`/\`method\`/\`url\`/\`body\`/\`cookies\` overrides per spec. Internal \`continueBlockedRequest\` alias kept for back-compat with the WPT shim.
- **Fixture endpoint** \`/oauth/token\`: accepts \`grant_type=refresh_token\` form posts, issues a Bearer that \`/api/protected\` also accepts. Minimum RFC 6749 §5.1 shape — no PKCE/rotation/scopes. \`REFRESH_TOKEN\` and \`REFRESHED_ACCESS_TOKEN\` exported.
- **Tests**:
  - \`bidi_network_spec_aliases_wbtest.mbt\` — probes \`network.continueRequest\` routes through the headers-override path
  - \`auth-server.test.ts\` — invalid_grant, valid exchange, and the full expired -> refresh -> retry round-trip at fixture level
  - \`auth-flow-via-bidi.test.ts\` — Playwright BiDi e2e drives the same round-trip from inside the BiDi runtime, including mid-session \`crater.setOriginAuthorization\` rotation

### Scope note

Crater's runtime fetch shim does **not** currently consult \`network.addIntercept\` registrations. The BiDi e2e therefore exercises the *page-driven refresh* pattern (page detects 401, page fetches refresh endpoint, driver rotates the registered Bearer). True *driver-intercepting-page-fetch* via \`continueRequest\` requires wiring \`addIntercept\` into the runtime fetch shim — left as a follow-up.

Part of the auth follow-up scope (HTTP Digest / OAuth refresh / cross-origin redirect strip / multi-origin coexistence). The refresh-token piece. Cross-origin redirect strip shipped in #170.

## Test plan

- [x] \`moon test -p mizchi/crater-webdriver-bidi/webdriver --file bidi_network_spec_aliases_wbtest.mbt\` — 7/7
- [x] \`pnpm exec vitest run scripts/fixtures/auth-server.test.ts\` — 15/15
- [ ] CI runs the Playwright BiDi e2e (\`auth flow via BiDi (OAuth refresh-token flow)\`)