### PR TITLE
Add HTTP Digest authentication fixture (RFC 7616)

### DIFF
--- a/scripts/fixtures/auth-server.test.ts
+++ b/scripts/fixtures/auth-server.test.ts
@@ -1,7 +1,13 @@
+import { randomBytes } from "node:crypto";
 import { test, expect } from "vitest";
 import {
+  DIGEST_PASSWORD,
+  DIGEST_REALM,
+  DIGEST_USERNAME,
   REFRESHED_ACCESS_TOKEN,
   REFRESH_TOKEN,
+  computeDigestAuthorization,
+  parseDigestChallenge,
   startAuthServer,
 } from "./auth-server.ts";
 
@@ -343,6 +349,152 @@ test("same-origin redirect preserves Authorization", async () => {
     expect(response.status).toBe(200);
     const echoed = (await response.json()) as { authorization: string | null };
     expect(echoed.authorization).toBe("Bearer survives-same-origin");
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("/digest/protected issues a Digest challenge without Authorization", async () => {
+  const { stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    const res = await fetch(`${apiUrl}/digest/protected`);
+    expect(res.status).toBe(401);
+    const www = res.headers.get("www-authenticate");
+    expect(www).not.toBeNull();
+    expect(www).toContain("Digest ");
+    expect(www).toContain(`realm="${DIGEST_REALM}"`);
+    expect(www).toContain('qop="auth"');
+    expect(www).toMatch(/nonce="[a-f0-9]+"/);
+    expect(www).toMatch(/algorithm=MD5/);
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("/digest/protected accepts a correctly computed MD5 Digest response", async () => {
+  const { stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    // First request: trigger the challenge so we get a fresh nonce.
+    const challengeRes = await fetch(`${apiUrl}/digest/protected`);
+    expect(challengeRes.status).toBe(401);
+    const www = challengeRes.headers.get("www-authenticate")!;
+    const challenge = parseDigestChallenge(www)!;
+    expect(challenge.get("realm")).toBe(DIGEST_REALM);
+
+    const uri = "/digest/protected";
+    const authHeader = computeDigestAuthorization({
+      username: DIGEST_USERNAME,
+      password: DIGEST_PASSWORD,
+      realm: challenge.get("realm")!,
+      nonce: challenge.get("nonce")!,
+      uri,
+      method: "GET",
+      qop: challenge.get("qop"),
+      nc: "00000001",
+      cnonce: randomBytes(8).toString("hex"),
+      algorithm: challenge.get("algorithm") ?? "MD5",
+      opaque: challenge.get("opaque"),
+    });
+
+    const ok = await fetch(`${apiUrl}${uri}`, {
+      headers: { authorization: authHeader },
+    });
+    expect(ok.status).toBe(200);
+    expect(ok.headers.get("content-type")).toContain("application/json");
+    const body = (await ok.json()) as { user: string; digest: boolean };
+    expect(body).toEqual({ user: DIGEST_USERNAME, digest: true });
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("/digest/protected accepts SHA-256 algorithm", async () => {
+  const { stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    const challengeRes = await fetch(`${apiUrl}/digest/protected`);
+    const www = challengeRes.headers.get("www-authenticate")!;
+    const challenge = parseDigestChallenge(www)!;
+    const uri = "/digest/protected";
+    const authHeader = computeDigestAuthorization({
+      username: DIGEST_USERNAME,
+      password: DIGEST_PASSWORD,
+      realm: challenge.get("realm")!,
+      nonce: challenge.get("nonce")!,
+      uri,
+      method: "GET",
+      qop: challenge.get("qop"),
+      nc: "00000001",
+      cnonce: randomBytes(8).toString("hex"),
+      algorithm: "SHA-256", // override the server-advertised MD5
+    });
+
+    const ok = await fetch(`${apiUrl}${uri}`, {
+      headers: { authorization: authHeader },
+    });
+    expect(ok.status).toBe(200);
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("/digest/protected rejects a Digest response with wrong password", async () => {
+  const { stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    const challengeRes = await fetch(`${apiUrl}/digest/protected`);
+    const www = challengeRes.headers.get("www-authenticate")!;
+    const challenge = parseDigestChallenge(www)!;
+    const uri = "/digest/protected";
+    const authHeader = computeDigestAuthorization({
+      username: DIGEST_USERNAME,
+      password: "wrong-password",
+      realm: challenge.get("realm")!,
+      nonce: challenge.get("nonce")!,
+      uri,
+      method: "GET",
+      qop: challenge.get("qop"),
+      nc: "00000001",
+      cnonce: randomBytes(8).toString("hex"),
+      algorithm: "MD5",
+    });
+
+    const denied = await fetch(`${apiUrl}${uri}`, {
+      headers: { authorization: authHeader },
+    });
+    expect(denied.status).toBe(401);
+    // Server should re-issue a fresh challenge so the client knows to retry
+    // with corrected credentials. (Real servers might emit `stale=true` to
+    // distinguish nonce-stale vs credential-wrong; the fixture doesn't.)
+    expect(denied.headers.get("www-authenticate")).toContain("Digest ");
+  } finally {
+    await stop();
+    await apiStop();
+  }
+});
+
+test("/digest/protected rejects RFC 2069 (no-qop) form with wrong response", async () => {
+  // RFC 2069 backward-compat shape: HASH(HA1:nonce:HA2) without qop/nc/cnonce.
+  // The server accepts the no-qop response form when qop is omitted by the
+  // client; this case proves the verification still rejects a bogus response
+  // string, not just qop-mode requests.
+  const { stop, apiUrl, apiStop } = await startAuthServer({ port: 0, apiPort: 0 });
+  try {
+    const challengeRes = await fetch(`${apiUrl}/digest/protected`);
+    const challenge = parseDigestChallenge(challengeRes.headers.get("www-authenticate")!)!;
+    const uri = "/digest/protected";
+    // Craft a header that LOOKS valid but with a hand-rolled (wrong) response.
+    const bogus =
+      `Digest username="${DIGEST_USERNAME}", realm="${challenge.get("realm")}", ` +
+      `nonce="${challenge.get("nonce")}", uri="${uri}", ` +
+      `response="0000000000000000000000000000000000000000000000000000000000000000", ` +
+      `algorithm=MD5`;
+    const denied = await fetch(`${apiUrl}${uri}`, {
+      headers: { authorization: bogus },
+    });
+    expect(denied.status).toBe(401);
   } finally {
     await stop();
     await apiStop();

--- a/scripts/fixtures/auth-server.ts
+++ b/scripts/fixtures/auth-server.ts
@@ -7,6 +7,7 @@
  *   exercise Crater's CORS gate (M5 in PR #131 security review).
  */
 
+import { createHash, randomBytes } from "node:crypto";
 import http, { IncomingMessage, ServerResponse } from "node:http";
 import { AddressInfo } from "node:net";
 
@@ -158,6 +159,149 @@ const PROTECTED_BEARER_TOKEN = "Bearer test-jwt-token"; // test fixture only
 export const REFRESH_TOKEN = "rt-test-refresh"; // test fixture only
 // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
 export const REFRESHED_ACCESS_TOKEN = "Bearer test-jwt-token-refreshed"; // test fixture only
+
+// HTTP Digest fixture credentials. Both algorithms (MD5 and SHA-256) accept
+// the same username/password pair — the algorithm only changes which hash
+// function is used to compute HA1, HA2 and the response per RFC 7616.
+export const DIGEST_REALM = "crater-digest-fixture";
+export const DIGEST_USERNAME = "alice";
+// secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+export const DIGEST_PASSWORD = "wonderland"; // test fixture only
+
+function parseDigestAuthorization(header: string): Map<string, string> | null {
+  // Strip leading "Digest " scheme token.
+  if (!header.startsWith("Digest ")) return null;
+  const params = header.slice("Digest ".length).trim();
+  const out = new Map<string, string>();
+  // RFC 7616 §3.4: parameters are auth-param "name=value" pairs separated
+  // by commas; values may be quoted-strings or tokens. We scan
+  // character-by-character to handle commas inside quoted values.
+  let i = 0;
+  while (i < params.length) {
+    while (i < params.length && /[\s,]/.test(params[i])) i++;
+    const nameStart = i;
+    while (i < params.length && params[i] !== "=") i++;
+    if (i >= params.length) break;
+    const name = params.slice(nameStart, i).trim();
+    i++; // consume '='
+    let value: string;
+    if (params[i] === '"') {
+      i++; // consume opening quote
+      const valStart = i;
+      while (i < params.length && params[i] !== '"') {
+        if (params[i] === "\\" && i + 1 < params.length) i += 2;
+        else i++;
+      }
+      value = params.slice(valStart, i);
+      if (i < params.length) i++; // consume closing quote
+    } else {
+      const valStart = i;
+      while (i < params.length && params[i] !== ",") i++;
+      value = params.slice(valStart, i).trim();
+    }
+    out.set(name.toLowerCase(), value);
+  }
+  return out;
+}
+
+function digestHash(algorithm: string, input: string): string {
+  // RFC 7616 §3.3: hash function H() depends on the algorithm directive.
+  // We support MD5 (mandatory baseline) and SHA-256. The "-sess" variants
+  // alter how HA1 is computed but use the same underlying digest, so the
+  // base hash function is the same.
+  const algo = algorithm.toLowerCase().replace(/-sess$/, "");
+  const nodeAlgo = algo === "sha-256" || algo === "sha256" ? "sha256" : "md5";
+  return createHash(nodeAlgo).update(input).digest("hex");
+}
+
+function verifyDigestAuthorization(
+  header: string,
+  method: string,
+): { username: string } | null {
+  const parsed = parseDigestAuthorization(header);
+  if (!parsed) return null;
+  const username = parsed.get("username");
+  const realm = parsed.get("realm");
+  const nonce = parsed.get("nonce");
+  const uri = parsed.get("uri");
+  const response = parsed.get("response");
+  const qop = parsed.get("qop");
+  const nc = parsed.get("nc");
+  const cnonce = parsed.get("cnonce");
+  const algorithm = parsed.get("algorithm") ?? "MD5";
+  if (!username || !realm || !nonce || !uri || !response) return null;
+  if (username !== DIGEST_USERNAME || realm !== DIGEST_REALM) return null;
+
+  const ha1 = digestHash(
+    algorithm,
+    `${DIGEST_USERNAME}:${DIGEST_REALM}:${DIGEST_PASSWORD}`,
+  );
+  const ha2 = digestHash(algorithm, `${method}:${uri}`);
+  // qop=auth uses the extended response: HASH(HA1:nonce:nc:cnonce:qop:HA2).
+  // Without qop, the bare RFC 2069 form HASH(HA1:nonce:HA2) is used.
+  const expected = qop
+    ? digestHash(algorithm, `${ha1}:${nonce}:${nc}:${cnonce}:${qop}:${ha2}`)
+    : digestHash(algorithm, `${ha1}:${nonce}:${ha2}`);
+  if (expected !== response) return null;
+  return { username };
+}
+
+/**
+ * RFC 7616 client-side response computation. Builds the Authorization header
+ * value a real Digest client would send after receiving a 401 challenge.
+ * Used by the fixture vitest and by Playwright e2e to drive the round-trip
+ * without depending on a userland Digest client library.
+ */
+export function computeDigestAuthorization(opts: {
+  username: string;
+  password: string;
+  realm: string;
+  nonce: string;
+  uri: string;
+  method: string;
+  qop?: string;
+  nc?: string;
+  cnonce?: string;
+  algorithm?: string;
+  opaque?: string;
+}): string {
+  const algorithm = opts.algorithm ?? "MD5";
+  const ha1 = digestHash(
+    algorithm,
+    `${opts.username}:${opts.realm}:${opts.password}`,
+  );
+  const ha2 = digestHash(algorithm, `${opts.method}:${opts.uri}`);
+  const response = opts.qop
+    ? digestHash(
+        algorithm,
+        `${ha1}:${opts.nonce}:${opts.nc}:${opts.cnonce}:${opts.qop}:${ha2}`,
+      )
+    : digestHash(algorithm, `${ha1}:${opts.nonce}:${ha2}`);
+  const parts = [
+    `username="${opts.username}"`,
+    `realm="${opts.realm}"`,
+    `nonce="${opts.nonce}"`,
+    `uri="${opts.uri}"`,
+    `response="${response}"`,
+    `algorithm=${algorithm}`,
+  ];
+  if (opts.qop) {
+    parts.push(`qop=${opts.qop}`);
+    if (opts.nc) parts.push(`nc=${opts.nc}`);
+    if (opts.cnonce) parts.push(`cnonce="${opts.cnonce}"`);
+  }
+  if (opts.opaque) parts.push(`opaque="${opts.opaque}"`);
+  return `Digest ${parts.join(", ")}`;
+}
+
+/**
+ * Parses a Digest challenge from the server's WWW-Authenticate header.
+ * Returns the directive map (realm/nonce/qop/etc.) for a client to feed
+ * into `computeDigestAuthorization`.
+ */
+export function parseDigestChallenge(header: string): Map<string, string> | null {
+  return parseDigestAuthorization(header);
+}
 
 function corsHeadersForOrigin(
   origin: string,
@@ -347,6 +491,49 @@ function handleApi(
         }),
       );
     });
+    return;
+  }
+  // RFC 7616 §3 HTTP Digest Access Authentication.
+  //
+  // Endpoint: GET /digest/protected
+  //
+  // Without a matching Authorization header, returns:
+  //   401 + WWW-Authenticate: Digest realm="...", qop="auth",
+  //                                  nonce="<server nonce>", algorithm=MD5
+  // With a valid Authorization: Digest header (correct response per
+  // RFC 7616 §3.4.1) returns 200 + JSON.
+  //
+  // Both MD5 (RFC 7616's mandatory baseline, kept for client compatibility)
+  // and SHA-256 are accepted. The fixture stores no nonce state — it
+  // verifies the response by recomputing it with the supplied nonce; that's
+  // permissive enough for round-trip testing without exposing replay
+  // protection complexity. Real servers cycle nonces and remember nc/cnonce
+  // pairs to defeat replay; that's out of scope for a fixture.
+  if (url.pathname === "/digest/protected") {
+    const corsHeaders = corsHeadersForOrigin(origin, appOrigin);
+    const auth = req.headers["authorization"];
+    if (typeof auth === "string" && auth.startsWith("Digest ")) {
+      const verified = verifyDigestAuthorization(auth, req.method ?? "GET");
+      if (verified) {
+        res.writeHead(200, {
+          "content-type": "application/json",
+          ...corsHeaders,
+        });
+        res.end(JSON.stringify({ user: verified.username, digest: true }));
+        return;
+      }
+    }
+    // No Authorization or verification failed: issue a fresh challenge.
+    const nonce = randomBytes(16).toString("hex");
+    const opaque = randomBytes(8).toString("hex");
+    res.writeHead(401, {
+      "content-type": "text/plain",
+      "www-authenticate":
+        `Digest realm="${DIGEST_REALM}", qop="auth", nonce="${nonce}", ` +
+        `opaque="${opaque}", algorithm=MD5`,
+      ...corsHeaders,
+    });
+    res.end("digest authentication required");
     return;
   }
   void sessions; // sessions available for future authenticated /api/* routes


### PR DESCRIPTION
## Summary

Adds the third auth scheme to the test fixture (alongside Bearer and Cookie). Lets tests drive a complete Digest round-trip end-to-end without a userland library.

- **Server**: \`GET /digest/protected\` issues \`WWW-Authenticate: Digest realm=..., qop="auth", nonce=..., opaque=..., algorithm=MD5\` on unauthenticated requests, accepts both MD5 / SHA-256 and both qop=auth / RFC 2069 no-qop forms.
- **Client helpers**: \`computeDigestAuthorization\` and \`parseDigestChallenge\` exported from the fixture module for reuse from tests. Computes the response per RFC 7616 §3.4.1.
- **Tests** at the fixture level: challenge shape, MD5 round-trip, SHA-256 round-trip, wrong-password rejection, hand-rolled bogus response rejection.

## Scope note

This PR ships the *fixture* and reusable client-side helpers. Wiring Digest auto-handling into Crater's BiDi runtime fetch shim — so a page can register credentials and have the shim handle the 401 challenge transparently, analogous to \`crater.setOriginAuthorization\` — is a meaningful API surface decision (need a new \`crater.setOriginCredentials\` BiDi command, MD5/SHA-256 in the shim's JS realm, retry-once policy, nonce/nc state) and is left as a follow-up. Filing as a separate issue.

Closes the last item in the auth follow-up scope (HTTP Digest / OAuth refresh / cross-origin redirect strip / multi-origin coexistence). Companion PRs: #170 (redirect strip), #171 (OAuth refresh), #169 (multi-origin + cookie+auth + token expiration).

## Test plan

- [x] \`pnpm exec vitest run scripts/fixtures/auth-server.test.ts\` — 15/15
- [ ] CI re-runs the full vitest suite