### PR TITLE
Wire @mizchi/utels error tracker into crater playground

### DIFF
--- a/js/playground/main.js
+++ b/js/playground/main.js
@@ -1,3 +1,7 @@
+// Side-effect import: must run before anything else so utels' global
+// error listeners are attached before MoonBit bundle eval can throw.
+import { tracker as utelsTracker } from './utels.js';
+
 // Import Crater layout engine (MoonBit compiled to JS)
 import * as crater from '@crater';
 
@@ -33,6 +37,11 @@ function render() {
   } catch (e) {
     jsonOutput.textContent = 'Error: ' + e.message;
     console.error(e);
+    // Locally-caught errors never reach window.error, so forward them to
+    // utels explicitly. The handler render() wraps is where Crater's
+    // MoonBit-side parse / layout panics surface — exactly the path we
+    // most want issue grouping on.
+    utelsTracker?.captureException(e);
   }
 }
 

--- a/js/playground/package.json
+++ b/js/playground/package.json
@@ -7,6 +7,9 @@
     "preview": "vite preview",
     "build:moonbit": "cd .. && moon build --target js"
   },
+  "dependencies": {
+    "@mizchi/utels": "^0.1.0"
+  },
   "devDependencies": {
     "vite": "^5.0.0"
   }

--- a/js/playground/utels.js
+++ b/js/playground/utels.js
@@ -1,0 +1,49 @@
+// utels error tracker init for the crater playground.
+//
+// Loaded BEFORE any other module imports run (see the side-effect import at
+// the top of main.js) so that early errors during MoonBit bundle eval are
+// captured. The tracker subscribes to `window.error` / `unhandledrejection`
+// internally — once initialized, every uncaught error and rejected promise
+// on the page is reported.
+//
+// Configuration is read from Vite's `import.meta.env`. The endpoint /
+// projectId / publicKey trio is required; if any is missing (local dev
+// with no .env, preview builds, contributor checkouts) the tracker is
+// installed as a no-op so the playground stays runnable without secrets.
+
+import { createBrowserErrorTracker } from "@mizchi/utels/browser";
+
+const env = import.meta.env;
+const endpoint = env.VITE_UTELS_ENDPOINT;
+const projectId = env.VITE_UTELS_PROJECT_ID;
+const publicKey = env.VITE_UTELS_PUBLIC_KEY;
+
+let tracker = null;
+
+if (endpoint && projectId && publicKey) {
+  tracker = createBrowserErrorTracker({
+    endpoint,
+    projectId,
+    publicKey,
+    release: env.VITE_UTELS_RELEASE ?? "local",
+    buildId: env.VITE_UTELS_BUILD_ID ?? "local",
+    sample: {
+      // Conservative defaults — the playground is low-traffic, error
+      // signal is high-value, everything else stays off until a user
+      // opts in by overriding the env at deploy time.
+      session: 1,
+      error: 1,
+      vital: 0,
+      ui: 0,
+      feature: 0,
+    },
+  });
+} else if (env.DEV) {
+  // Loud in dev only — production builds with missing env should fail
+  // silently rather than spam the console for unsuspecting visitors.
+  console.info(
+    "[utels] tracker disabled — set VITE_UTELS_ENDPOINT / VITE_UTELS_PROJECT_ID / VITE_UTELS_PUBLIC_KEY to enable.",
+  );
+}
+
+export { tracker };


### PR DESCRIPTION
## Summary

Single-screen Vite frontend, single entry point. Wires the browser tracker via a side-effect-imported \`utels.js\` so global error listeners attach before any other module — including the MoonBit crater bundle — has a chance to throw.

### Changes

- \`js/playground/package.json\` — adds \`@mizchi/utels: ^0.1.0\`.
- \`js/playground/utels.js\` (new) — reads \`VITE_UTELS_ENDPOINT\` / \`_PROJECT_ID\` / \`_PUBLIC_KEY\` from \`import.meta.env\`. When the trio is unset (local dev with no \`.env\`, contributor checkouts), the tracker is left uninstalled rather than pointed at an unknown endpoint. Optional \`VITE_UTELS_RELEASE\` / \`VITE_UTELS_BUILD_ID\` propagate from CI.
- \`js/playground/main.js\` — imports the named \`tracker\`, forwards \`render()\`'s locally-caught exceptions to \`captureException\` (since locally-caught errors never reach \`window.error\`).

### Config posture

- Browser bundle ships only the \`publicKey\` — gated on origin allowlist server-side per the utels README.
- \`secretKey\` / \`UTELS_UPLOAD_TOKEN\` / \`UTELS_INGEST_TOKEN\` never enter this repo.
- To enable in production: set the three \`VITE_UTELS_*\` vars before \`vite build\` (or in a \`.env.production\` not committed).

### Sample rates

\`session: 1, error: 1, vital: 0, ui: 0, feature: 0\`. Low-traffic playground, error signal is high value, the rest stays off until someone opts in at deploy time.

## Local install note

\`pnpm install\` in \`js/playground/\` is required after merge (or after pull) to materialize the new dep. Auto-mode flagged adding a package I named myself; mizchi to run install locally.

## Test plan

- [ ] \`pnpm -C js/playground install\` then \`pnpm -C js/playground dev\` — confirm console shows the \"tracker disabled\" info line when env vars are absent
- [ ] Set the three \`VITE_UTELS_*\` env vars, repeat — confirm no info line, throw something in render() (e.g. paste invalid HTML), verify the event hits the utels backend