### PR TITLE
Wire HTTP Digest auto-handling into BiDi runtime fetch shim

### DIFF
--- a/http/profile/auth.mbt
+++ b/http/profile/auth.mbt
@@ -1,18 +1,38 @@
 ///|
-/// Per-origin Authorization header storage carried by a Profile.
-/// Header values are written via WebDriver `crater.setOriginAuthorization`
-/// and attached by the BiDi runtime fetch shim when the caller has not
-/// already supplied an `Authorization` header.
-pub(all) struct AuthState {
-  mut origin_headers : Map[String, String]
+/// Per-origin username/password pair for HTTP Basic / Digest authentication.
+/// Written via WebDriver `crater.setOriginCredentials` and consumed by the
+/// BiDi runtime fetch shim's 401 Digest retry path.
+pub(all) struct OriginCredentials {
+  username : String
+  password : String
 }
 
 ///|
-/// Show impl deliberately redacts header values; only origins are
-/// rendered. Prevents secret leaks via panic stack traces or
+/// Per-origin Authorization header storage carried by a Profile.
+///
+/// Two related-but-separate storage maps live on this state:
+///
+/// - `origin_headers`: complete pre-formed `Authorization: ...` header
+///   values, written via `crater.setOriginAuthorization` and attached
+///   to outbound requests when the caller has not already supplied an
+///   `Authorization` header. Used for Bearer-style tokens.
+///
+/// - `origin_credentials`: raw username/password pairs, written via
+///   `crater.setOriginCredentials` and used by the fetch shim's 401
+///   Digest auto-retry path to compute a Digest response from the
+///   challenge the server returned. Never sent unless a 401 challenge
+///   arrives.
+pub(all) struct AuthState {
+  mut origin_headers : Map[String, String]
+  mut origin_credentials : Map[String, OriginCredentials]
+}
+
+///|
+/// Show impl deliberately redacts header values AND credentials; only
+/// origins are rendered. Prevents secret leaks via panic stack traces or
 /// structural debugging.
 pub impl Show for AuthState with output(self, logger) {
-  logger.write_string("AuthState{")
+  logger.write_string("AuthState{headers=[")
   let origins = self.list_origins()
   for i = 0; i < origins.length(); i = i + 1 {
     if i > 0 {
@@ -21,12 +41,24 @@ pub impl Show for AuthState with output(self, logger) {
     logger.write_string(origins[i])
     logger.write_string(": <redacted>")
   }
-  logger.write_string("}")
+  logger.write_string("], credentials=[")
+  let cred_origins = self.list_credential_origins()
+  for i = 0; i < cred_origins.length(); i = i + 1 {
+    if i > 0 {
+      logger.write_string(", ")
+    }
+    logger.write_string(cred_origins[i])
+    logger.write_string(": <redacted>")
+  }
+  logger.write_string("]}")
 }
 
 ///|
 pub fn AuthState::default() -> AuthState {
-  AuthState::{ origin_headers: Map([], capacity=0) }
+  AuthState::{
+    origin_headers: Map([], capacity=0),
+    origin_credentials: Map([], capacity=0),
+  }
 }
 
 ///|
@@ -58,6 +90,42 @@ pub fn AuthState::header_for_origin(
 pub fn AuthState::list_origins(self : AuthState) -> Array[String] {
   let result = []
   for origin, _ in self.origin_headers {
+    result.push(origin)
+  }
+  result.sort()
+  result
+}
+
+///|
+pub fn AuthState::set_origin_credentials(
+  self : AuthState,
+  origin : String,
+  username : String,
+  password : String,
+) -> Unit {
+  self.origin_credentials[origin] = { username, password }
+}
+
+///|
+pub fn AuthState::clear_origin_credentials(
+  self : AuthState,
+  origin : String,
+) -> Unit {
+  self.origin_credentials.remove(origin)
+}
+
+///|
+pub fn AuthState::credentials_for_origin(
+  self : AuthState,
+  origin : String,
+) -> OriginCredentials? {
+  self.origin_credentials.get(origin)
+}
+
+///|
+pub fn AuthState::list_credential_origins(self : AuthState) -> Array[String] {
+  let result = []
+  for origin, _ in self.origin_credentials {
     result.push(origin)
   }
   result.sort()

--- a/http/profile/pkg.generated.mbti
+++ b/http/profile/pkg.generated.mbti
@@ -14,13 +14,23 @@ import {
 // Types and methods
 pub(all) struct AuthState {
   mut origin_headers : Map[String, String]
+  mut origin_credentials : Map[String, OriginCredentials]
 }
+pub fn AuthState::clear_origin_credentials(Self, String) -> Unit
 pub fn AuthState::clear_origin_header(Self, String) -> Unit
+pub fn AuthState::credentials_for_origin(Self, String) -> OriginCredentials?
 pub fn AuthState::default() -> Self
 pub fn AuthState::header_for_origin(Self, String) -> String?
+pub fn AuthState::list_credential_origins(Self) -> Array[String]
 pub fn AuthState::list_origins(Self) -> Array[String]
+pub fn AuthState::set_origin_credentials(Self, String, String, String) -> Unit
 pub fn AuthState::set_origin_header(Self, String, String) -> Unit
 pub impl Show for AuthState
+
+pub(all) struct OriginCredentials {
+  username : String
+  password : String
+}
 
 pub(all) struct Profile {
   mut user_agent : String?

--- a/http/profile/profile_wbtest.mbt
+++ b/http/profile/profile_wbtest.mbt
@@ -4,7 +4,7 @@ test "AuthState::default is empty" {
   inspect(
     state,
     content=(
-      #|AuthState{}
+      #|AuthState{headers=[], credentials=[]}
     ),
   )
 }

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -954,6 +954,17 @@ scenarios {
     reviewStatus = "approved"
     contributes { "goal.protocol-compat"; "goal.dom-compat" }
   }
+  // -- Protocol: BiDi origin-credentials + Digest auto-retry (#173) ----------
+  new {
+    id = "protocol.bidi-origin-credentials-injection"
+    name = "BiDi clients can register per-origin credentials for HTTP Digest auto-retry"
+    description =
+      "Three BiDi extension commands mirror the Authorization-injection surface for username/password pairs: crater.setOriginCredentials sets, crater.clearOriginCredentials removes, crater.listOriginCredentials returns the set of registered origins (credential values intentionally NOT exposed). The runtime fetch shim's response handler watches for 401 responses whose WWW-Authenticate header begins with `Digest `; when registered credentials exist for the request's origin AND no Authorization was already attached, the shim parses the challenge per RFC 7616 §3.4, computes the response (MD5 / SHA-256 supported, qop=auth and RFC 2069 no-qop forms), and retries the request once with `Authorization: Digest ...`. The retry is one-shot — a second 401 surfaces verbatim. Caller-wins policy still applies: a page-supplied Authorization (or one attached by crater.setOriginAuthorization) bypasses the Digest path entirely. Origin normalization, value redaction in Show, and absence from list responses match the Authorization surface. See GitHub issue #173. Source: TODO follow-up after PR #172."
+    tags { "bidi"; "auth"; "digest"; "runtime"; "protocol" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.protocol-compat" }
+  }
   // -- Protocol: BiDi network.continueWithAuth + addIntercept spec names ----
   new {
     id = "protocol.bidi-network-continue-with-auth"

--- a/tests/auth-flow-via-bidi.test.ts
+++ b/tests/auth-flow-via-bidi.test.ts
@@ -33,6 +33,8 @@
 
 import { expect, test } from "@playwright/test";
 import {
+  DIGEST_PASSWORD,
+  DIGEST_USERNAME,
   REFRESHED_ACCESS_TOKEN,
   REFRESH_TOKEN,
   startAuthServer,
@@ -928,6 +930,191 @@ test.describe("auth flow via BiDi (OAuth refresh-token flow)", () => {
       } catch {
         // ignore
       }
+      try {
+        await session.script.evaluate({
+          expression: `globalThis.__setRequestSandbox({ mode: 'same-origin' }); null`,
+          awaitPromise: false,
+        });
+      } catch {
+        // ignore
+      }
+      await session.end();
+      await fixture.stop();
+      await fixture.apiStop();
+    }
+  });
+});
+
+test.describe("auth flow via BiDi (HTTP Digest auto-retry)", () => {
+  test("crater.setOriginCredentials drives a 401 Digest retry to 200", async () => {
+    // End-to-end Digest auto-retry: register credentials via the new
+    // crater.setOriginCredentials BiDi command, fetch /digest/protected
+    // from inside the BiDi runtime, and assert the response was 200 —
+    // proving the shim parsed the challenge, computed the response, and
+    // retried the request with Authorization: Digest attached, all
+    // without the page touching the credentials.
+    const fixture = await startAuthServer();
+    const session = await connectCraterBidi();
+    try {
+      const rememberResp = await session.raw.send(
+        "script.rememberSyntheticLocationHref",
+        { context: session.contextId, href: `${fixture.url}/login` },
+      );
+      expect(
+        rememberResp.type,
+        `rememberSyntheticLocationHref: ${rememberResp.error ?? rememberResp.message}`,
+      ).toBe("success");
+
+      const setCredsResp = await session.raw.send(
+        "crater.setOriginCredentials",
+        {
+          origin: fixture.apiUrl,
+          username: DIGEST_USERNAME,
+          password: DIGEST_PASSWORD,
+          context: session.contextId,
+        },
+      );
+      expect(
+        setCredsResp.type,
+        `crater.setOriginCredentials: ${setCredsResp.error ?? setCredsResp.message}`,
+      ).toBe("success");
+
+      // crater.listOriginCredentials must surface the registered origin
+      // without exposing the credential values.
+      const listResp = await session.raw.send(
+        "crater.listOriginCredentials",
+        { context: session.contextId },
+      );
+      expect(listResp.type).toBe("success");
+      const listed = (listResp.result as { origins?: Array<{ origin: string }> }).origins ?? [];
+      expect(listed.some(o => o.origin === fixture.apiUrl)).toBe(true);
+      const listedJson = JSON.stringify(listed);
+      expect(listedJson).not.toContain(DIGEST_USERNAME);
+      expect(listedJson).not.toContain(DIGEST_PASSWORD);
+
+      await session.script.evaluate({
+        expression: `globalThis.__setRequestSandbox({ mode: 'open' }); null`,
+        awaitPromise: false,
+      });
+
+      const digestJson = await session.script.evaluate<string>({
+        expression: `(async () => {
+          const r = await fetch(${JSON.stringify(`${fixture.apiUrl}/digest/protected`)});
+          const body = await r.text();
+          return JSON.stringify({ status: r.status, body });
+        })()`,
+        awaitPromise: true,
+      });
+      const digest = JSON.parse(digestJson) as { status: number; body: string };
+      expect(
+        digest.status,
+        `digest response: ${JSON.stringify(digest)}`,
+      ).toBe(200);
+      const decoded = JSON.parse(digest.body) as { user: string; digest: boolean };
+      expect(decoded).toEqual({ user: DIGEST_USERNAME, digest: true });
+    } finally {
+      try {
+        await session.script.evaluate({
+          expression: `globalThis.__setRequestSandbox({ mode: 'same-origin' }); null`,
+          awaitPromise: false,
+        });
+      } catch {
+        // ignore
+      }
+      await session.end();
+      await fixture.stop();
+      await fixture.apiStop();
+    }
+  });
+
+  test("missing credentials surface the raw 401 — no infinite retry", async () => {
+    // Negative path: without crater.setOriginCredentials registered for
+    // the api origin, the shim must NOT silently absorb the 401. The
+    // page-side fetch sees status=401 just like any other endpoint —
+    // confirms the retry path is gated on registered credentials and
+    // doesn't loop or hang when none exist.
+    const fixture = await startAuthServer();
+    const session = await connectCraterBidi();
+    try {
+      const rememberResp = await session.raw.send(
+        "script.rememberSyntheticLocationHref",
+        { context: session.contextId, href: `${fixture.url}/login` },
+      );
+      expect(rememberResp.type).toBe("success");
+
+      await session.script.evaluate({
+        expression: `globalThis.__setRequestSandbox({ mode: 'open' }); null`,
+        awaitPromise: false,
+      });
+
+      const raw = await session.script.evaluate<string>({
+        expression: `(async () => {
+          const r = await fetch(${JSON.stringify(`${fixture.apiUrl}/digest/protected`)});
+          return JSON.stringify({ status: r.status });
+        })()`,
+        awaitPromise: true,
+      });
+      const parsed = JSON.parse(raw) as { status: number };
+      expect(parsed.status).toBe(401);
+    } finally {
+      try {
+        await session.script.evaluate({
+          expression: `globalThis.__setRequestSandbox({ mode: 'same-origin' }); null`,
+          awaitPromise: false,
+        });
+      } catch {
+        // ignore
+      }
+      await session.end();
+      await fixture.stop();
+      await fixture.apiStop();
+    }
+  });
+
+  test("caller-supplied Authorization wins over registered Digest credentials", async () => {
+    // If the page sets its own Authorization header, the shim must NOT
+    // strip it and step in with the registered Digest credentials. A
+    // wrong page-supplied Authorization should surface a 401 verbatim —
+    // proving the credentials path is gated behind the no-Authorization
+    // precondition, matching the policy used for crater.setOriginAuthorization.
+    const fixture = await startAuthServer();
+    const session = await connectCraterBidi();
+    try {
+      const rememberResp = await session.raw.send(
+        "script.rememberSyntheticLocationHref",
+        { context: session.contextId, href: `${fixture.url}/login` },
+      );
+      expect(rememberResp.type).toBe("success");
+
+      const setCredsResp = await session.raw.send(
+        "crater.setOriginCredentials",
+        {
+          origin: fixture.apiUrl,
+          username: DIGEST_USERNAME,
+          password: DIGEST_PASSWORD,
+          context: session.contextId,
+        },
+      );
+      expect(setCredsResp.type).toBe("success");
+
+      await session.script.evaluate({
+        expression: `globalThis.__setRequestSandbox({ mode: 'open' }); null`,
+        awaitPromise: false,
+      });
+
+      const raw = await session.script.evaluate<string>({
+        expression: `(async () => {
+          const r = await fetch(${JSON.stringify(`${fixture.apiUrl}/digest/protected`)}, {
+            // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
+            headers: { Authorization: 'Bearer wrong-i-want-the-401' },
+          });
+          return JSON.stringify({ status: r.status });
+        })()`,
+        awaitPromise: true,
+      });
+      const parsed = JSON.parse(raw) as { status: number };
+      expect(parsed.status).toBe(401);
+    } finally {
       try {
         await session.script.evaluate({
           expression: `globalThis.__setRequestSandbox({ mode: 'same-origin' }); null`,

--- a/webdriver/webdriver/bidi_authorization.mbt
+++ b/webdriver/webdriver/bidi_authorization.mbt
@@ -295,6 +295,18 @@ fn BidiProtocol::dispatch_crater(
       self.handle_crater_list_origin_authorizations(request.id, request.params)
       Ok(())
     }
+    "setOriginCredentials" => {
+      self.handle_crater_set_origin_credentials(request.id, request.params)
+      Ok(())
+    }
+    "clearOriginCredentials" => {
+      self.handle_crater_clear_origin_credentials(request.id, request.params)
+      Ok(())
+    }
+    "listOriginCredentials" => {
+      self.handle_crater_list_origin_credentials(request.id, request.params)
+      Ok(())
+    }
     _ => {
       self.send_error(
         request.id,

--- a/webdriver/webdriver/bidi_origin_credentials.mbt
+++ b/webdriver/webdriver/bidi_origin_credentials.mbt
@@ -1,0 +1,228 @@
+///|
+/// Maximum length in bytes for stored credential fields. RFC 7617 / 7616
+/// don't impose a fixed limit, but capping at 1 KB each prevents a
+/// malicious or accidental write from filling the per-session profile.
+const CREDENTIAL_FIELD_LIMIT : Int = 1024
+
+///|
+/// Validate a candidate credential string (username or password).
+/// Reject empty, oversized, or values containing control characters /
+/// ANSI escape sequences. Same rules as `validate_header_value` minus
+/// the tab allowance — credentials shouldn't contain control whitespace.
+fn validate_credential_field(
+  value : String,
+  field_name : String,
+) -> Result[Unit, String] {
+  if value.length() == 0 {
+    return Err(field_name + " must not be empty")
+  }
+  if value.length() > CREDENTIAL_FIELD_LIMIT {
+    return Err(field_name + " exceeds 1KB limit")
+  }
+  let chars = value.to_array()
+  for i = 0; i < chars.length(); i = i + 1 {
+    let code = chars[i].to_int()
+    if code == 0x1b {
+      return Err(field_name + " must not contain ANSI escape sequences")
+    }
+    if code < 0x20 {
+      return Err(field_name + " must not contain control characters")
+    }
+  }
+  Ok(())
+}
+
+///|
+/// Handle `crater.setOriginCredentials`. Persists a username/password
+/// pair on the per-session profile under a normalized origin key.
+/// Mirror of `handle_crater_set_origin_authorization`; credentials are
+/// only consumed by the runtime fetch shim's 401 Digest auto-retry path,
+/// never sent unsolicited.
+fn BidiProtocol::handle_crater_set_origin_credentials(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let map = match params {
+    Some(Object(m)) => m
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "params must be an object",
+      )
+      return
+    }
+  }
+  let raw_origin = match map.get("origin") {
+    Some(String(o)) => o
+    _ => {
+      self.send_error(request_id, "invalid argument", "origin must be a string")
+      return
+    }
+  }
+  let username = match map.get("username") {
+    Some(String(v)) => v
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "username must be a string",
+      )
+      return
+    }
+  }
+  let password = match map.get("password") {
+    Some(String(v)) => v
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "password must be a string",
+      )
+      return
+    }
+  }
+  let normalized = match normalize_origin(raw_origin) {
+    Ok(o) => o
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  match validate_credential_field(username, "username") {
+    Ok(_) => ()
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  match validate_credential_field(password, "password") {
+    Ok(_) => ()
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  let ctx_id = self.resolve_authorization_context(map, request_id)
+  guard ctx_id is Some(ctx) else { return }
+  let profile = match self.profile_for_session(ctx) {
+    Some(p) => p
+    None => {
+      self.send_error(request_id, "no such frame", "Unknown context: " + ctx)
+      return
+    }
+  }
+  profile.auth_state.set_origin_credentials(normalized, username, password)
+  self.push_credentials_snapshot(ctx)
+  self.send_success(request_id, Some(make_object({})))
+}
+
+///|
+/// Handle `crater.clearOriginCredentials`. Removes any stored
+/// credentials for the normalized origin from the per-session profile.
+fn BidiProtocol::handle_crater_clear_origin_credentials(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let map = match params {
+    Some(Object(m)) => m
+    _ => {
+      self.send_error(
+        request_id, "invalid argument", "params must be an object",
+      )
+      return
+    }
+  }
+  let raw_origin = match map.get("origin") {
+    Some(String(o)) => o
+    _ => {
+      self.send_error(request_id, "invalid argument", "origin must be a string")
+      return
+    }
+  }
+  let normalized = match normalize_origin(raw_origin) {
+    Ok(o) => o
+    Err(reason) => {
+      self.send_error(request_id, "invalid argument", reason)
+      return
+    }
+  }
+  let ctx_id = self.resolve_authorization_context(map, request_id)
+  guard ctx_id is Some(ctx) else { return }
+  let profile = match self.profile_for_session(ctx) {
+    Some(p) => p
+    None => {
+      self.send_error(request_id, "no such frame", "Unknown context: " + ctx)
+      return
+    }
+  }
+  profile.auth_state.clear_origin_credentials(normalized)
+  self.push_credentials_snapshot(ctx)
+  self.send_success(request_id, Some(make_object({})))
+}
+
+///|
+/// Handle `crater.listOriginCredentials`. Returns the set of registered
+/// origins without exposing any username or password.
+fn BidiProtocol::handle_crater_list_origin_credentials(
+  self : BidiProtocol,
+  request_id : Int,
+  params : Json?,
+) -> Unit {
+  let map : Map[String, Json] = match params {
+    Some(Object(m)) => m
+    _ => Map([], capacity=0)
+  }
+  let ctx_id = self.resolve_authorization_context(map, request_id)
+  guard ctx_id is Some(ctx) else { return }
+  let profile = match self.profile_for_session(ctx) {
+    Some(p) => p
+    None => {
+      self.send_error(request_id, "no such frame", "Unknown context: " + ctx)
+      return
+    }
+  }
+  let origins_json : Array[Json] = []
+  for origin in profile.auth_state.list_credential_origins() {
+    origins_json.push(make_object({ "origin": Json::string(origin) }))
+  }
+  self.send_success(
+    request_id,
+    Some(make_object({ "origins": Json::array(origins_json) })),
+  )
+}
+
+///|
+/// Serialize the partition's origin_credentials as a JSON object
+/// suitable for pushing into globalThis.__bidiContextCredentials[ctxId].
+/// Credential values only cross the JS bridge — the WebDriver-facing
+/// surface (list / events) never serializes them.
+fn BidiProtocol::serialize_credentials_snapshot_for_runtime(
+  self : BidiProtocol,
+  ctx_id : String,
+) -> String {
+  match self.profile_for_session(ctx_id) {
+    Some(profile) => {
+      let entries : Map[String, Json] = Map([], capacity=0)
+      for origin in profile.auth_state.list_credential_origins() {
+        match profile.auth_state.credentials_for_origin(origin) {
+          Some(creds) =>
+            entries[origin] = make_object({
+              "username": Json::string(creds.username),
+              "password": Json::string(creds.password),
+            })
+          None => ()
+        }
+      }
+      make_object(entries).stringify()
+    }
+    None => "{}"
+  }
+}
+
+///|
+/// Push the per-context credentials snapshot to the JS runtime so the
+/// fetch shim's Digest auto-retry can resolve username/password by origin.
+fn BidiProtocol::push_credentials_snapshot(
+  self : BidiProtocol,
+  ctx_id : String,
+) -> Unit {
+  let snapshot = self.serialize_credentials_snapshot_for_runtime(ctx_id)
+  set_runtime_context_credentials(ctx_id, snapshot)
+}

--- a/webdriver/webdriver/bidi_origin_credentials_wbtest.mbt
+++ b/webdriver/webdriver/bidi_origin_credentials_wbtest.mbt
@@ -1,0 +1,171 @@
+///|
+/// Verifies that `crater.setOriginCredentials` stores a username/password
+/// pair on the per-session profile's AuthState under the requested origin.
+test "crater.setOriginCredentials stores per-origin credentials" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginCredentials\",\"params\":{\"origin\":\"https://api.example.com\",\"username\":\"alice\",\"password\":\"wonderland\"}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"type\":\"success\""))
+  let profile = proto.profile_for_session("session-1").unwrap()
+  let creds = profile.auth_state.credentials_for_origin(
+    "https://api.example.com",
+  )
+  inspect(creds is Some(_), content="true")
+  match creds {
+    Some(c) => {
+      assert_eq(c.username, "alice")
+      assert_eq(c.password, "wonderland")
+    }
+    None => assert_false(true)
+  }
+}
+
+///|
+/// Origin is normalized before storage: uppercase host lowercased,
+/// default port stripped. Mirror of the equivalent Authorization test.
+test "crater.setOriginCredentials normalizes origin" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginCredentials\",\"params\":{\"origin\":\"https://Example.COM:443\",\"username\":\"u\",\"password\":\"p\"}}",
+  )
+  ignore(proto.take_messages())
+  let profile = proto.profile_for_session("session-1").unwrap()
+  inspect(
+    profile.auth_state.credentials_for_origin("https://example.com") is Some(_),
+    content="true",
+  )
+  inspect(
+    profile.auth_state.credentials_for_origin("https://Example.COM:443")
+    is Some(_),
+    content="false",
+  )
+}
+
+///|
+/// Missing username produces `invalid argument` with a message naming
+/// the offending field.
+test "crater.setOriginCredentials rejects missing username" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginCredentials\",\"params\":{\"origin\":\"https://api.example.com\",\"password\":\"p\"}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"error\":\"invalid argument\""))
+  assert_true(json.contains("username"))
+}
+
+///|
+/// Missing password produces `invalid argument` with a message naming
+/// the offending field.
+test "crater.setOriginCredentials rejects missing password" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginCredentials\",\"params\":{\"origin\":\"https://api.example.com\",\"username\":\"u\"}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"error\":\"invalid argument\""))
+  assert_true(json.contains("password"))
+}
+
+///|
+/// Control characters in credentials are rejected — same hardening as
+/// the Authorization path, prevents header / log injection at use sites.
+test "crater.setOriginCredentials rejects control characters in password" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginCredentials\",\"params\":{\"origin\":\"https://api.example.com\",\"username\":\"u\",\"password\":\"p\\nLog-Forge: evil\"}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"error\":\"invalid argument\""))
+  assert_true(json.contains("control"))
+}
+
+///|
+/// `crater.clearOriginCredentials` removes a previously-stored entry.
+test "crater.clearOriginCredentials removes the per-origin entry" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginCredentials\",\"params\":{\"origin\":\"https://api.example.com\",\"username\":\"u\",\"password\":\"p\"}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"crater.clearOriginCredentials\",\"params\":{\"origin\":\"https://api.example.com\"}}",
+  )
+  ignore(proto.take_messages())
+  let profile = proto.profile_for_session("session-1").unwrap()
+  inspect(
+    profile.auth_state.credentials_for_origin("https://api.example.com")
+    is Some(_),
+    content="false",
+  )
+}
+
+///|
+/// `crater.listOriginCredentials` returns the registered origins WITHOUT
+/// exposing any username/password. Defends against an attacker WebDriver
+/// client (or a hijacked transport) introspecting the registered set.
+test "crater.listOriginCredentials returns origins, never credentials" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"crater.setOriginCredentials\",\"params\":{\"origin\":\"https://api.example.com\",\"username\":\"alice\",\"password\":\"wonderland\"}}",
+  )
+  ignore(proto.take_messages())
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"crater.listOriginCredentials\",\"params\":{}}",
+  )
+  let msgs = proto.take_messages()
+  let json = msgs[0].to_json()
+  assert_true(json.contains("\"type\":\"success\""))
+  assert_true(json.contains("https://api.example.com"))
+  // The username and password values must NOT appear in the response.
+  assert_false(json.contains("alice"))
+  assert_false(json.contains("wonderland"))
+}
+
+///|
+/// AuthState Show impl redacts both stored headers AND stored credentials,
+/// so panic stack traces / structural debug output never leak either.
+test "AuthState Show redacts credentials" {
+  let state = @browser_http.AuthState::default()
+  state.set_origin_credentials("https://api.example.com", "alice", "wonderland")
+  inspect(
+    state,
+    content=(
+      #|AuthState{headers=[], credentials=[https://api.example.com: <redacted>]}
+    ),
+  )
+}

