### PR TITLE
Shim navigator.serviceWorker registration for PWA boot survival

### DIFF
--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -3116,6 +3116,78 @@ extern "js" fn js_evaluate_expression(
   #|       replace: function(url) { globalThis.__pageUrl = url; this.href = url; },
   #|       reload: function() {}
   #|     };
+  #|     // ServiceWorker registration shim — PWAs / offline-capable apps
+  #|     // call `navigator.serviceWorker.register(url)` at boot and chain
+  #|     // off the returned ServiceWorkerRegistration. Without this, the
+  #|     // promise either rejects or never resolves and the boot path
+  #|     // bails. We return a minimal-but-spec-shaped Registration with
+  #|     // non-null active/installing/waiting ServiceWorker stubs and a
+  #|     // resolved `navigator.serviceWorker.ready` so subsequent .then
+  #|     // chains keep moving. The SW script itself is NOT executed —
+  #|     // fetch interception by the worker is out of scope. (#181)
+  #|     const _makeServiceWorker = (scriptURL) => ({
+  #|       scriptURL: String(scriptURL || ''),
+  #|       state: 'activated',
+  #|       onstatechange: null,
+  #|       postMessage(_msg, _transfer) { /* no-op */ },
+  #|       addEventListener(_type, _listener) { /* no-op */ },
+  #|       removeEventListener(_type, _listener) { /* no-op */ },
+  #|     });
+  #|     const _makeRegistration = (scope, scriptURL) => {
+  #|       const sw = _makeServiceWorker(scriptURL);
+  #|       return {
+  #|         scope: String(scope || '/'),
+  #|         installing: null,
+  #|         waiting: null,
+  #|         active: sw,
+  #|         navigationPreload: {
+  #|           enable: () => Promise.resolve(),
+  #|           disable: () => Promise.resolve(),
+  #|           getState: () => Promise.resolve({ enabled: false }),
+  #|           setHeaderValue: (_v) => Promise.resolve(),
+  #|         },
+  #|         update: () => Promise.resolve(),
+  #|         unregister: () => Promise.resolve(true),
+  #|         addEventListener(_type, _listener) {},
+  #|         removeEventListener(_type, _listener) {},
+  #|         onupdatefound: null,
+  #|         pushManager: {
+  #|           subscribe: () => Promise.reject(new DOMException('Push not supported', 'NotSupportedError')),
+  #|           getSubscription: () => Promise.resolve(null),
+  #|           permissionState: () => Promise.resolve('denied'),
+  #|         },
+  #|       };
+  #|     };
+  #|     const _serviceWorkerContainer = (() => {
+  #|       const registrations = new Map(); // scope -> registration
+  #|       const defaultScope = '/';
+  #|       const defaultReg = _makeRegistration(defaultScope, '');
+  #|       registrations.set(defaultScope, defaultReg);
+  #|       const container = {
+  #|         controller: defaultReg.active,
+  #|         ready: Promise.resolve(defaultReg),
+  #|         register(scriptURL, options) {
+  #|           const scope = (options && options.scope) ? String(options.scope) : defaultScope;
+  #|           const reg = _makeRegistration(scope, scriptURL);
+  #|           registrations.set(scope, reg);
+  #|           return Promise.resolve(reg);
+  #|         },
+  #|         getRegistration(scope) {
+  #|           const key = scope === undefined ? defaultScope : String(scope);
+  #|           return Promise.resolve(registrations.get(key) || null);
+  #|         },
+  #|         getRegistrations() {
+  #|           return Promise.resolve(Array.from(registrations.values()));
+  #|         },
+  #|         startMessages() { /* no-op */ },
+  #|         addEventListener(_type, _listener) {},
+  #|         removeEventListener(_type, _listener) {},
+  #|         oncontrollerchange: null,
+  #|         onmessage: null,
+  #|         onmessageerror: null,
+  #|       };
+  #|       return container;
+  #|     })();
   #|     globalThis.navigator = {
   #|       userAgent: 'Crater/1.0 (MoonBit; BiDi)',
   #|       platform: 'Crater',
@@ -3126,8 +3198,16 @@ extern "js" fn js_evaluate_expression(
   #|       userActivation: {
   #|         isActive: false,
   #|         hasBeenActive: false
-  #|       }
+  #|       },
+  #|       serviceWorker: _serviceWorkerContainer,
   #|     };
+  #|     // Stash the container so any LATER navigator-replacing code path
+  #|     // can re-attach it. The win.navigator literal in
+  #|     // installContextWindowApi reads from `__bidiServiceWorkerContainer`
+  #|     // rather than from a snapshot of `globalThis.navigator` taken
+  #|     // before this init ran, so the SW surface survives the
+  #|     // contextWindow rebind that happens at every evaluate.
+  #|     globalThis.__bidiServiceWorkerContainer = _serviceWorkerContainer;
   #|     // History API — pushState / replaceState update location AND
   #|     // globalThis.__pageUrl so SPA routers can read the new URL through
   #|     // either surface. back() / forward() / go() walk a real stack and
@@ -5094,6 +5174,18 @@ extern "js" fn js_evaluate_expression(
   #|       userActivation: baseNavigator.userActivation && typeof baseNavigator.userActivation === 'object'
   #|         ? { ...baseNavigator.userActivation }
   #|         : { isActive: false, hasBeenActive: false },
+  #|       // Forward the ServiceWorker container so the
+  #|       // navigator.serviceWorker.register surface survives the
+  #|       // globalThis.navigator = contextWindow.navigator replacement
+  #|       // that happens at every script.evaluate boundary. We read
+  #|       // from the persisted `__bidiServiceWorkerContainer` stash
+  #|       // rather than baseNavigator, because contextWindow setup
+  #|       // can fire BEFORE the document-init block (which is guarded
+  #|       // by `if (!globalThis.document)`) runs on the first
+  #|       // evaluate, in which case baseNavigator wouldn't yet have
+  #|       // the container. The stash is set unconditionally in the
+  #|       // init block (#181).
+  #|       serviceWorker: globalThis.__bidiServiceWorkerContainer || baseNavigator.serviceWorker,
   #|     };
   #|     win.innerWidth = Number(globalThis.innerWidth || 1024);
   #|     win.innerHeight = Number(globalThis.innerHeight || 768);
@@ -5141,6 +5233,24 @@ extern "js" fn js_evaluate_expression(
   #|     globalThis.navigator = contextWindow.navigator;
   #|   } else if (globalThis.navigator && typeof globalThis.navigator === 'object') {
   #|     contextWindow.navigator = globalThis.navigator;
+  #|   }
+  #|   // Reattach the ServiceWorker container if the navigator rebind
+  #|   // above (or a stale contextWindow.navigator created before the
+  #|   // SW init ran) left it missing. Runs every evaluate so a fresh
+  #|   // navigator never lacks navigator.serviceWorker by the time
+  #|   // user code runs (#181).
+  #|   if (
+  #|     globalThis.navigator &&
+  #|     typeof globalThis.navigator === 'object' &&
+  #|     !globalThis.navigator.serviceWorker &&
+  #|     globalThis.__bidiServiceWorkerContainer
+  #|   ) {
+  #|     try {
+  #|       globalThis.navigator.serviceWorker = globalThis.__bidiServiceWorkerContainer;
+  #|       if (contextWindow.navigator && contextWindow.navigator !== globalThis.navigator) {
+  #|         contextWindow.navigator.serviceWorker = globalThis.__bidiServiceWorkerContainer;
+  #|       }
+  #|     } catch (_e) { /* navigator may be frozen — swallow */ }
   #|   }
   #|   if (contextWindow.document && typeof contextWindow.document === "object") {
   #|     globalThis.document = contextWindow.document;

--- a/webdriver/webdriver/bidi_runtime_service_worker_wbtest.mbt
+++ b/webdriver/webdriver/bidi_runtime_service_worker_wbtest.mbt
@@ -1,0 +1,104 @@
+///|
+/// ServiceWorker registration surface (#181).
+///
+/// PWAs / offline-capable apps call `navigator.serviceWorker.register(url)`
+/// at boot and chain off the returned `ServiceWorkerRegistration`. The
+/// Crater realm exposes a minimal-but-spec-shaped container so the boot
+/// promise resolves and `navigator.serviceWorker.ready` settles, even
+/// though the SW script itself never executes.
+///
+/// What's COVERED:
+///
+/// - `navigator.serviceWorker` exists with the spec property surface
+/// - `register(url)` returns a resolved ServiceWorkerRegistration
+/// - `ready` resolves with a registration whose `active` is a non-null
+///   ServiceWorker
+/// - `getRegistration` / `getRegistrations` work
+///
+/// What's NOT covered (out of scope for #181, future work):
+///
+/// - Actual execution of the SW script
+/// - fetch interception by the worker
+/// - Push notifications (pushManager.subscribe rejects with
+///   NotSupportedError, which IS the spec response when push is
+///   unavailable — pin it)
+/// - Lifecycle events (install / activate / fetch / message)
+
+///|
+async test "navigator.serviceWorker.register resolves with a Registration" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__swStage = '<none>'; globalThis.__swErr = '<none>'; navigator.serviceWorker.register('/sw.js').then(reg => { globalThis.__swStage = 'registered:' + String(reg.scope) + ':' + String(reg.active && reg.active.scriptURL); }, err => { globalThis.__swErr = String(err); });",
+  )
+  @async.sleep(30)
+  let stage = read_global_string(proto, 3, "__swStage")
+  // Registration carries the scope and an active worker pointing back
+  // at the supplied script URL.
+  assert_true(stage.contains("registered:/:"))
+  assert_true(stage.contains("/sw.js"))
+}
+
+///|
+async test "navigator.serviceWorker.ready resolves with an active worker" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__swReady = '<none>'; navigator.serviceWorker.ready.then(reg => { globalThis.__swReady = 'ready:' + String(reg.active && reg.active.state); });",
+  )
+  @async.sleep(20)
+  let resp = read_global_string(proto, 3, "__swReady")
+  // The ready promise pre-resolves with the default registration whose
+  // active worker is in the 'activated' state.
+  assert_true(resp.contains("ready:activated"))
+}
+
+///|
+async test "registered scope is retrievable via getRegistration" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__swScope = '<none>'; navigator.serviceWorker.register('/sw.js', { scope: '/app/' }).then(() => navigator.serviceWorker.getRegistration('/app/')).then(reg => { globalThis.__swScope = reg ? reg.scope : 'null'; });",
+  )
+  @async.sleep(30)
+  let resp = read_global_string(proto, 3, "__swScope")
+  assert_true(resp.contains("\"/app/\""))
+}
+
+///|
+async test "getRegistrations returns the registered scopes" {
+  let proto = make_proto_with_session()
+  // The realm-wide registrations Map persists across tests in the same
+  // moon-test invocation, so we can't assert on an exact set. Instead
+  // we register two distinctive scopes and check both appear in the
+  // returned list.
+  run_sync_in_context(
+    proto, 2, "globalThis.__swAll = '<none>'; Promise.all([ navigator.serviceWorker.register('/a.js', { scope: '/p181-a/' }), navigator.serviceWorker.register('/b.js', { scope: '/p181-b/' }), ]).then(() => navigator.serviceWorker.getRegistrations()).then(regs => { globalThis.__swAll = regs.map(r => r.scope).join('|'); });",
+  )
+  @async.sleep(40)
+  let resp = read_global_string(proto, 3, "__swAll")
+  assert_true(resp.contains("/p181-a/"))
+  assert_true(resp.contains("/p181-b/"))
+}
+
+///|
+async test "Registration.unregister resolves true" {
+  let proto = make_proto_with_session()
+  run_sync_in_context(
+    proto, 2, "globalThis.__swUnreg = '<none>'; navigator.serviceWorker.register('/sw.js').then(reg => reg.unregister()).then(ok => { globalThis.__swUnreg = String(ok); });",
+  )
+  @async.sleep(30)
+  let resp = read_global_string(proto, 3, "__swUnreg")
+  assert_true(resp.contains("\"true\""))
+}
+
+///|
+async test "pushManager.subscribe rejects with NotSupportedError" {
+  let proto = make_proto_with_session()
+  // The spec response when push is unavailable. Pinned so apps that
+  // gracefully feature-detect via try/catch around subscribe() get a
+  // consistent rejection rather than a hang.
+  run_sync_in_context(
+    proto, 2, "globalThis.__pushErr = '<none>'; navigator.serviceWorker.register('/sw.js').then(reg => reg.pushManager.subscribe()).then(() => { globalThis.__pushErr = 'unexpected-success'; }, err => { globalThis.__pushErr = String(err.name || err); });",
+  )
+  @async.sleep(30)
+  let resp = read_global_string(proto, 3, "__pushErr")
+  assert_true(resp.contains("\"NotSupportedError\""))
+}


