### PR TITLE
Add real impls for IntersectionObserver / ResizeObserver / history / Web Storage

### DIFF
--- a/webdriver/webdriver/bidi_runtime_context.mbt
+++ b/webdriver/webdriver/bidi_runtime_context.mbt
@@ -10,7 +10,7 @@ extern "js" fn reset_runtime_js_state() -> Unit =
   #|       if (typeof globalThis.__bidiSyncWindowPropertiesToGlobal === "function") return;
   #|       const reserved = new Set([
   #|         "window", "self", "parent", "top", "frames",
-  #|         "document", "location", "navigator",
+  #|         "document", "location", "navigator", "history",
   #|         "screen", "matchMedia",
   #|         "innerWidth", "innerHeight", "outerWidth", "outerHeight",
   #|         "devicePixelRatio", "pageXOffset", "pageYOffset",
@@ -25,6 +25,9 @@ extern "js" fn reset_runtime_js_state() -> Unit =
   #|         "CompositionEvent", "CustomEvent", "MessageEvent", "StorageEvent",
   #|         "DragEvent", "ClipboardEvent", "DataTransfer", "DOMParser",
   #|         "DOMException", "Node", "Attr", "Element", "HTMLElement", "Document",
+  #|         // Observer APIs shimmed by bidi_runtime_eval.mbt. Without
+  #|         // these, the per-eval window→globalThis sync would clear them.
+  #|         "IntersectionObserver", "ResizeObserver", "MutationObserver",
   #|       ]);
   #|       globalThis.__bidiSyncWindowPropertiesToGlobal = (win) => {
   #|         const source = win && typeof win === "object" ? win : globalThis.window;

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -265,7 +265,7 @@ extern "js" fn js_evaluate_expression(
   #|     if (typeof globalThis.__bidiSyncWindowPropertiesToGlobal === "function") return;
   #|     const reserved = new Set([
   #|       "window", "self", "parent", "top", "frames",
-  #|       "document", "location", "navigator",
+  #|       "document", "location", "navigator", "history",
   #|       "screen", "matchMedia",
   #|       "innerWidth", "innerHeight", "outerWidth", "outerHeight",
   #|       "devicePixelRatio", "pageXOffset", "pageYOffset",
@@ -280,6 +280,11 @@ extern "js" fn js_evaluate_expression(
   #|       "CompositionEvent", "CustomEvent", "MessageEvent", "StorageEvent",
   #|       "DragEvent", "ClipboardEvent", "DataTransfer", "DOMParser",
   #|       "DOMException", "Node", "Attr", "Element", "HTMLElement", "Document",
+  #|       // Observer APIs shimmed by bidi_runtime_eval.mbt. Without these in
+  #|       // the reserved set, the per-eval window→globalThis sync would
+  #|       // delete them (when window doesn't carry them) right before the
+  #|       // user expression runs.
+  #|       "IntersectionObserver", "ResizeObserver", "MutationObserver",
   #|     ]);
   #|     globalThis.__bidiSyncWindowPropertiesToGlobal = (win) => {
   #|       const source = win && typeof win === "object" ? win : globalThis.window;
@@ -3116,32 +3121,177 @@ extern "js" fn js_evaluate_expression(
   #|         hasBeenActive: false
   #|       }
   #|     };
-  #|     globalThis.history = {
-  #|       length: 1,
-  #|       state: null,
-  #|       pushState: function(state, title, url) { this.state = state; this.length++; },
-  #|       replaceState: function(state, title, url) { this.state = state; },
-  #|       go: function(delta) {},
-  #|       back: function() {},
-  #|       forward: function() {}
+  #|     // History API — pushState / replaceState update location AND
+  #|     // globalThis.__pageUrl so SPA routers can read the new URL through
+  #|     // either surface. back() / forward() / go() walk a real stack and
+  #|     // fire `popstate` with the previously-pushed state, per HTML spec.
+  #|     // The popstate event flows through the same dispatchEvent the rest
+  #|     // of the shim uses, so any registered router listener picks it up.
+  #|     const _updateLocationFromUrl = (rawUrl) => {
+  #|       if (rawUrl === undefined || rawUrl === null) return;
+  #|       let resolved;
+  #|       try {
+  #|         resolved = new URL(String(rawUrl), globalThis.location.href);
+  #|       } catch (_e) { return; }
+  #|       globalThis.location.href = resolved.href;
+  #|       globalThis.location.origin = resolved.origin;
+  #|       globalThis.location.protocol = resolved.protocol;
+  #|       globalThis.location.host = resolved.host;
+  #|       globalThis.location.hostname = resolved.hostname;
+  #|       globalThis.location.port = resolved.port;
+  #|       globalThis.location.pathname = resolved.pathname;
+  #|       globalThis.location.search = resolved.search;
+  #|       globalThis.location.hash = resolved.hash;
+  #|       globalThis.__pageUrl = resolved.href;
   #|     };
-  #|     globalThis.localStorage = {
-  #|       _data: {},
-  #|       getItem: function(key) { return this._data[key] || null; },
-  #|       setItem: function(key, value) { this._data[key] = String(value); },
-  #|       removeItem: function(key) { delete this._data[key]; },
-  #|       clear: function() { this._data = {}; },
-  #|       get length() { return Object.keys(this._data).length; },
-  #|       key: function(n) { return Object.keys(this._data)[n] || null; }
+  #|     globalThis.history = (() => {
+  #|       const stack = [{ state: null, url: null }];
+  #|       let cursor = 0;
+  #|       const dispatchPopState = (state) => {
+  #|         try {
+  #|           const ev = globalThis.__bidiCreateEvent
+  #|             ? globalThis.__bidiCreateEvent("popstate", { bubbles: false, cancelable: false })
+  #|             : new Event("popstate");
+  #|           ev.state = state;
+  #|           globalThis.dispatchEvent(ev);
+  #|         } catch (_e) { /* swallow — popstate dispatch must never fail navigation */ }
+  #|       };
+  #|       return {
+  #|         get length() { return stack.length; },
+  #|         get state() { return stack[cursor].state; },
+  #|         pushState(state, _title, url) {
+  #|           // Spec: truncate any forward entries when a new state is pushed.
+  #|           stack.length = cursor + 1;
+  #|           _updateLocationFromUrl(url);
+  #|           stack.push({ state, url: globalThis.location.href });
+  #|           cursor = stack.length - 1;
+  #|         },
+  #|         replaceState(state, _title, url) {
+  #|           _updateLocationFromUrl(url);
+  #|           stack[cursor] = { state, url: globalThis.location.href };
+  #|         },
+  #|         go(delta) {
+  #|           const target = cursor + ((delta | 0) || 0);
+  #|           if (target < 0 || target >= stack.length) return;
+  #|           cursor = target;
+  #|           const entry = stack[cursor];
+  #|           if (entry.url) _updateLocationFromUrl(entry.url);
+  #|           dispatchPopState(entry.state);
+  #|         },
+  #|         back() { this.go(-1); },
+  #|         forward() { this.go(1); },
+  #|       };
+  #|     })();
+  #|     // localStorage / sessionStorage — single-realm in-memory store
+  #|     // backed by a Map so length / key()/iteration are honest and the
+  #|     // underlying data isn't reachable via a property name like `_data`.
+  #|     // Cross-realm `storage` event isn't fired because the runtime has
+  #|     // exactly one realm; same-realm setItem doesn't fire `storage` per
+  #|     // spec, so callers never observe a missing event.
+  #|     const _makeWebStorage = () => {
+  #|       const data = new Map();
+  #|       return {
+  #|         getItem(key) {
+  #|           const k = String(key);
+  #|           return data.has(k) ? data.get(k) : null;
+  #|         },
+  #|         setItem(key, value) {
+  #|           // Spec: keys and values are stored as DOMStrings. Coerce both
+  #|           // BEFORE the Map write so getItem returns a string consistent
+  #|           // with what the page would see in a real browser.
+  #|           data.set(String(key), String(value));
+  #|         },
+  #|         removeItem(key) { data.delete(String(key)); },
+  #|         clear() { data.clear(); },
+  #|         get length() { return data.size; },
+  #|         key(n) {
+  #|           const idx = Number(n);
+  #|           if (!Number.isFinite(idx) || idx < 0 || idx >= data.size) return null;
+  #|           let i = 0;
+  #|           for (const k of data.keys()) {
+  #|             if (i === idx) return k;
+  #|             i++;
+  #|           }
+  #|           return null;
+  #|         },
+  #|       };
   #|     };
-  #|     globalThis.sessionStorage = {
-  #|       _data: {},
-  #|       getItem: function(key) { return this._data[key] || null; },
-  #|       setItem: function(key, value) { this._data[key] = String(value); },
-  #|       removeItem: function(key) { delete this._data[key]; },
-  #|       clear: function() { this._data = {}; },
-  #|       get length() { return Object.keys(this._data).length; },
-  #|       key: function(n) { return Object.keys(this._data)[n] || null; }
+  #|     globalThis.localStorage = _makeWebStorage();
+  #|     globalThis.sessionStorage = _makeWebStorage();
+  #|     // IntersectionObserver — minimum viable shim for headless / paint-
+  #|     // tree-only execution. On observe(target), enqueues a microtask
+  #|     // that fires the callback with a synthetic "fully intersecting"
+  #|     // entry. This is the right default for test-mode: the most common
+  #|     // consumer pattern is "render content once it scrolls into view";
+  #|     // reporting always-intersecting causes that content to render
+  #|     // eagerly, which is what a test harness wants. A future iteration
+  #|     // can read the paint tree to compute real intersections.
+  #|     globalThis.IntersectionObserver = class IntersectionObserver {
+  #|       constructor(callback, options) {
+  #|         this._callback = typeof callback === 'function' ? callback : () => {};
+  #|         this._options = options || {};
+  #|         this._targets = new Set();
+  #|       }
+  #|       observe(target) {
+  #|         if (!target || this._targets.has(target)) return;
+  #|         this._targets.add(target);
+  #|         const rect = (target.getBoundingClientRect && typeof target.getBoundingClientRect === 'function')
+  #|           ? target.getBoundingClientRect()
+  #|           : { x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 };
+  #|         const entry = {
+  #|           target,
+  #|           isIntersecting: true,
+  #|           intersectionRatio: 1,
+  #|           boundingClientRect: rect,
+  #|           intersectionRect: rect,
+  #|           rootBounds: null,
+  #|           time: typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now(),
+  #|         };
+  #|         const cb = this._callback;
+  #|         const self = this;
+  #|         Promise.resolve().then(() => {
+  #|           try { cb.call(self, [entry], self); } catch (_e) { /* swallow */ }
+  #|         });
+  #|       }
+  #|       unobserve(target) { this._targets.delete(target); }
+  #|       disconnect() { this._targets.clear(); }
+  #|       takeRecords() { return []; }
+  #|     };
+  #|     // ResizeObserver — same shape as IntersectionObserver. observe(t)
+  #|     // schedules a microtask that fires the callback with the target's
+  #|     // current bounding rect as the contentRect / borderBoxSize /
+  #|     // contentBoxSize triple. Crater has no real resize signal in test
+  #|     // mode so the observer fires exactly once per observe() and never
+  #|     // re-fires; UI libs that use ResizeObserver to compute initial
+  #|     // layout (popovers, tooltips, virtualized lists) get their first
+  #|     // measurement and proceed.
+  #|     globalThis.ResizeObserver = class ResizeObserver {
+  #|       constructor(callback) {
+  #|         this._callback = typeof callback === 'function' ? callback : () => {};
+  #|         this._targets = new Set();
+  #|       }
+  #|       observe(target) {
+  #|         if (!target || this._targets.has(target)) return;
+  #|         this._targets.add(target);
+  #|         const rect = (target.getBoundingClientRect && typeof target.getBoundingClientRect === 'function')
+  #|           ? target.getBoundingClientRect()
+  #|           : { width: 0, height: 0, x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0 };
+  #|         const size = { inlineSize: rect.width || 0, blockSize: rect.height || 0 };
+  #|         const entry = {
+  #|           target,
+  #|           contentRect: rect,
+  #|           borderBoxSize: [size],
+  #|           contentBoxSize: [size],
+  #|           devicePixelContentBoxSize: [size],
+  #|         };
+  #|         const cb = this._callback;
+  #|         const self = this;
+  #|         Promise.resolve().then(() => {
+  #|           try { cb.call(self, [entry], self); } catch (_e) { /* swallow */ }
+  #|         });
+  #|       }
+  #|       unobserve(target) { this._targets.delete(target); }
+  #|       disconnect() { this._targets.clear(); }
   #|     };
   #|     globalThis.requestAnimationFrame = function(cb) { return setTimeout(cb, 16); };
   #|     globalThis.cancelAnimationFrame = function(id) { clearTimeout(id); };

--- a/webdriver/webdriver/bidi_runtime_web_apis_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_web_apis_wbtest.mbt
@@ -1,0 +1,184 @@
+///|
+/// Runtime web API shim coverage — locks the behaviour of localStorage,
+/// sessionStorage, history.pushState/replaceState/back, IntersectionObserver,
+/// and ResizeObserver in the BiDi JS realm. These shims are the surface
+/// modern SPA frontends (Preact / React / Lit) expect to be present at
+/// page load; the tests pin the shape so a regression in the shim setup
+/// can't silently re-stub them into uselessness.
+///
+/// Helper notes:
+///
+/// 1. `read_global_string` returns the raw BiDi response JSON, which
+///    JSON-encodes the value (inner `"` -> `\"`). Tests therefore read one
+///    scalar at a time rather than stringifying an object — comparing
+///    `\"id\":42` against `"id":42` via String::contains doesn't match
+///    because of the escape backslash.
+///
+/// 2. The init block in bidi_runtime_eval.mbt is guarded by
+///    `if (!globalThis.document)`, so it runs ONCE per JS realm. Multiple
+///    tests in the same `moon test` invocation share `globalThis.history`,
+///    `globalThis.localStorage`, etc. Tests must not assume "fresh" state
+///    on entry — they reset what they need, or assert deltas (e.g. for
+///    history.length) rather than absolute values.
+
+///|
+test "localStorage round-trips a string value" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "localStorage.clear(); localStorage.setItem('k', 'v'); globalThis.__lsRead = localStorage.getItem('k');",
+  )
+  let resp = read_global_string(proto, 3, "__lsRead")
+  assert_true(resp.contains("\"v\""))
+}
+
+///|
+test "localStorage coerces non-string values to DOMString" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "localStorage.clear(); localStorage.setItem('n', 42); globalThis.__lsRead = localStorage.getItem('n');",
+  )
+  let resp = read_global_string(proto, 3, "__lsRead")
+  // Per spec, the stored value is the string "42", not the number 42.
+  assert_true(resp.contains("\"42\""))
+}
+
+///|
+test "localStorage.getItem returns null for missing keys, including empty-string values" {
+  let proto = make_proto_with_session()
+  // The previous stub `this._data[key] || null` would mis-return null for
+  // an explicitly stored empty string. Lock the corrected behaviour: empty
+  // string is preserved, missing key returns null.
+  run_sync_in_context(
+    proto, 2, "localStorage.clear(); localStorage.setItem('empty', ''); globalThis.__lsEmpty = localStorage.getItem('empty'); globalThis.__lsMissing = String(localStorage.getItem('not-set'));",
+  )
+  let empty = read_global_string(proto, 3, "__lsEmpty")
+  assert_true(empty.contains("\"\""))
+  let missing = read_global_string(proto, 4, "__lsMissing")
+  // Stringifying null gives the literal "null" the response surfaces.
+  assert_true(missing.contains("\"null\""))
+}
+
+///|
+test "localStorage length and key(n) reflect insertion order" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "localStorage.clear(); localStorage.setItem('a','1'); localStorage.setItem('b','2'); localStorage.setItem('c','3'); globalThis.__lsLen = String(localStorage.length); globalThis.__lsKey0 = localStorage.key(0); globalThis.__lsKey2 = localStorage.key(2); globalThis.__lsKeyOob = String(localStorage.key(99));",
+  )
+  let len = read_global_string(proto, 3, "__lsLen")
+  assert_true(len.contains("\"3\""))
+  let key0 = read_global_string(proto, 4, "__lsKey0")
+  assert_true(key0.contains("\"a\""))
+  let key2 = read_global_string(proto, 5, "__lsKey2")
+  assert_true(key2.contains("\"c\""))
+  let oob = read_global_string(proto, 6, "__lsKeyOob")
+  // Out-of-bounds index returns null, not the empty string the old stub
+  // would produce via `[] || null` on undefined.
+  assert_true(oob.contains("\"null\""))
+}
+
+///|
+test "sessionStorage is a separate store from localStorage" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "localStorage.clear(); sessionStorage.clear(); localStorage.setItem('shared','from-local'); sessionStorage.setItem('shared','from-session'); globalThis.__l = localStorage.getItem('shared'); globalThis.__s = sessionStorage.getItem('shared');",
+  )
+  let l = read_global_string(proto, 3, "__l")
+  assert_true(l.contains("\"from-local\""))
+  let s = read_global_string(proto, 4, "__s")
+  assert_true(s.contains("\"from-session\""))
+}
+
+///|
+test "history.pushState updates location.pathname and globalThis.__pageUrl" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.location.href = 'https://example.com/start'; globalThis.__pageUrl = 'https://example.com/start'; history.pushState({ id: 42 }, '', '/new-route?q=1'); globalThis.__path = String(globalThis.location.pathname); globalThis.__search = String(globalThis.location.search); globalThis.__pageUrl2 = String(globalThis.__pageUrl); globalThis.__stateId = String(history.state.id);",
+  )
+  let pathname = read_global_string(proto, 3, "__path")
+  assert_true(pathname.contains("/new-route"))
+  let search = read_global_string(proto, 4, "__search")
+  assert_true(search.contains("?q=1"))
+  let page_url = read_global_string(proto, 5, "__pageUrl2")
+  assert_true(page_url.contains("/new-route"))
+  let state_id = read_global_string(proto, 6, "__stateId")
+  // Reading the scalar id avoids JSON.stringify's quote-escape problem
+  // when comparing through the BiDi response wrapper.
+  assert_true(state_id.contains("\"42\""))
+}
+
+///|
+test "history.replaceState updates location without growing the stack" {
+  let proto = make_proto_with_session()
+  // Assert that the stack length is UNCHANGED by replaceState, regardless
+  // of the absolute starting length (which leaks across tests inside a
+  // single moon test invocation — see header note 2).
+  run_sync_in_context(
+    proto, 2, "globalThis.location.href = 'https://example.com/a'; globalThis.__pageUrl = 'https://example.com/a'; const before = history.length; history.replaceState({ r: 1 }, '', '/replaced'); globalThis.__lenDelta = String(history.length - before); globalThis.__path = String(globalThis.location.pathname);",
+  )
+  let delta = read_global_string(proto, 3, "__lenDelta")
+  // replaceState must NOT push a new entry (spec) — delta should be 0.
+  assert_true(delta.contains("\"0\""))
+  let path_after = read_global_string(proto, 4, "__path")
+  assert_true(path_after.contains("/replaced"))
+}
+
+///|
+async test "history.back() fires popstate with the previous state" {
+  let proto = make_proto_with_session()
+  // The listener-registration global is per-realm and persists across
+  // evaluates; previous tests may have left stale popstate listeners. We
+  // attach our own and check that AT LEAST ONE dispatch matched the state
+  // we pushed — order-independent.
+  run_sync_in_context(
+    proto, 2, "globalThis.location.href = 'https://example.com/'; globalThis.__pageUrl = 'https://example.com/'; globalThis.__popMarker = '<none>'; const stepListener = (ev) => { if (ev && ev.state && ev.state.step) globalThis.__popMarker = String(ev.state.step); }; globalThis.addEventListener('popstate', stepListener); history.pushState({ step: 'one' }, '', '/one'); history.pushState({ step: 'two' }, '', '/two'); history.back(); globalThis.removeEventListener && globalThis.removeEventListener('popstate', stepListener);",
+  )
+  @async.sleep(10)
+  let resp = read_global_string(proto, 4, "__popMarker")
+  // back() lands on the most-recently-pushed prior entry with state {step:'one'}.
+  assert_true(resp.contains("\"one\""))
+}
+
+///|
+async test "IntersectionObserver fires the callback once after observe" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__ioRatio = '-1'; globalThis.__ioTarget = '<none>'; const target = { id: 't', getBoundingClientRect: () => ({ x: 0, y: 0, width: 10, height: 20, top: 0, left: 0, right: 10, bottom: 20 }) }; const io = new IntersectionObserver((entries) => { globalThis.__ioRatio = String(entries[0].intersectionRatio); globalThis.__ioTarget = String(entries[0].target.id); }); io.observe(target);",
+  )
+  @async.sleep(10)
+  let ratio = read_global_string(proto, 3, "__ioRatio")
+  assert_true(ratio.contains("\"1\""))
+  let target = read_global_string(proto, 4, "__ioTarget")
+  assert_true(target.contains("\"t\""))
+}
+
+///|
+async test "IntersectionObserver re-observes after unobserve" {
+  let proto = make_proto_with_session()
+  // unobserve() drops the target from the observer's set. A subsequent
+  // observe() of the same target is treated as a fresh observation and
+  // fires the callback again. Counter is read back as a string-coerced
+  // numeric global.
+  run_sync_in_context(
+    proto, 2, "globalThis.__ioCount = 0; const target = { id: 'd', getBoundingClientRect: () => ({ x: 0, y: 0, width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }) }; const io = new IntersectionObserver(() => { globalThis.__ioCount = globalThis.__ioCount + 1; }); io.observe(target); io.unobserve(target); io.observe(target);",
+  )
+  @async.sleep(10)
+  run_sync_in_context(
+    proto, 3, "globalThis.__ioReport = String(globalThis.__ioCount);",
+  )
+  let resp = read_global_string(proto, 4, "__ioReport")
+  // Two observe() calls with unobserve() in between → both fire. Net: 2.
+  assert_true(resp.contains("\"2\""))
+}
+
+///|
+async test "ResizeObserver fires callback once with target's bounding rect" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__roWidth = '-1'; globalThis.__roInline = '-1'; const target = { id: 'r', getBoundingClientRect: () => ({ x: 0, y: 0, width: 200, height: 50, top: 0, left: 0, right: 200, bottom: 50 }) }; const ro = new ResizeObserver((entries) => { globalThis.__roWidth = String(entries[0].contentRect.width); globalThis.__roInline = String(entries[0].borderBoxSize[0].inlineSize); }); ro.observe(target);",
+  )
+  @async.sleep(10)
+  let width = read_global_string(proto, 3, "__roWidth")
+  assert_true(width.contains("\"200\""))
+  let inline_size = read_global_string(proto, 4, "__roInline")
+  assert_true(inline_size.contains("\"200\""))
+}


