### PR TITLE
Add FileReader shim + reserve File/Blob/FileReader in the realm sync

### DIFF
--- a/webdriver/webdriver/bidi_runtime_context.mbt
+++ b/webdriver/webdriver/bidi_runtime_context.mbt
@@ -30,6 +30,9 @@ extern "js" fn reset_runtime_js_state() -> Unit =
   #|         "IntersectionObserver", "ResizeObserver", "MutationObserver",
   #|         // Network primitives provided natively by Node 22+.
   #|         "WebSocket", "EventSource",
+  #|         // File upload surface (Blob/File native in Node 22, FileReader
+  #|         // shimmed by bidi_runtime_eval.mbt).
+  #|         "Blob", "File", "FileReader", "FileList",
   #|       ]);
   #|       globalThis.__bidiSyncWindowPropertiesToGlobal = (win) => {
   #|         const source = win && typeof win === "object" ? win : globalThis.window;

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -289,6 +289,9 @@ extern "js" fn js_evaluate_expression(
   #|       // ensures the per-eval sync doesn't drop the WebSocket / EventSource
   #|       // constructors that real-time apps need.
   #|       "WebSocket", "EventSource",
+  #|       // File upload surface — Blob/File are native in Node 22, FileReader
+  #|       // is shimmed below. Real apps' upload UIs touch all three.
+  #|       "Blob", "File", "FileReader", "FileList",
   #|     ]);
   #|     globalThis.__bidiSyncWindowPropertiesToGlobal = (win) => {
   #|       const source = win && typeof win === "object" ? win : globalThis.window;
@@ -3339,6 +3342,115 @@ extern "js" fn js_evaluate_expression(
   #|         }
   #|       };
   #|     })();
+  #|     // FileReader shim — Node 22 ships Blob and File natively but NOT
+  #|     // FileReader. Real upload UIs call readAsText / readAsArrayBuffer /
+  #|     // readAsDataURL on a File and listen for the `load` event. We
+  #|     // implement the readers as thin async wrappers over Blob.text() /
+  #|     // Blob.arrayBuffer(), fire load/loadend events through a small
+  #|     // EventTarget-shaped surface, and honor abort(). The reserved-
+  #|     // properties set above keeps it from being clobbered by the
+  #|     // per-evaluate window→globalThis sync.
+  #|     if (typeof globalThis.FileReader !== 'function') {
+  #|       class FileReader {
+  #|         constructor() {
+  #|           this.result = null;
+  #|           this.error = null;
+  #|           this.readyState = 0;
+  #|           this.onload = null;
+  #|           this.onloadend = null;
+  #|           this.onloadstart = null;
+  #|           this.onerror = null;
+  #|           this.onabort = null;
+  #|           this.onprogress = null;
+  #|           this._listeners = {};
+  #|         }
+  #|         addEventListener(type, listener) {
+  #|           const key = String(type);
+  #|           if (!this._listeners[key]) this._listeners[key] = [];
+  #|           if (typeof listener === 'function' && !this._listeners[key].includes(listener)) {
+  #|             this._listeners[key].push(listener);
+  #|           }
+  #|         }
+  #|         removeEventListener(type, listener) {
+  #|           const key = String(type);
+  #|           if (!this._listeners[key]) return;
+  #|           this._listeners[key] = this._listeners[key].filter(fn => fn !== listener);
+  #|         }
+  #|         _fire(type) {
+  #|           const ev = { type, target: this, currentTarget: this };
+  #|           const propHandler = this['on' + type];
+  #|           if (typeof propHandler === 'function') {
+  #|             try { propHandler.call(this, ev); } catch (_e) {}
+  #|           }
+  #|           const list = this._listeners[type] || [];
+  #|           for (const fn of list.slice()) {
+  #|             try { fn.call(this, ev); } catch (_e) {}
+  #|           }
+  #|         }
+  #|         _read(blob, mode) {
+  #|           if (this.readyState === 1) {
+  #|             throw new DOMException('FileReader is already reading', 'InvalidStateError');
+  #|           }
+  #|           this.readyState = 1;
+  #|           this.result = null;
+  #|           this.error = null;
+  #|           const self = this;
+  #|           const succeed = (value) => {
+  #|             if (self.readyState !== 1) return;
+  #|             self.result = value;
+  #|             self.readyState = 2;
+  #|             self._fire('load');
+  #|             self._fire('loadend');
+  #|           };
+  #|           const fail = (err) => {
+  #|             if (self.readyState !== 1) return;
+  #|             self.error = err;
+  #|             self.readyState = 2;
+  #|             self._fire('error');
+  #|             self._fire('loadend');
+  #|           };
+  #|           Promise.resolve().then(() => self._fire('loadstart'));
+  #|           const blobApi = (typeof blob === 'object' && blob !== null) ? blob : null;
+  #|           if (!blobApi) { fail(new TypeError('FileReader read called with non-Blob')); return; }
+  #|           if (mode === 'text') {
+  #|             Promise.resolve(blobApi.text()).then(succeed, fail);
+  #|           } else if (mode === 'arrayBuffer') {
+  #|             Promise.resolve(blobApi.arrayBuffer()).then(succeed, fail);
+  #|           } else if (mode === 'dataURL') {
+  #|             Promise.resolve(blobApi.arrayBuffer()).then((buf) => {
+  #|               const bytes = new Uint8Array(buf);
+  #|               let bin = '';
+  #|               for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  #|               const b64 = btoa(bin);
+  #|               const ct = (blobApi.type && typeof blobApi.type === 'string') ? blobApi.type : 'application/octet-stream';
+  #|               succeed('data:' + ct + ';base64,' + b64);
+  #|             }, fail);
+  #|           } else if (mode === 'binaryString') {
+  #|             Promise.resolve(blobApi.arrayBuffer()).then((buf) => {
+  #|               const bytes = new Uint8Array(buf);
+  #|               let bin = '';
+  #|               for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  #|               succeed(bin);
+  #|             }, fail);
+  #|           }
+  #|         }
+  #|         readAsText(blob) { this._read(blob, 'text'); }
+  #|         readAsArrayBuffer(blob) { this._read(blob, 'arrayBuffer'); }
+  #|         readAsDataURL(blob) { this._read(blob, 'dataURL'); }
+  #|         readAsBinaryString(blob) { this._read(blob, 'binaryString'); }
+  #|         abort() {
+  #|           if (this.readyState !== 1) return;
+  #|           this.readyState = 2;
+  #|           this.error = new DOMException('Read aborted', 'AbortError');
+  #|           this._fire('abort');
+  #|           this._fire('loadend');
+  #|         }
+  #|       }
+  #|       FileReader.EMPTY = 0;
+  #|       FileReader.LOADING = 1;
+  #|       FileReader.DONE = 2;
+  #|       globalThis.FileReader = FileReader;
+  #|     }
   #|     globalThis.getComputedStyle = function(el) {
   #|       // Return a CSSStyleDeclaration-like object with direct property access
   #|       const style = el._style || {};

--- a/webdriver/webdriver/bidi_runtime_file_reader_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_file_reader_wbtest.mbt
@@ -1,0 +1,95 @@
+///|
+/// FileReader / File / Blob surface in the BiDi runtime realm (#180).
+///
+/// Node 22+ exposes Blob and File natively. FileReader doesn't exist
+/// in Node — we install a shim that wraps Blob.text() / arrayBuffer()
+/// and fires the standard load/loadend events. URL.createObjectURL /
+/// URL.revokeObjectURL come from Node natively (the URL global itself
+/// is already reserved).
+///
+/// Real upload UIs touch all of this:
+///   `<input type='file'>` produces a File, the page calls
+///   `new FileReader().readAsDataURL(file)` to preview it, or
+///   `URL.createObjectURL(file)` for a blob: src on an img.
+/// These tests pin the surface so the next refactor of the realm
+/// sync can't strip any of it out.
+
+///|
+test "Blob and File constructors are reachable" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__b = String(typeof Blob); globalThis.__f = String(typeof File); globalThis.__fr = String(typeof FileReader);",
+  )
+  let b = read_global_string(proto, 3, "__b")
+  assert_true(b.contains("\"function\""))
+  let f = read_global_string(proto, 4, "__f")
+  assert_true(f.contains("\"function\""))
+  let fr = read_global_string(proto, 5, "__fr")
+  assert_true(fr.contains("\"function\""))
+}
+
+///|
+test "Blob exposes size and type from its constructor options" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "const b = new Blob(['hello world'], { type: 'text/plain' }); globalThis.__bSize = String(b.size); globalThis.__bType = String(b.type);",
+  )
+  let size = read_global_string(proto, 3, "__bSize")
+  assert_true(size.contains("\"11\""))
+  let ty = read_global_string(proto, 4, "__bType")
+  assert_true(ty.contains("\"text/plain\""))
+}
+
+///|
+async test "FileReader.readAsText fires load with the text contents" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__frResult = '<none>'; globalThis.__frEnd = '<none>'; const blob = new Blob(['mizchi'], { type: 'text/plain' }); const r = new FileReader(); r.onload = () => { globalThis.__frResult = String(r.result); }; r.onloadend = () => { globalThis.__frEnd = String(r.readyState); }; r.readAsText(blob);",
+  )
+  // FileReader fires load asynchronously (Blob.text() returns a Promise).
+  @async.sleep(40)
+  let result = read_global_string(proto, 3, "__frResult")
+  assert_true(result.contains("\"mizchi\""))
+  let end = read_global_string(proto, 4, "__frEnd")
+  // FileReader.DONE === 2 — the loadend fires AFTER readyState is set.
+  assert_true(end.contains("\"2\""))
+}
+
+///|
+async test "FileReader.readAsDataURL produces a base64-encoded data URL" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__frUrl = '<none>'; const blob = new Blob(['hi'], { type: 'text/plain' }); const r = new FileReader(); r.onload = () => { globalThis.__frUrl = String(r.result); }; r.readAsDataURL(blob);",
+  )
+  @async.sleep(40)
+  let resp = read_global_string(proto, 3, "__frUrl")
+  // btoa('hi') = 'aGk=' — the data URL embeds it as base64 with the
+  // blob's content-type prefix.
+  assert_true(resp.contains("data:text/plain;base64,aGk="))
+}
+
+///|
+async test "FileReader fires loadstart/load/loadend in order" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__frEvents = []; const blob = new Blob(['x'], { type: 'text/plain' }); const r = new FileReader(); r.addEventListener('loadstart', () => globalThis.__frEvents.push('s')); r.addEventListener('load', () => globalThis.__frEvents.push('l')); r.addEventListener('loadend', () => globalThis.__frEvents.push('e')); r.readAsText(blob);",
+  )
+  @async.sleep(40)
+  run_sync_in_context(
+    proto, 3, "globalThis.__frEventReport = (globalThis.__frEvents || []).join(',');",
+  )
+  let resp = read_global_string(proto, 4, "__frEventReport")
+  // Spec order: loadstart -> load -> loadend.
+  assert_true(resp.contains("\"s,l,e\""))
+}
+
+///|
+test "URL.createObjectURL returns a blob: URL for a Blob argument" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "const b = new Blob(['x'], { type: 'text/plain' }); const url = URL.createObjectURL(b); globalThis.__objUrl = String(url); URL.revokeObjectURL(url);",
+  )
+  let resp = read_global_string(proto, 3, "__objUrl")
+  // Spec: returned URL begins with `blob:` followed by an opaque token.
+  assert_true(resp.contains("blob:"))
+}


### PR DESCRIPTION
Closes #180.

Node 22 ships Blob and File natively but NOT FileReader. The BiDi runtime's per-evaluate window → globalThis sync was also clobbering Blob/File because they weren't reserved. A page that did \`new FileReader().readAsDataURL(file)\` at boot got ReferenceError on FileReader (and would lose Blob/File too depending on sync ordering).

## What changed

- New \`FileReader\` shim in \`bidi_runtime_eval.mbt\` built on \`Blob.text()\` / \`Blob.arrayBuffer()\`:
  - readAsText / readAsArrayBuffer / readAsDataURL / readAsBinaryString
  - EventTarget (addEventListener) + on-handler properties (onload / onloadend / onloadstart / onerror / onabort)
  - readyState transitions EMPTY=0 → LOADING=1 → DONE=2
  - abort() with AbortError DOMException
- \`Blob\`, \`File\`, \`FileReader\`, \`FileList\` added to the reserved-properties set in both copies of the sync function.

## Tests

6 wbtests covering the upload-UI path: constructor presence, Blob size/type, FileReader.readAsText round-trip + readyState, readAsDataURL produces base64 data URL with content-type, event ordering (loadstart → load → loadend), URL.createObjectURL returns a blob: URL.