### PR TITLE
Wire in-realm alert/confirm/prompt to BiDi userPromptOpened

### DIFF
--- a/webdriver/webdriver/bidi_protocol_context_lifecycle.mbt
+++ b/webdriver/webdriver/bidi_protocol_context_lifecycle.mbt
@@ -62,6 +62,15 @@ fn BidiProtocol::apply_effective_viewport_to_runtime_context(
     logical_ctx_id,
   )
   set_runtime_context_credentials(runtime_ctx_id, creds_json)
+  // Drain user prompts (alert/confirm/prompt) the page recorded in the
+  // PREVIOUS evaluate, then push the current unhandledPromptBehavior
+  // snapshot so the page's next alert/confirm/prompt resolves with the
+  // right semantics. The drain runs at the start of every evaluate
+  // (apply_effective_viewport runs ahead of js_evaluate_expression), so
+  // there's a one-evaluate delay between an alert call and the
+  // userPromptOpened event — same as the cookie-ingest pattern. (#183)
+  self.flush_pending_user_prompts()
+  self.push_prompt_handlers_snapshot(logical_ctx_id)
 }
 
 ///|

--- a/webdriver/webdriver/bidi_runtime_context.mbt
+++ b/webdriver/webdriver/bidi_runtime_context.mbt
@@ -583,15 +583,69 @@ extern "js" fn js_set_runtime_context(ctx_id : String) -> Unit =
   #|     if (!contextWindow.sessionStorage) contextWindow.sessionStorage = ensureStorage("sessionStorage");
   #|     globalThis.localStorage = contextWindow.localStorage;
   #|     globalThis.sessionStorage = contextWindow.sessionStorage;
+  #|     // alert / confirm / prompt — wire to the BiDi user-prompt bridge.
+  #|     // A page-side call queues a userPromptOpened observation and returns
+  #|     // the resolved value per the context's unhandledPromptBehavior (snapshot
+  #|     // pushed via __bidiPromptHandlers). The MoonBit drain runs at every
+  #|     // script.evaluate boundary and emits the deferred BiDi event so
+  #|     // Playwright's `page.on('dialog')` consumers observe the dialog.
+  #|     //
+  #|     // Limitation: real browsers BLOCK the page on alert/confirm/prompt
+  #|     // until the user (or driver) answers. Crater's headless realm can't
+  #|     // synchronously park JS waiting for an out-of-realm decision, so the
+  #|     // resolution is taken from the snapshot at call time — accept ⇒ true /
+  #|     // default-value, dismiss ⇒ false / null. Drivers that need control
+  #|     // over the response set the behavior via session.new
+  #|     // `unhandledPromptBehavior` BEFORE the page calls alert/confirm/prompt.
+  #|     const resolvePromptHandler = (promptType) => {
+  #|       const handlers = globalThis.__bidiPromptHandlers;
+  #|       if (handlers && typeof handlers === "object") {
+  #|         const direct = handlers[promptType];
+  #|         if (typeof direct === "string") return direct;
+  #|         const fallback = handlers.default;
+  #|         if (typeof fallback === "string") return fallback;
+  #|       }
+  #|       return "dismiss";
+  #|     };
+  #|     const enqueueUserPrompt = (promptType, message, defaultValue) => {
+  #|       if (!Array.isArray(globalThis.__bidiPendingUserPrompts)) {
+  #|         globalThis.__bidiPendingUserPrompts = [];
+  #|       }
+  #|       const handler = resolvePromptHandler(promptType);
+  #|       const ctx = String(globalThis.__bidiCurrentContext || "default-context");
+  #|       globalThis.__bidiPendingUserPrompts.push({
+  #|         ctx,
+  #|         type: promptType,
+  #|         message: message === undefined || message === null ? "" : String(message),
+  #|         defaultValue: defaultValue === undefined || defaultValue === null ? null : String(defaultValue),
+  #|         handler,
+  #|       });
+  #|       return handler;
+  #|     };
   #|     if (typeof contextWindow.alert !== "function") {