### PR DESCRIPTION
Closes the P0 web-API inventory items from the practicality survey: modern SPA frontends (Preact / React / Lit / Material WC) require these surfaces present and behaviorally meaningful. Each was either missing or a stub that broke before the page bootstrapped.

## What changed

| Surface | Before | After |
|---|---|---|
| \`IntersectionObserver\` | not defined → \`new\` threw | shim that fires the callback once per observe with intersectionRatio=1 (headless wants eager render) |
| \`ResizeObserver\` | not defined → \`new\` threw | shim that fires once with the target's bounding rect as contentRect / borderBoxSize / contentBoxSize |
| \`history\` | length++ stub, no location update, no popstate | real stack+cursor; pushState/replaceState update location.pathname/search/href and __pageUrl; back/forward/go fire \`popstate\` with state through the shared dispatchEvent |
| \`localStorage\` / \`sessionStorage\` | leaky \`_data\` prop, empty-string vs null bug, OOB returning empty | Map-backed closure with spec-correct coercion and bounds checks |

\`__bidiSyncWindowPropertiesToGlobal\` reserved set extended with \`history\`, \`IntersectionObserver\`, \`ResizeObserver\`, \`MutationObserver\` so the per-evaluate sync doesn't clear them before the user expression runs. Updated in both bidi_runtime_eval.mbt and bidi_runtime_context.mbt — the install function has two definition sites and only the first one wins.

## Tests

11 cases in \`bidi_runtime_web_apis_wbtest.mbt\` — see commit for full list. All pass under \`moon test -p mizchi/crater-webdriver-bidi/webdriver --file bidi_runtime_web_apis_wbtest.mbt\`.

Two runtime-model caveats are documented at the top of the wbtest file:
1. BiDi response JSON-encodes string values (\`"\` → \`\\"\`), so \`contains\` assertions read scalars not stringified objects.
2. The shim init block is guarded by \`if (!globalThis.document)\` and runs once per JS realm; tests share \`globalThis.history\` etc inside one \`moon test\` invocation. Tests use delta assertions (e.g. \`history.length - before === 0\` for replaceState) instead of absolute starting state.

## Follow-up issues

The remaining P0/P1 web-API gaps surfaced by the survey are filed separately so this PR stays focused. See PR comments below.