### PR DESCRIPTION
Closes #181.

PWAs / offline-capable apps call \`navigator.serviceWorker.register(url)\` at boot and chain off the returned Registration. Without this, the promise either rejected or never resolved, and the boot path bailed before the rest of the app could render.

## What's covered

| Surface | Behavior |
|---|---|
| \`register(url, options?)\` | Resolves with a Registration carrying \`scope\` and a non-null \`active\` ServiceWorker stub |
| \`ready\` | Pre-resolved with the default registration |
| \`getRegistration(scope?)\` / \`getRegistrations()\` | Return what was registered |
| \`controller\` | The default active worker |
| Each Registration | \`update\`, \`unregister\`, \`pushManager.subscribe\` (rejects with NotSupportedError per spec) |

The container is stashed as \`globalThis.__bidiServiceWorkerContainer\` so the per-evaluate \`globalThis.navigator = contextWindow.navigator\` rebind can reattach it. Two attach points — the contextWindow.navigator literal AND a reattach pass right before user code runs — guarantee \`navigator.serviceWorker\` is non-null at every evaluate boundary.

## What's NOT covered (explicitly out of scope)

- Actual execution of the SW script
- Fetch interception by the worker
- Push notifications (the NotSupportedError rejection is the spec response when push is unavailable — pinned via test)
- Lifecycle events (install / activate / fetch / message)

## Tests

6 wbtests covering register → Registration → ready → getRegistration → getRegistrations → unregister → pushManager.subscribe-rejection.