-  #|       contextWindow.alert = function(_message) { return undefined; };
+  #|       contextWindow.alert = function(message) {
+  #|         enqueueUserPrompt("alert", message, null);
+  #|         // alert returns undefined regardless of handler — accepting vs
+  #|         // dismissing only changes whether the page knew the user saw it.
+  #|         return undefined;
+  #|       };
   #|     }
   #|     if (typeof contextWindow.confirm !== "function") {
-  #|       contextWindow.confirm = function(_message) { return false; };
+  #|       contextWindow.confirm = function(message) {
+  #|         const handler = enqueueUserPrompt("confirm", message, null);
+  #|         return handler === "accept" || handler === "accept and notify";
+  #|       };
   #|     }
   #|     if (typeof contextWindow.prompt !== "function") {
-  #|       contextWindow.prompt = function(_message, defaultValue) {
-  #|         return defaultValue === undefined ? "" : String(defaultValue);
+  #|       contextWindow.prompt = function(message, defaultValue) {
+  #|         const handler = enqueueUserPrompt("prompt", message, defaultValue);
+  #|         if (handler === "accept" || handler === "accept and notify") {
+  #|           return defaultValue === undefined || defaultValue === null
+  #|             ? ""
+  #|             : String(defaultValue);
+  #|         }
+  #|         // dismiss / dismiss and notify / ignore → null per HTML spec
+  #|         return null;
   #|       };
   #|     }
   #|     globalThis.alert = contextWindow.alert.bind(contextWindow);
@@ -1206,6 +1260,52 @@ extern "js" fn js_drain_pending_cookie_ingest() -> String =
 /// `{url, cookies: [setCookieHeaderValue, ...], ctx}`.
 fn drain_pending_cookie_ingest() -> String {
   js_drain_pending_cookie_ingest()
+}
+
+///|
+/// Push the per-context unhandledPromptBehavior snapshot into the JS realm.
+/// Read by `resolvePromptHandler` inside alert/confirm/prompt to decide
+/// the synchronous return value. Snapshot shape mirrors the spec
+/// dictionary: `{ alert: "dismiss", confirm: "accept", prompt: "dismiss",
+/// default: "dismiss" }`. Missing entries default to "dismiss".
+pub extern "js" fn js_set_runtime_prompt_handlers(
+  handlers_json : String,
+) -> Unit =
+  #| (handlersJson) => {
+  #|   try {
+  #|     const parsed = JSON.parse(handlersJson);
+  #|     if (parsed && typeof parsed === "object") {
+  #|       globalThis.__bidiPromptHandlers = parsed;
+  #|       return;
+  #|     }
+  #|   } catch (_e) {}
+  #|   globalThis.__bidiPromptHandlers = {};
+  #| }
+
+///|
+fn set_runtime_prompt_handlers(handlers_json : String) -> Unit {
+  js_set_runtime_prompt_handlers(handlers_json)
+}
+
+///|
+/// Drain the pending user-prompt buffer. Each entry is
+/// `{ctx, type, message, defaultValue, handler}` where `type` is one of
+/// "alert" | "confirm" | "prompt" and `handler` is the resolved
+/// unhandledPromptBehavior at the time alert/confirm/prompt was called.
+/// MoonBit converts each entry to a `browsingContext.userPromptOpened`
+/// event at the next script.evaluate boundary.
+extern "js" fn js_drain_pending_user_prompts() -> String =
+  #| () => {
+  #|   const buf = globalThis.__bidiPendingUserPrompts;
+  #|   if (!Array.isArray(buf) || buf.length === 0) return "[]";
+  #|   const out = JSON.stringify(buf);
+  #|   globalThis.__bidiPendingUserPrompts = [];
+  #|   return out;
+  #| }
+
+///|
+fn drain_pending_user_prompts() -> String {
+  js_drain_pending_user_prompts()
 }
 
 ///|

