### PR TITLE
Broaden synthetic iframe-creation matcher for real-app patterns (#182 slice 3)

### DIFF
--- a/webdriver/webdriver/bidi_iframe_creation_variants_wbtest.mbt
+++ b/webdriver/webdriver/bidi_iframe_creation_variants_wbtest.mbt
@@ -1,0 +1,129 @@
+///|
+/// JS iframe creation pattern variants (#182 sub-task).
+///
+/// `try_handle_synthetic_iframe_creation` previously matched only the
+/// narrow WPT shape `createElement('iframe')` + literal
+/// `appendChild(iframe)` + `iframe.src=`. Real apps name the element
+/// variable anything, append via any parent, and set src via any of
+/// several spec-allowed forms. These tests pin the loosened matcher.
+///
+/// What's covered:
+///
+/// - createElement + non-literal-`iframe` variable name + appendChild
+/// - .src with whitespace around the `=`
+/// - setAttribute('src', ...) / setAttribute("src", ...)
+/// - srcdoc → child context registered at `about:srcdoc`
+/// - alternative DOM insertion verbs (prepend, append, insertBefore)
+///
+/// What's still out of scope (left under #182):
+///
+/// - Async iframe insertion (`await someAsyncOp(); document.body.append(f)`)
+///   — the synthetic handler runs at script.evaluate time before any
+///   `await` fence resolves
+/// - Document fragments / DocumentFragment.appendChild flows
+/// - iframe.contentWindow.foo cross-frame access for shapes other than
+///   the hardcoded one-liner in the existing handler
+
+///|
+fn eval_in_session(
+  proto : BidiProtocol,
+  request_id : Int,
+  expr : String,
+) -> Unit {
+  let payload = "{\"id\":" +
+    request_id.to_string() +
+    ",\"method\":\"script.evaluate\",\"params\":{\"expression\":" +
+    Json::string(expr).stringify() +
+    ",\"target\":{\"context\":\"session-1\"},\"awaitPromise\":false}}"
+  let _ = proto.process_message(payload)
+  let _ = proto.take_messages()
+}
+
+///|
+fn iframe_proto_with_session() -> BidiProtocol {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  let _ = proto.take_messages()
+  proto
+}
+
+///|
+test "createElement + custom-named variable + appendChild registers a child" {
+  let proto = iframe_proto_with_session()
+  // Variable named `f`, not `iframe`. The previous matcher required
+  // `appendChild(iframe)` literally and would have missed this.
+  eval_in_session(
+    proto, 2, "const f = document.createElement('iframe'); f.src = '/from-f'; document.body.appendChild(f);",
+  )
+  let children = proto.context_children.get("session-1").unwrap_or([])
+  assert_true(children.length() >= 1)
+}
+
+///|
+test "createElement + custom parent.appendChild registers a child" {
+  let proto = iframe_proto_with_session()
+  // `wrapper.appendChild(iframe)` instead of `document.body.appendChild(iframe)`.
+  eval_in_session(
+    proto, 2, "const wrapper = document.getElementById('host'); const iframe = document.createElement('iframe'); iframe.src='/wrapped'; wrapper.appendChild(iframe);",
+  )
+  let children = proto.context_children.get("session-1").unwrap_or([])
+  assert_true(children.length() >= 1)
+}
+
+///|
+test "src with whitespace around the equals sign is honored" {
+  let proto = iframe_proto_with_session()
+  // Spaces around `=`. The original matcher used the marker
+  // `iframe.src=` (no space) and would have fallen back to about:blank.
+  eval_in_session(
+    proto, 2, "const iframe = document.createElement('iframe'); iframe.src = '/whitespaced'; document.body.appendChild(iframe);",
+  )
+  let children = proto.context_children.get("session-1").unwrap_or([])
+  assert_true(children.length() >= 1)
+}
+
+///|
+test "setAttribute('src', ...) is honored" {
+  let proto = iframe_proto_with_session()
+  eval_in_session(
+    proto, 2, "const iframe = document.createElement('iframe'); iframe.setAttribute('src', '/via-setAttr'); document.body.appendChild(iframe);",
+  )
+  let children = proto.context_children.get("session-1").unwrap_or([])
+  assert_true(children.length() >= 1)
+}
+
+///|
+test "srcdoc creates a child at about:srcdoc" {
+  let proto = iframe_proto_with_session()
+  eval_in_session(
+    proto, 2, "const iframe = document.createElement('iframe'); iframe.srcdoc = '<p>inline</p>'; document.body.appendChild(iframe);",
+  )
+  let children = proto.context_children.get("session-1").unwrap_or([])
+  assert_true(children.length() >= 1)
+}
+
+///|
+test "alternative DOM insertion verb (prepend) registers a child" {
+  let proto = iframe_proto_with_session()
+  eval_in_session(
+    proto, 2, "const iframe = document.createElement('iframe'); iframe.src='/pre'; document.body.prepend(iframe);",
+  )
+  let children = proto.context_children.get("session-1").unwrap_or([])
+  assert_true(children.length() >= 1)
+}
+
+///|
+test "matcher does NOT trigger without a createElement('iframe') call" {
+  let proto = iframe_proto_with_session()
+  // A page that creates a DIV (or any non-iframe element) and inserts
+  // it must NOT trigger child-context registration. Pins the strong
+  // gate condition so the loosened matcher doesn't false-positive.
+  eval_in_session(
+    proto, 2, "const d = document.createElement('div'); d.id='nope'; document.body.appendChild(d);",
+  )
+  let children = proto.context_children.get("session-1").unwrap_or([])
+  // No iframe created → no child context.
+  assert_eq(children.length(), 0)
+}

--- a/webdriver/webdriver/bidi_protocol.mbt
+++ b/webdriver/webdriver/bidi_protocol.mbt
@@ -1379,18 +1379,71 @@ fn BidiProtocol::try_handle_synthetic_iframe_creation(
   expression : String,
 ) -> Bool {
   let trimmed = expression.trim().to_owned()
-  let creates_iframe = (
-      trimmed.contains("createElement('iframe')") ||
-      trimmed.contains("createElement(\"iframe\")")
-    ) &&
-    trimmed.contains("appendChild(iframe)")
-  if !creates_iframe {
+  // Detection: any `createElement('iframe')` (single or double quotes,
+  // optional internal whitespace) followed somewhere by ANY appendChild
+  // call. The previous matcher required the literal `appendChild(iframe)`
+  // — that missed every real-app pattern that names the element variable
+  // anything other than `iframe`, uses a non-document.body parent, or
+  // appends via insertBefore / replaceChild / prepend. Loosening to
+  // "anything that ends in some kind of append" catches the common cases
+  // without false-positive risk (the createElement gate is the strong
+  // condition).
+  let creates_iframe_element = trimmed.contains("createElement('iframe')") ||
+    trimmed.contains("createElement(\"iframe\")")
+  let has_dom_insertion = trimmed.contains("appendChild(") ||
+    trimmed.contains("insertBefore(") ||
+    trimmed.contains("replaceChild(") ||
+    trimmed.contains("prepend(") ||
+    trimmed.contains("append(") ||
+    trimmed.contains("replaceWith(") ||
+    trimmed.contains("before(") ||
+    trimmed.contains("after(")
+  if !creates_iframe_element || !has_dom_insertion {
     return false
   }
 
-  let raw_src = extract_quoted_after_marker(trimmed, "iframe.src=").unwrap_or(
-    "about:blank",
-  )
+  // src extraction: try the canonical `iframe.src=...` form first
+  // (kept for back-compat with the WPT shape), then progressively wider
+  // variants — `.src = ...` with surrounding whitespace, `.srcdoc`,
+  // `setAttribute('src', ...)`. Each variant returns Some when matched;
+  // first match wins. Fall back to about:blank.
+  let raw_src = match extract_quoted_after_marker(trimmed, "iframe.src=") {
+    Some(v) if v != "" => v
+    _ =>
+      match extract_quoted_after_marker(trimmed, ".src = ") {
+        Some(v) if v != "" => v
+        _ =>
+          match extract_quoted_after_marker(trimmed, ".src=") {
+            Some(v) if v != "" => v
+            _ =>
+              match extract_quoted_after_marker(trimmed, ".src =") {
+                Some(v) if v != "" => v
+                _ =>
+                  match
+                    extract_second_quoted_after_marker(
+                      trimmed, "setAttribute('src'",
+                    ) {
+                    Some(v) if v != "" => v
+                    _ =>
+                      match
+                        extract_second_quoted_after_marker(
+                          trimmed, "setAttribute(\"src\"",
+                        ) {
+                        Some(v) if v != "" => v
+                        _ =>
+                          // srcdoc path — inline HTML, no real URL. Per
+                          // spec, srcdoc renders as `about:srcdoc`.
+                          if trimmed.contains(".srcdoc") {
+                            "about:srcdoc"
+                          } else {
+                            "about:blank"
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  }
   let src = if raw_src == "" { "about:blank" } else { raw_src }
 
   let user_ctx = self.context_user_context


### PR DESCRIPTION
Third slice of the #182 tracking issue. The previous matcher at \`try_handle_synthetic_iframe_creation\` only triggered on the narrow WPT shape — variable named \`iframe\`, parent \`document.body\`, \`iframe.src=\` with no whitespace. Real SPAs render iframes with arbitrary variable names, custom parents, alternative insertion verbs, srcdoc, or setAttribute. None of those triggered child-context registration before this PR.

## Detection loosening

- Gate: \`createElement('iframe')\` OR \`createElement(\"iframe\")\` (unchanged)
- Insertion verb: now matches ANY of appendChild / insertBefore / replaceChild / prepend / append / replaceWith / before / after (was: only literal \`appendChild(iframe)\`)

## src extraction fallback chain

| Order | Pattern |
|-------|---------|
| 1 | \`iframe.src=\` (back-compat) |
| 2 | \`.src = \` (whitespace around \`=\`) |
| 3 | \`.src=\` (any preceding variable) |
| 4 | \`.src =\` (left-space only) |
| 5 | \`setAttribute('src', ...)\` / \`setAttribute(\"src\", ...)\` |
| 6 | \`.srcdoc\` → \`about:srcdoc\` per HTML spec |
| 7 | Fallback: \`about:blank\` |

## Tests

7 wbtests in \`bidi_iframe_creation_variants_wbtest.mbt\`. Includes a NEGATIVE test pinning that \`createElement('div')\` + \`appendChild\` does NOT register a child — the createElement-with-'iframe' check remains the strong gate.

## Regression check

\`moon test --target js\`: 3375 / 3375 pass.

## Still open under #182

- Async iframe insertion (\`await\` fences run after the synthetic handler matches)
- DocumentFragment-mediated insertion
- Cross-frame \`iframe.contentWindow.foo\` access for shapes other than the hardcoded WPT one-liner