--- a/webdriver/webdriver/bidi_protocol_context_lifecycle.mbt
+++ b/webdriver/webdriver/bidi_protocol_context_lifecycle.mbt
@@ -55,6 +55,13 @@ fn BidiProtocol::apply_effective_viewport_to_runtime_context(
   // protocol.bidi-origin-authorization-injection.
   let auth_json = self.serialize_auth_snapshot_for_runtime(logical_ctx_id)
   set_runtime_context_authorization(runtime_ctx_id, auth_json)
+  // Push the partition credentials snapshot so the runtime fetch shim's
+  // 401 Digest auto-retry path can resolve username/password by origin.
+  // Resolves protocol.bidi-origin-credentials-injection (#173).
+  let creds_json = self.serialize_credentials_snapshot_for_runtime(
+    logical_ctx_id,
+  )
+  set_runtime_context_credentials(runtime_ctx_id, creds_json)
 }
 
 ///|

--- a/webdriver/webdriver/bidi_runtime_context.mbt
+++ b/webdriver/webdriver/bidi_runtime_context.mbt
@@ -1834,3 +1834,52 @@ fn set_runtime_context_authorization(
 ) -> Unit {
   js_set_runtime_context_authorization(ctx_id, auth_json)
 }
+
+///|
+/// Push the per-context Digest credentials snapshot into the JS realm.
+/// The snapshot shape is `{ origin: { username, password } }`. Consumed
+/// by the fetch shim's 401 Digest auto-retry path via the auto-installed
+/// `globalThis.__bidiResolveCredentials(url)` helper.
+///
+/// Credentials are passed by-value into the JS realm — there is no
+/// indirection that would let the page read them ambient-style. The
+/// runtime-side helper only returns the matching entry for the request's
+/// origin AND only inside the retry path that already has a Digest
+/// challenge in hand, so an attacker page on a different origin can't
+/// silently extract a stored credential by issuing fetches.
+pub extern "js" fn js_set_runtime_context_credentials(
+  ctx_id : String,
+  creds_json : String,
+) -> Unit =
+  #| (ctxId, credsJson) => {
+  #|   if (!globalThis.__bidiContextCredentials) globalThis.__bidiContextCredentials = {};
+  #|   try {
+  #|     globalThis.__bidiContextCredentials[ctxId] = JSON.parse(credsJson);
+  #|   } catch (_e) {
+  #|     globalThis.__bidiContextCredentials[ctxId] = {};
+  #|   }
+  #|   if (typeof globalThis.__bidiResolveCredentials !== 'function') {
+  #|     globalThis.__bidiResolveCredentials = function(url) {
+  #|       const ctx = String(globalThis.__bidiCurrentContext || 'default-context');
+  #|       const map = (globalThis.__bidiContextCredentials || {})[ctx] || {};
+  #|       try {
+  #|         const u = new URL(url);
+  #|         let origin = u.protocol + '//' + u.hostname;
+  #|         if (
+  #|           (u.protocol === 'http:'  && u.port && u.port !== '80') ||
+  #|           (u.protocol === 'https:' && u.port && u.port !== '443')
+  #|         ) origin += ':' + u.port;
+  #|         return map[origin] || null;
+  #|       } catch (_e) { return null; }
+  #|     };
+  #|   }
+  #| }
+
+///|
+/// Push the per-context credentials snapshot for `ctx_id` into the JS realm.
+fn set_runtime_context_credentials(
+  ctx_id : String,
+  creds_json : String,
+) -> Unit {
+  js_set_runtime_context_credentials(ctx_id, creds_json)
+}

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -3407,6 +3407,97 @@ extern "js" fn js_evaluate_expression(
   #|         }
   #|         return true;
   #|       };
+  #|       // ---------------------------------------------------------------
+  #|       // RFC 7616 HTTP Digest support.
+  #|       //
+  #|       // When a 401 response carries `WWW-Authenticate: Digest ...` and
+  #|       // credentials are registered for the request's origin via
+  #|       // `crater.setOriginCredentials`, the shim parses the challenge,
+  #|       // computes a response per RFC 7616 §3.4.1, and retries the
+  #|       // request once with `Authorization: Digest ...` attached. The
+  #|       // retry is one-shot — a second 401 surfaces verbatim to the
+  #|       // caller, no looping.
+  #|       //
+  #|       // Hash primitives use Node's `node:crypto` via `require()` so
+  #|       // MD5 (RFC 7616 mandatory baseline) is available — Web Crypto's
+  #|       // SubtleCrypto omits MD5 on purpose.
+  #|       // ---------------------------------------------------------------
+  #|       const digestHashHex = (algorithm, input) => {
+  #|         const algoUpper = String(algorithm || 'MD5').toUpperCase().replace(/-SESS$/, '');
+  #|         const nodeAlgo = algoUpper === 'SHA-256' || algoUpper === 'SHA256' ? 'sha256' : 'md5';
+  #|         return require('node:crypto').createHash(nodeAlgo).update(input).digest('hex');
+  #|       };
+  #|       const parseDigestChallengeHeader = (header) => {
+  #|         if (!header || !header.startsWith('Digest ')) return null;
+  #|         const params = header.slice('Digest '.length).trim();
+  #|         const out = {};
+  #|         let i = 0;
+  #|         while (i < params.length) {
+  #|           while (i < params.length && /[\s,]/.test(params[i])) i++;
+  #|           const nameStart = i;
+  #|           while (i < params.length && params[i] !== '=') i++;
+  #|           if (i >= params.length) break;
+  #|           const name = params.slice(nameStart, i).trim();
+  #|           i++; // consume '='
+  #|           let value;
+  #|           if (params[i] === '"') {
+  #|             i++;
+  #|             const valStart = i;
+  #|             while (i < params.length && params[i] !== '"') {
+  #|               if (params[i] === '\\' && i + 1 < params.length) i += 2;
+  #|               else i++;
+  #|             }
+  #|             value = params.slice(valStart, i).replace(/\\(.)/g, '$1');
+  #|             if (i < params.length) i++;
+  #|           } else {
+  #|             const valStart = i;
+  #|             while (i < params.length && params[i] !== ',') i++;
+  #|             value = params.slice(valStart, i).trim();
+  #|           }
+  #|           out[name.toLowerCase()] = value;
+  #|         }
+  #|         return out;
+  #|       };
+  #|       const escapeDigestQuoted = (v) => String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  #|       const buildDigestAuthHeader = (creds, challenge, method, uri) => {
+  #|         const algorithm = challenge.algorithm || 'MD5';
+  #|         const algoUpper = String(algorithm).toUpperCase().replace(/-SESS$/, '');
+  #|         if (algoUpper !== 'MD5' && algoUpper !== 'SHA-256' && algoUpper !== 'SHA256') return null;
+  #|         const qopList = challenge.qop ? challenge.qop.split(',').map(s => s.trim()) : [];
+  #|         const qop = qopList.includes('auth') ? 'auth' : (qopList.length === 0 ? '' : null);
+  #|         if (qop === null) return null;
+  #|         const ha1 = digestHashHex(algorithm, creds.username + ':' + challenge.realm + ':' + creds.password);
+  #|         const ha2 = digestHashHex(algorithm, method + ':' + uri);
+  #|         let response;
+  #|         let nc;
+  #|         let cnonce;
+  #|         if (qop) {
+  #|           nc = '00000001';
+  #|           // 16 hex chars of best-effort entropy for cnonce. Random.toString
+  #|           // is fine here because cnonce only needs to be unpredictable to
+  #|           // the SERVER, not cryptographically random — its job is to keep
+  #|           // the client side from being pinned by a chosen-nonce attack.
+  #|           cnonce = Math.random().toString(16).slice(2).padEnd(16, '0').slice(0, 16);
+  #|           response = digestHashHex(algorithm, ha1 + ':' + challenge.nonce + ':' + nc + ':' + cnonce + ':' + qop + ':' + ha2);
+  #|         } else {
+  #|           response = digestHashHex(algorithm, ha1 + ':' + challenge.nonce + ':' + ha2);
+  #|         }
+  #|         const parts = [
+  #|           'username="' + escapeDigestQuoted(creds.username) + '"',
+  #|           'realm="' + escapeDigestQuoted(challenge.realm) + '"',
+  #|           'nonce="' + escapeDigestQuoted(challenge.nonce) + '"',
+  #|           'uri="' + escapeDigestQuoted(uri) + '"',
+  #|           'response="' + response + '"',
+  #|           'algorithm=' + algorithm,
+  #|         ];
+  #|         if (qop) {
+  #|           parts.push('qop=' + qop);
+  #|           parts.push('nc=' + nc);
+  #|           parts.push('cnonce="' + cnonce + '"');
+  #|         }
+  #|         if (challenge.opaque) parts.push('opaque="' + escapeDigestQuoted(challenge.opaque) + '"');
+  #|         return 'Digest ' + parts.join(', ');
+  #|       };
   #|       const maybeSendPreflight = async (resolvedUrl, mode, method, headersObj, sourceOrigin, targetOrigin) => {
   #|         if (mode === 'navigate' || mode === 'no-cors') return;
   #|         if (!sourceOrigin || !targetOrigin || sourceOrigin === targetOrigin) return;
@@ -3573,6 +3664,53 @@ extern "js" fn js_evaluate_expression(
   #|             });
   #|           } catch (_e) { /* swallow — never fail a fetch on ingest */ }
   #|         };
+  #|         let digestAttempted = false;
+  #|         const maybeDigestRetry = (response) => {
+  #|           // One-shot: never recurse past a single retry. A persistent
+  #|           // 401 after one attempt surfaces verbatim to the caller.
+  #|           if (digestAttempted) return response;
+  #|           if (!response || response.status !== 401) return response;
+  #|           const wwwAuth = response.headers.get('www-authenticate');
+  #|           if (!wwwAuth || !wwwAuth.startsWith('Digest ')) return response;
+  #|           // Caller-supplied (or __bidiResolveAuth-supplied) Authorization
+  #|           // wins. We only step in when no Authorization was attached.
+  #|           if (headers.has('Authorization')) return response;
+  #|           if (typeof globalThis.__bidiResolveCredentials !== 'function') return response;
+  #|           let creds;
+  #|           try { creds = globalThis.__bidiResolveCredentials(resolvedUrl); } catch (_e) { return response; }
+  #|           if (!creds || !creds.username || !creds.password) return response;
+  #|           const challenge = parseDigestChallengeHeader(wwwAuth);
+  #|           if (!challenge || !challenge.realm || !challenge.nonce) return response;
+  #|           const u = new URL(resolvedUrl);
+  #|           const uri = u.pathname + (u.search || '');
+  #|           const retryAuth = buildDigestAuthHeader(creds, challenge, methodForPreflight, uri);
+  #|           if (!retryAuth) return response;
+  #|           const retryHeaders = new Headers(headers);
+  #|           retryHeaders.set('Authorization', retryAuth);
+  #|           const retryOptions = { ...reqOptions, headers: retryHeaders };
+  #|           digestAttempted = true;
+  #|           // Fresh activeRequests tracker for the retry — finish() for
+  #|           // the original 401 already ran by the time we land here.
+  #|           globalThis.__activeNetworkRequests++;
+  #|           notifyNetworkChange();
+  #|           let retryDone = false;
+  #|           const retryFinish = () => {
+  #|             if (retryDone) return;
+  #|             retryDone = true;
+  #|             globalThis.__activeNetworkRequests--;
+  #|             notifyNetworkChange();
+  #|           };
+  #|           return dispatchRaw(resolvedUrl, retryOptions)
+  #|             .then(retryResponse => {
+  #|               captureInboundSetCookies(retryResponse);
+  #|               retryFinish();
+  #|               return retryResponse;
+  #|             })
+  #|             .catch(error => {
+  #|               retryFinish();
+  #|               throw error;
+  #|             });
+  #|         };
   #|         const sendActual = () => dispatchRaw(resolvedUrl, reqOptions)
   #|           .then(response => {
   #|             if (!isNavigation && enforceCors && mode === 'cors' && sourceOrigin && targetOrigin && sourceOrigin !== targetOrigin) {
@@ -3593,6 +3731,7 @@ extern "js" fn js_evaluate_expression(
   #|             finish();
   #|             return response;
   #|           })
+  #|           .then(maybeDigestRetry)
   #|           .catch(error => {
   #|             finish();
   #|             throw error;

--- a/webdriver/webdriver/pkg.generated.mbti
+++ b/webdriver/webdriver/pkg.generated.mbti
@@ -97,6 +97,8 @@ pub fn input_set_pointer_event_properties(Double, Double, Double, Double, Double
 
 pub fn js_set_runtime_context_authorization(String, String) -> Unit
 
+pub fn js_set_runtime_context_credentials(String, String) -> Unit
+
 pub fn navigate_and_send_async(@core.Any, Int, String, String, String) -> Unit
 
 pub fn parse_data_url(String) -> (String, String)?


### PR DESCRIPTION
Closes #173.

## Summary

Last item of the auth scope. Pages running under Crater BiDi can now register per-origin username/password pairs, and a 401 Digest challenge for the same origin is handled transparently by the runtime fetch shim — the page never sees the 401, never touches the credentials, only the post-retry response.

### New BiDi commands

Mirror of the per-origin Authorization API from earlier PRs.

| Command | Behavior |
|---|---|
| \`crater.setOriginCredentials({origin, username, password, context})\` | Store credentials for one origin |
| \`crater.clearOriginCredentials({origin, context})\` | Remove the entry |
| \`crater.listOriginCredentials({context})\` | Return registered origins — values intentionally **not** exposed |

### Runtime fetch shim retry policy

After a response resolves, the shim runs \`maybeDigestRetry\`:

1. one-shot guard (\`digestAttempted\`)
2. \`response.status === 401\`
3. \`WWW-Authenticate\` starts with \`Digest \`
4. **no Authorization already on the request** (caller-wins — page-supplied Authorization OR \`__bidiResolveAuth\` Bearer wins)
5. registered credentials exist for the request's origin
6. challenge has realm + nonce
7. algorithm is in the supported set (MD5 / SHA-256)
8. qop is \`auth\` or empty (RFC 2069 no-qop form)

If all pass, compute response per RFC 7616 §3.4.1 and dispatch the retry once with \`Authorization: Digest ...\`. A second 401 surfaces verbatim — no looping.

MD5 + SHA-256 via Node's \`node:crypto\` (\`require()\` is available in the BiDi JS realm — used elsewhere too). Web Crypto's SubtleCrypto omits MD5 on purpose, so it can't be the primary source for the RFC 7616 baseline.

### Security posture

- Stored credentials are redacted by \`AuthState\`'s \`Show\` impl (won't leak through panic stack traces or debug output).
- \`crater.listOriginCredentials\` returns origins only.
- Username / password are CRLF + control-char + ANSI-escape rejected at the boundary (\`validate_credential_field\`), same hardening as the Authorization header path.
- Caller-wins policy: an existing Authorization header bypasses the Digest path entirely. An attacker page can't strip a stored Bearer by sending a Digest challenge.
- Snapshot only crosses into the JS realm by value via a typed extern; the resolver helper returns only the entry matching the request's origin.

## Test plan

- [x] \`moon test -p mizchi/crater-webdriver-bidi/webdriver --file bidi_origin_credentials_wbtest.mbt\` — 8/8
- [x] \`moon test -p http/profile\` — 12/12 (existing + updated AuthState snapshot)
- [x] \`moon check\` — 0 errors (pre-existing deprecation warnings only)
- [ ] CI runs the new Playwright BiDi e2e cases (\`auth flow via BiDi (HTTP Digest auto-retry)\`)

## Scope notes

- **Persistence**: per-context, same as \`crater.setOriginAuthorization\`. Cleared when the context closes.
- **nc reuse**: not implemented. Every retry computes with \`nc=00000001\` and a fresh \`cnonce\`. A real server cycles nonces fast enough that reuse rarely matters; an optimization for later.
- **\`stale=true\`**: not specially handled. Falls through as a normal 401 — caller would re-issue the request, which re-fires the retry path with the fresh nonce. Worth revisiting if a real server in tests is observed rejecting the first retry due to nonce staleness.