--- a/webdriver/webdriver/bidi_user_prompt_bridge.mbt
+++ b/webdriver/webdriver/bidi_user_prompt_bridge.mbt
@@ -1,0 +1,107 @@
+///|
+/// User-prompt bridge between the BiDi JS realm and MoonBit-side BiDi event
+/// emission. Two responsibilities:
+///
+/// 1. Push the active `unhandledPromptBehavior` snapshot into the JS realm
+///    so `globalThis.alert/confirm/prompt` can synchronously resolve a
+///    return value matching the driver-configured policy.
+/// 2. Drain the JS-side `__bidiPendingUserPrompts` queue at every
+///    script.evaluate boundary and emit one `browsingContext.userPromptOpened`
+///    BiDi event per queued entry, so consumers like Playwright's
+///    `page.on('dialog')` observe the dialog.
+///
+/// Resolution semantics: Crater's headless realm cannot synchronously park
+/// the page while it waits for an out-of-realm decision. The JS-side
+/// alert/confirm/prompt therefore RESOLVE IMMEDIATELY based on the snapshot,
+/// then queue a deferred event. Drivers that need control over the
+/// resolution set unhandledPromptBehavior on session.new before any
+/// page-side prompt fires.
+
+///|
+/// Build the JSON snapshot pushed to `globalThis.__bidiPromptHandlers` for
+/// the given browsing context. The result is the resolved per-type handler
+/// (alert / confirm / prompt) plus a `default` fallback, all selected via
+/// `resolve_unhandled_prompt_handler` so the JS side never has to walk the
+/// MoonBit-side user-context lookup itself.
+fn BidiProtocol::serialize_prompt_handlers_snapshot_for_runtime(
+  self : BidiProtocol,
+  ctx_id : String,
+) -> String {
+  let entries : Map[String, Json] = Map([], capacity=4)
+  entries["alert"] = Json::string(
+    self.resolve_unhandled_prompt_handler(ctx_id, "alert"),
+  )
+  entries["confirm"] = Json::string(
+    self.resolve_unhandled_prompt_handler(ctx_id, "confirm"),
+  )
+  entries["prompt"] = Json::string(
+    self.resolve_unhandled_prompt_handler(ctx_id, "prompt"),
+  )
+  entries["default"] = Json::string(
+    self.resolve_unhandled_prompt_handler(ctx_id, "default"),
+  )
+  make_object(entries).stringify()
+}
+
+///|
+/// Push the per-context prompt-handler snapshot to the JS realm.
+fn BidiProtocol::push_prompt_handlers_snapshot(
+  self : BidiProtocol,
+  ctx_id : String,
+) -> Unit {
+  let snapshot = self.serialize_prompt_handlers_snapshot_for_runtime(ctx_id)
+  set_runtime_prompt_handlers(snapshot)
+}
+
+///|
+/// Drain the JS-side pending-user-prompt buffer and emit one
+/// `browsingContext.userPromptOpened` event per queued entry. Called at
+/// every script.evaluate boundary so consumers see dialog observations
+/// promptly (BiDi events are emitted on the next message dispatch).
+///
+/// The page-side return value was already resolved synchronously when
+/// alert/confirm/prompt fired; this drain is purely observational.
+fn BidiProtocol::flush_pending_user_prompts(self : BidiProtocol) -> Unit {
+  let drained = drain_pending_user_prompts()
+  if drained.length() == 0 || drained == "[]" {
+    return
+  }
+  let parsed = @json.parse(drained) catch { _ => return }
+  let entries = match parsed {
+    Json::Array(items) => items
+    _ => return
+  }
+  for entry in entries {
+    let map = match entry {
+      Json::Object(map) => map
+      _ => continue
+    }
+    let ctx_id = match map.get("ctx") {
+      Some(Json::String(value)) => value
+      _ => continue
+    }
+    if !self.manager.has_session(ctx_id) {
+      continue
+    }
+    let prompt_type = match map.get("type") {
+      Some(Json::String(value)) => value
+      _ => continue
+    }
+    let message = match map.get("message") {
+      Some(Json::String(value)) => value
+      _ => ""
+    }
+    let default_value : String? = match map.get("defaultValue") {
+      Some(Json::String(value)) => Some(value)
+      Some(Json::Null) => None
+      _ => None
+    }
+    let handler = match map.get("handler") {
+      Some(Json::String(value)) => value
+      _ => self.resolve_unhandled_prompt_handler(ctx_id, prompt_type)
+    }
+    self.emit_user_prompt_opened(
+      ctx_id, prompt_type, handler, message, default_value,
+    )
+  }
+}

