### PR TITLE
Reserve WebSocket / EventSource against the realm sync

### DIFF
--- a/webdriver/webdriver/bidi_runtime_context.mbt
+++ b/webdriver/webdriver/bidi_runtime_context.mbt
@@ -28,6 +28,8 @@ extern "js" fn reset_runtime_js_state() -> Unit =
   #|         // Observer APIs shimmed by bidi_runtime_eval.mbt. Without
   #|         // these, the per-eval window→globalThis sync would clear them.
   #|         "IntersectionObserver", "ResizeObserver", "MutationObserver",
+  #|         // Network primitives provided natively by Node 22+.
+  #|         "WebSocket", "EventSource",
   #|       ]);
   #|       globalThis.__bidiSyncWindowPropertiesToGlobal = (win) => {
   #|         const source = win && typeof win === "object" ? win : globalThis.window;

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -285,6 +285,10 @@ extern "js" fn js_evaluate_expression(
   #|       // delete them (when window doesn't carry them) right before the
   #|       // user expression runs.
   #|       "IntersectionObserver", "ResizeObserver", "MutationObserver",
+  #|       // Network primitives provided natively by Node 22+. Reserving them
+  #|       // ensures the per-eval sync doesn't drop the WebSocket / EventSource
+  #|       // constructors that real-time apps need.
+  #|       "WebSocket", "EventSource",
   #|     ]);
   #|     globalThis.__bidiSyncWindowPropertiesToGlobal = (win) => {
   #|       const source = win && typeof win === "object" ? win : globalThis.window;

--- a/webdriver/webdriver/bidi_runtime_websocket_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_websocket_wbtest.mbt
@@ -1,0 +1,62 @@
+///|
+/// WebSocket constructor exposure in the BiDi runtime realm (#179).
+///
+/// Node 22+ exposes `globalThis.WebSocket` natively (and `EventSource`).
+/// The BiDi runtime keeps both in its reserved-properties set so the
+/// per-evaluate window → globalThis sync doesn't drop them.
+///
+/// These tests pin the constructor surface so a real-time / chat /
+/// live-update app can at least bootstrap. End-to-end behavior
+/// (CORS gating, BiDi network event emission for the WS upgrade,
+/// per-message intercept) is a larger scope tracked by #179; this
+/// PR is just the "is the constructor reachable" floor.
+
+///|
+test "WebSocket constructor is exposed in the realm" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__wsType = String(typeof WebSocket); globalThis.__wsProto = String(WebSocket && WebSocket.prototype ? typeof WebSocket.prototype.send : 'no-proto');",
+  )
+  let ty = read_global_string(proto, 3, "__wsType")
+  assert_true(ty.contains("\"function\""))
+  let proto_send = read_global_string(proto, 4, "__wsProto")
+  // WebSocket.prototype.send must be a function on a real WebSocket
+  // class — distinguishes the native Node 22 binding from a stray
+  // arrow-function stub.
+  assert_true(proto_send.contains("\"function\""))
+}
+
+///|
+test "WebSocket exposes the standard readyState constants" {
+  let proto = make_proto_with_session()
+  // CONNECTING=0, OPEN=1, CLOSING=2, CLOSED=3 per WHATWG spec.
+  run_sync_in_context(
+    proto, 2, "globalThis.__wsStates = String(WebSocket.CONNECTING) + ',' + String(WebSocket.OPEN) + ',' + String(WebSocket.CLOSING) + ',' + String(WebSocket.CLOSED);",
+  )
+  let resp = read_global_string(proto, 3, "__wsStates")
+  assert_true(resp.contains("\"0,1,2,3\""))
+}
+
+// EventSource is intentionally NOT tested here. Node's exposure of
+// `globalThis.EventSource` varies by minor version (it's `--experimental`
+// in some releases and stable in others). The reserved-set entry above
+// still protects it from being dropped by the sync — if it's there, it
+// stays — but pinning a presence test would create version-coupled
+// flakiness in the CI matrix. SSE consumers can rely on `typeof
+// EventSource === 'function'` from page code.
+
+///|
+test "WebSocket instance construction with an invalid URL throws SyntaxError" {
+  let proto = make_proto_with_session()
+  // We don't actually open a WebSocket here — connecting to a real
+  // server from within a wbtest would require fixture infra. Instead
+  // we verify the constructor rejects malformed URLs synchronously
+  // per spec (a syntactically invalid URL is a SyntaxError at
+  // construction time, BEFORE any async handshake).
+  run_sync_in_context(
+    proto, 2, "globalThis.__wsErr = '<none>'; try { new WebSocket('not-a-valid-url'); } catch (e) { globalThis.__wsErr = String(e.name || e); }",
+  )
+  let resp = read_global_string(proto, 3, "__wsErr")
+  // Node's native WebSocket throws SyntaxError for bare paths.
+  assert_true(resp.contains("\"SyntaxError\""))
+}


### PR DESCRIPTION
Closes #179.

Node 22+ exposes \`globalThis.WebSocket\` (and variably \`EventSource\`) natively. The BiDi runtime's per-evaluate window → globalThis sync was DELETING them right before the user expression ran because they weren't in the reserved-properties set. A page that did \`new WebSocket(url)\` at boot got a ReferenceError.

## What changed

- Added \`WebSocket\` and \`EventSource\` to both copies of the reserved-properties set in \`__bidiSyncWindowPropertiesToGlobal\`. The native bindings now survive the sync.

## Scope note

End-to-end WS behavior — CORS gating on the upgrade, BiDi network events for the WS lifecycle, per-message intercept — is still tracked under #179 for follow-up. This PR is the \"constructor is reachable\" floor that lets real-time apps bootstrap at all.

## Tests

3 wbtests in \`bidi_runtime_websocket_wbtest.mbt\`:

- \`typeof WebSocket === 'function'\` and \`WebSocket.prototype.send\` is a function (distinguishes the native class from a stray stub)
- WebSocket exposes the standard readyState constants 0/1/2/3
- WebSocket constructor rejects a malformed URL with \`SyntaxError\` per spec (synchronous construction-time validation, no fixture server needed)

EventSource is intentionally NOT tested — Node's exposure varies across minor versions, so a presence assertion would create flaker risk in CI. The reserved-set entry still protects it from the sync when it IS available.