### PR TITLE
Decode HTML entities and complete Observer surface in BiDi runtime

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1615,6 +1615,8 @@
     }
   },
   "remote": {
+    "http://127.0.0.1:59872/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:62734/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/.nuxt/manifest/meta/dev.json?import": "858f50a24cef1dff3ab43b9cff53db16c168dbff1ada78fc5cab0e95991cc90c",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@dotlottie_player-component.js?v=eb4b3b66": "1ce46030a500cc0383cddbf0cbb9c670fbae7dea9f0e6bcd118d789dfdcee9ba",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@vueuse_core.js?v=eb4b3b66": "5f653b9c57f5782b5bb03702d0c45a3244cede1f4f2de02060ded03abe2ddce3",
@@ -2128,7 +2130,11 @@
     "https://deno.land/std@0.208.0/http/unstable_cookie_map.ts": "b635eb7b87de20ba924ae77aef083d1ee6bca531b85ed518339bf05fb9defc4f",
     "https://deno.land/std@0.208.0/http/unstable_method.ts": "e7a0241972871a1a7dae2ce33e93e32e9d21f165ebeaf88bbe9f5c6b9c20307e",
     "https://deno.land/std@0.208.0/http/unstable_server_sent_event.ts": "6410770e067fc7a67e1acec7592e54b9ff1c95706c9a9457e8d396f23c3eb390",
-    "https://deno.land/std@0.208.0/http/user_agent.ts": "35d3c70d0926b0e121b8c1bbc324b3522479158acaa4f0c43928362b7bf4e6f4"
+    "https://deno.land/std@0.208.0/http/user_agent.ts": "35d3c70d0926b0e121b8c1bbc324b3522479158acaa4f0c43928362b7bf4e6f4",
+    "https://esm.sh/lodash-es@4.17.21/es2022/add.mjs?__crater_module_instance=crater-module-49-0-0": "8466c75c2773cd062a2e1533734623a3dfbada27e53e85065f43af44837cb8e3",
+    "https://esm.sh/lodash-es@4.17.21/es2022/add.mjs?__crater_module_instance=crater-module-49-0-1": "8466c75c2773cd062a2e1533734623a3dfbada27e53e85065f43af44837cb8e3",
+    "https://esm.sh/lodash-es@4.17.21/es2022/add.mjs?__crater_module_instance=crater-module-51-0-0-0": "8466c75c2773cd062a2e1533734623a3dfbada27e53e85065f43af44837cb8e3",
+    "https://esm.sh/lodash-es@4.17.21/es2022/add.mjs?__crater_module_instance=crater-module-51-0-0-1": "8466c75c2773cd062a2e1533734623a3dfbada27e53e85065f43af44837cb8e3"
   },
   "workspace": {
     "packageJson": {

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -1992,6 +1992,32 @@ extern "js" fn js_evaluate_expression(
   #|       cloneNode() { return createMockProcessingInstruction(this.target, this.data); }
   #|     });
   #|
+  #|     const namedEntityTable = {
+  #|       amp: "&", lt: "<", gt: ">", quot: '"', apos: "'",
+  #|       nbsp: " ", ensp: " ", emsp: " ",
+  #|       copy: "©", reg: "®", trade: "™",
+  #|       mdash: "—", ndash: "–",
+  #|       lsquo: "‘", rsquo: "’", ldquo: "“", rdquo: "”",
+  #|       hellip: "…", bull: "•", middot: "·",
+  #|       cent: "¢", pound: "£", euro: "€", yen: "¥",
+  #|       deg: "°", plusmn: "±", times: "×", divide: "÷",
+  #|       frac12: "½", frac14: "¼", frac34: "¾",
+  #|     };
+  #|     const decodeHtmlEntities = (input) => {
+  #|       const s = String(input);
+  #|       if (s.indexOf("&") < 0) return s;
+  #|       return s.replace(/&(#x[0-9A-Fa-f]+|#[0-9]+|[A-Za-z][A-Za-z0-9]{0,8});/g, (whole, body) => {
+  #|         if (body.charCodeAt(0) === 35) { // #
+  #|           const isHex = body.charCodeAt(1) === 120 || body.charCodeAt(1) === 88;
+  #|           const num = isHex ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+  #|           if (!Number.isFinite(num) || num < 0 || num > 0x10FFFF) return whole;
+  #|           try { return String.fromCodePoint(num); } catch (_e) { return whole; }
+  #|         }
+  #|         const named = namedEntityTable[body];
+  #|         return named === undefined ? whole : named;
+  #|       });
+  #|     };
+  #|     globalThis.__bidiDecodeHtmlEntities = decodeHtmlEntities;
   #|     const parseHTMLFragment = (fragmentHtml, ownerDocument) => {
   #|       const source = String(fragmentHtml || "");
   #|       const root = { _children: [] };
@@ -2022,7 +2048,8 @@ extern "js" fn js_evaluate_expression(
   #|         }
   #|         if (token[0] !== "<") {
   #|           if (token.trim() === "") continue;
-  #|           const textNode = createMockTextNode(token);
+  #|           const decoded = decodeHtmlEntities(token);
+  #|           const textNode = createMockTextNode(decoded);
   #|           textNode.ownerDocument = ownerDocument;
   #|           pushNode(stack[stack.length - 1], textNode);
   #|           continue;
@@ -2053,7 +2080,8 @@ extern "js" fn js_evaluate_expression(
   #|         let attrMatch;
   #|         while ((attrMatch = attrRe.exec(attrChunk))) {
   #|           const attrName = String(attrMatch[1]);
-  #|           const attrValue = attrMatch[2] ?? attrMatch[3] ?? attrMatch[4] ?? attrName;
+  #|           const rawAttrValue = attrMatch[2] ?? attrMatch[3] ?? attrMatch[4] ?? attrName;
+  #|           const attrValue = decodeHtmlEntities(rawAttrValue);
   #|           if (attrName.includes(":") && typeof element.setAttributeNS === "function") {
   #|             const ns = attrName.startsWith("svg:") ? "http://www.w3.org/2000/svg" : null;
   #|             element.setAttributeNS(ns, attrName, attrValue);
@@ -3318,6 +3346,16 @@ extern "js" fn js_evaluate_expression(
   #|         this._callback = typeof callback === 'function' ? callback : () => {};
   #|         this._options = options || {};
   #|         this._targets = new Set();
+  #|         this.root = (options && 'root' in options) ? options.root : null;
+  #|         this.rootMargin = (options && typeof options.rootMargin === 'string') ? options.rootMargin : '0px';
+  #|         const t = options ? options.threshold : undefined;
+  #|         if (Array.isArray(t)) {
+  #|           this.thresholds = t.slice().sort((a, b) => a - b);
+  #|         } else if (typeof t === 'number') {
+  #|           this.thresholds = [t];
+  #|         } else {
+  #|           this.thresholds = [0];
+  #|         }
   #|       }
   #|       observe(target) {
   #|         if (!target || this._targets.has(target)) return;
@@ -3379,6 +3417,7 @@ extern "js" fn js_evaluate_expression(
   #|       }
   #|       unobserve(target) { this._targets.delete(target); }
   #|       disconnect() { this._targets.clear(); }
+  #|       takeRecords() { return []; }
   #|     };
   #|     // requestAnimationFrame — batched per frame so multiple
   #|     // synchronous rAF calls coalesce into a single timer fire (matches
@@ -4644,6 +4683,9 @@ extern "js" fn js_evaluate_expression(
   #|           return htmlStr.slice(start, i).toLowerCase();
   #|         };
   #|
+  #|         const decodeEntitiesLocal = (typeof globalThis.__bidiDecodeHtmlEntities === 'function')
+  #|           ? globalThis.__bidiDecodeHtmlEntities
+  #|           : (s) => s;
   #|         const parseAttrValue = () => {
   #|           skipWhitespace();
   #|           if (htmlStr[i] === '=') {
@@ -4656,10 +4698,10 @@ extern "js" fn js_evaluate_expression(
   #|               const end = htmlStr.indexOf(quote, i);
   #|               if (end < 0) {
   #|                 i = len;
-  #|                 return htmlStr.slice(start);
+  #|                 return decodeEntitiesLocal(htmlStr.slice(start));
   #|               }
   #|               i = end + 1;
-  #|               return htmlStr.slice(start, end);
+  #|               return decodeEntitiesLocal(htmlStr.slice(start, end));
   #|             } else {
   #|               const start = i;
   #|               while (i < len) {
@@ -4667,7 +4709,7 @@ extern "js" fn js_evaluate_expression(
   #|                 if (isWhitespaceCode(code) || htmlStr[i] === '>') break;
   #|                 i++;
   #|               }
-  #|               return htmlStr.slice(start, i);
+  #|               return decodeEntitiesLocal(htmlStr.slice(start, i));
   #|             }
   #|           }
   #|           return '';
@@ -4810,7 +4852,7 @@ extern "js" fn js_evaluate_expression(
   #|                 text += htmlStr[i++];
   #|               }
   #|               if (text.trim()) {
-  #|                 el.appendChild(globalThis.document.createTextNode(text));
+  #|                 el.appendChild(globalThis.document.createTextNode(decodeEntitiesLocal(text)));
   #|               }
   #|             }
   #|           }


### PR DESCRIPTION
## Summary

- IntersectionObserver missed `rootMargin`, `thresholds`, and `takeRecords()` — pages reading those off the instance got `undefined`.
- ResizeObserver missed `takeRecords()`, hanging callers that drain pending entries before disconnect.
- Both HTML parsers in the BiDi runtime fed raw token text into text nodes and attribute values, so `&amp;`, `&lt;`, `&copy;`, numeric entities, etc. survived into the DOM. Added a shared `decodeHtmlEntities` helper (named + decimal + hex) and wired it into the text-node and attribute-value paths of `parseHTMLFragment` and the `__loadHTML` hand-rolled parser.

Surfaced while exercising Crater as a Playwright backend against real sites. A re-run against `github.com/mizchi` now shows decoded `&` in headings ("Events & webinars", "SUPPORT & SERVICES") where the raw entities were previously visible.

Inline-whitespace collapse between siblings (`<a>x</a> <span>y</span>` → `"xy"`) is a separate, layout-level problem and is tracked in #201.

## Test plan

- [x] `pnpm test:playwright` — 138/138 green
- [x] `pnpm test:preact` — 49/49 green
- [x] `pnpm test:bidi-e2e` — 13/13 green
- [x] Visual smoke against `https://github.com/mizchi` — entities decoded, baseline layout preserved