--- a/webdriver/webdriver/bidi_user_prompt_bridge_wbtest.mbt
+++ b/webdriver/webdriver/bidi_user_prompt_bridge_wbtest.mbt
@@ -1,0 +1,189 @@
+///|
+/// User-prompt bridge coverage. Pins the in-realm alert/confirm/prompt
+/// shims to (a) resolve their return values from the per-context
+/// `unhandledPromptBehavior` snapshot and (b) push observable
+/// `browsingContext.userPromptOpened` events through the JS → MoonBit
+/// drain at every script.evaluate boundary.
+///
+/// The flush hook fires from `apply_effective_viewport_to_runtime_context`,
+/// which these tests trigger via the synthetic `__craterApplyViewport()`
+/// expression (the same path used by the cookie-ingest tests).
+
+///|
+/// Helper: subscribe to a BiDi event on a specific context. Returns after
+/// draining the success response from the outbox.
+fn subscribe_event(
+  proto : BidiProtocol,
+  request_id : Int,
+  event_name : String,
+  ctx_id : String,
+) -> Unit {
+  let payload = "{\"id\":" +
+    request_id.to_string() +
+    ",\"method\":\"session.subscribe\",\"params\":{\"events\":[\"" +
+    event_name +
+    "\"],\"contexts\":[\"" +
+    ctx_id +
+    "\"]}}"
+  let _ = proto.process_message(payload)
+  let _ = proto.take_messages()
+}
+
+///|
+/// Helper: build a session with a user-context-level
+/// `unhandledPromptBehavior` set on `default`, returning the proto after
+/// the session.new + setUnhandledPromptBehavior dance.
+fn session_with_prompt_handlers(handlers_json_inner : String) -> BidiProtocol {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{\"capabilities\":{\"alwaysMatch\":{\"unhandledPromptBehavior\":" +
+    handlers_json_inner +
+    "}}}}",
+  )
+  let _ = proto.take_messages()
+  proto
+}
+
+///|
+/// Helper: drive the runtime-context lifecycle hook so the user-prompt
+/// queue gets drained into BiDi events. Mirrors the cookie-ingest pattern.
+fn fire_drain_hook(proto : BidiProtocol, ctx_id : String) -> Unit {
+  proto.apply_effective_viewport_to_runtime_context(ctx_id, ctx_id)
+}
+
+///|
+/// Filter messages for events matching the given method name. Returns
+/// the array of raw JSON strings.
+fn collect_events(proto : BidiProtocol, ev : String) -> Array[String] {
+  let out : Array[String] = []
+  for msg in proto.take_messages() {
+    let json = msg.to_json()
+    if json.contains("\"method\":\"" + ev + "\"") {
+      out.push(json)
+    }
+  }
+  out
+}
+
+///|
+/// Like `run_sync_in_context` but DOES NOT drain the outbox after sending
+/// the script.evaluate payload, so the caller can inspect any events the
+/// evaluate emitted (e.g. userPromptOpened from the in-realm bridge).
+fn run_sync_in_context_keep(
+  proto : BidiProtocol,
+  request_id : Int,
+  expr : String,
+) -> Unit {
+  let payload = "{\"id\":" +
+    request_id.to_string() +
+    ",\"method\":\"script.evaluate\",\"params\":{\"expression\":" +
+    Json::string(expr).stringify() +
+    ",\"target\":{\"context\":\"session-1\"},\"awaitPromise\":false}}"
+  let _ = proto.process_message(payload)
+}
+
+///|
+test "alert() in default-behavior session emits userPromptOpened with dismiss handler" {
+  let proto = make_proto_with_session()
+  subscribe_event(proto, 2, "browsingContext.userPromptOpened", "session-1")
+  let _ = proto.take_messages()
+  // The synthetic handler at try_handle_synthetic_user_prompt intercepts
+  // expressions that START with `alert(` / `confirm(` / `prompt(` and
+  // parks the request waiting for `browsingContext.handleUserPrompt`.
+  // Wrap the call in a leading no-op so the in-realm bridge fires
+  // instead — that's the path real pages hit when alert() is called
+  // from event handlers, async callbacks, or library code.
+  //
+  // The bridge drain runs at the START of every script.evaluate
+  // (apply_effective_viewport), so any events queued by this alert()
+  // call fire at the NEXT script.evaluate, not this one. Trigger a
+  // no-op second evaluate (kept so messages remain in the outbox)
+  // to flush.
+  run_sync_in_context(proto, 3, "void 0; alert('hello');")
+  let _ = proto.take_messages()
+  run_sync_in_context_keep(proto, 4, "void 0;")
+  let events = collect_events(proto, "browsingContext.userPromptOpened")
+  assert_true(events.length() >= 1)
+  let payload = events[events.length() - 1]
+  assert_true(payload.contains("\"type\":\"alert\""))
+  assert_true(payload.contains("\"handler\":\"dismiss\""))
+  assert_true(payload.contains("\"message\":\"hello\""))
+}
+
+///|
+test "confirm() with default-dismiss behavior returns false synchronously" {
+  let proto = make_proto_with_session()
+  fire_drain_hook(proto, "session-1")
+  let _ = proto.take_messages()
+  run_sync_in_context(
+    proto, 2, "globalThis.__confirmResult = String(confirm('proceed?'));",
+  )
+  let result = read_global_string(proto, 3, "__confirmResult")
+  // Spec: dismiss → confirm returns false.
+  assert_true(result.contains("\"false\""))
+}
+
+///|
+test "prompt() with default-dismiss behavior returns null synchronously" {
+  let proto = make_proto_with_session()
+  fire_drain_hook(proto, "session-1")
+  let _ = proto.take_messages()
+  run_sync_in_context(
+    proto, 2, "globalThis.__promptResult = String(prompt('name?', 'mizchi'));",
+  )
+  let result = read_global_string(proto, 3, "__promptResult")
+  // Spec: dismiss → prompt returns null; String(null) = "null".
+  assert_true(result.contains("\"null\""))
+}
+
+///|
+test "confirm() with accept behavior returns true synchronously" {
+  let proto = session_with_prompt_handlers(
+    "{\"confirm\":\"accept\",\"default\":\"dismiss\"}",
+  )
+  fire_drain_hook(proto, "session-1")
+  let _ = proto.take_messages()
+  run_sync_in_context(
+    proto, 2, "globalThis.__confirmResult = String(confirm('proceed?'));",
+  )
+  let result = read_global_string(proto, 3, "__confirmResult")
+  assert_true(result.contains("\"true\""))
+}
+
+///|
+test "prompt() with accept behavior returns the default value" {
+  let proto = session_with_prompt_handlers(
+    "{\"prompt\":\"accept\",\"default\":\"dismiss\"}",
+  )
+  fire_drain_hook(proto, "session-1")
+  let _ = proto.take_messages()
+  run_sync_in_context(
+    proto, 2, "globalThis.__promptResult = String(prompt('name?', 'mizchi'));",
+  )
+  let result = read_global_string(proto, 3, "__promptResult")
+  // accept + default value present → returns the default value string.
+  assert_true(result.contains("\"mizchi\""))
+}
+
+///|
+test "userPromptOpened event reports the resolved handler chosen at queue time" {
+  let proto = session_with_prompt_handlers(
+    "{\"confirm\":\"accept\",\"alert\":\"dismiss\",\"default\":\"dismiss\"}",
+  )
+  subscribe_event(proto, 2, "browsingContext.userPromptOpened", "session-1")
+  let _ = proto.take_messages()
+  // Wrap in `void` so the synthetic handler at script_eval.mbt:284
+  // doesn't preempt the in-realm bridge. Flush via a follow-up no-op
+  // evaluate (drain runs at apply_effective_viewport, which is the
+  // START of every script.evaluate).
+  run_sync_in_context(proto, 3, "void confirm('proceed?');")
+  let _ = proto.take_messages()
+  run_sync_in_context_keep(proto, 4, "void 0;")
+  let events = collect_events(proto, "browsingContext.userPromptOpened")
+  assert_true(events.length() >= 1)
+  let payload = events[events.length() - 1]
+  assert_true(payload.contains("\"type\":\"confirm\""))
+  // The event records the handler the bridge actually applied — not
+  // the global default — so observability matches the resolution.
+  assert_true(payload.contains("\"handler\":\"accept\""))
+}

--- a/webdriver/webdriver/pkg.generated.mbti
+++ b/webdriver/webdriver/pkg.generated.mbti
@@ -99,6 +99,8 @@ pub fn js_set_runtime_context_authorization(String, String) -> Unit
 
 pub fn js_set_runtime_context_credentials(String, String) -> Unit
 
+pub fn js_set_runtime_prompt_handlers(String) -> Unit
+
 pub fn navigate_and_send_async(@core.Any, Int, String, String, String) -> Unit
 
 pub fn parse_data_url(String) -> (String, String)?


### PR DESCRIPTION
Closes #183.

Page code that calls \`alert\` / \`confirm\` / \`prompt\` from anything other than a top-level \`script.evaluate\` expression — event handlers, async callbacks, library code, etc — now (a) emits a \`browsingContext.userPromptOpened\` event observable by Playwright's \`page.on('dialog')\` and (b) returns a value matching the session's \`unhandledPromptBehavior\` instead of the previous silent no-op.

## What changed

| Layer | Before | After |
|---|---|---|
| In-realm \`window.alert/confirm/prompt\` | silent no-op (alert→undefined, confirm→false, prompt→default value) | Resolves return value from \`__bidiPromptHandlers\` snapshot AND queues an entry for the MoonBit-side bridge |
| Snapshot push | none | \`js_set_runtime_prompt_handlers\` pushes the resolved per-type handler at every \`script.evaluate\` start |
| Event emission | only synthetic-handler path (top-level \`alert(...)\` expression) | New \`flush_pending_user_prompts\` drains the JS queue at every \`script.evaluate\` boundary and emits \`userPromptOpened\` events |

The drain hooks into \`apply_effective_viewport_to_runtime_context\` (start of every evaluate), mirroring the \`flush_pending_cookie_ingest\` pattern. Events queued by evaluate N fire at the boundary of evaluate N+1.

## Resolution model — one caveat

Crater can't synchronously park the JS realm waiting for an out-of-realm decision, so alert/confirm/prompt **resolve immediately** based on the per-context \`unhandledPromptBehavior\` snapshot:

| handler | alert | confirm | prompt |
|---|---|---|---|
| dismiss / dismiss and notify (default) | undefined | false | null |
| accept / accept and notify | undefined | true | default value |

Drivers that need a specific response set \`unhandledPromptBehavior\` via \`session.new\` BEFORE the page calls alert/confirm/prompt. This is the right model for headless / scripted test runners; it diverges from a real browser where the prompt blocks until user input arrives. Documented inline at the top of \`bidi_user_prompt_bridge.mbt\`.

## Synthetic handler coexistence

\`try_handle_synthetic_user_prompt\` still preempts top-level alert/confirm/prompt expressions and parks the request for \`browsingContext.handleUserPrompt\` to resume — that's the real WebDriver-spec blocking semantics for that narrow case. The new in-realm bridge handles every OTHER caller path.

## Tests

6 wbtests in \`bidi_user_prompt_bridge_wbtest.mbt\`:

- \`alert()\` emits userPromptOpened with the dismiss handler
- \`confirm()\` / \`prompt()\` return false / null under default dismiss
- \`confirm()\` returns true when session has \`confirm:"accept"\`
- \`prompt()\` returns the default value when session has \`prompt:"accept"\`
- \`userPromptOpened\` event records the handler actually applied

\`moon test --target js\` passes 3351 / 3351 (no regressions in the broader suite).