### PR TITLE
Expose HTMLHyperlinkElementUtils on <a>, <area>, <link>

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1616,6 +1616,7 @@
   },
   "remote": {
     "http://127.0.0.1:59872/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:60320/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:62734/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/.nuxt/manifest/meta/dev.json?import": "858f50a24cef1dff3ab43b9cff53db16c168dbff1ada78fc5cab0e95991cc90c",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@dotlottie_player-component.js?v=eb4b3b66": "1ce46030a500cc0383cddbf0cbb9c670fbae7dea9f0e6bcd118d789dfdcee9ba",

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -1887,6 +1887,48 @@ extern "js" fn js_evaluate_expression(
   #|       if (lowerTag === 'form') {
   #|         installFormSubmissionMethods(el);
   #|       }
+  #|       if (lowerTag === 'a' || lowerTag === 'area' || lowerTag === 'link') {
+  #|         // HTMLHyperlinkElementUtils — resolves `href` against the current
+  #|         // document base URL and exposes the URL components real pages
+  #|         // read (`a.protocol`, `a.host`, `a.origin`, `a.pathname`, ...).
+  #|         // Without these getters, framework code that decides routing
+  #|         // from `a.href` or `event.target.host` silently sees undefined.
+  #|         const resolvedUrl = function(self) {
+  #|           const raw = self._attrs ? self._attrs.href : undefined;
+  #|           if (raw === undefined || raw === null || raw === '') return null;
+  #|           const base = (globalThis.location && typeof globalThis.location.href === 'string' && globalThis.location.href)
+  #|             ? globalThis.location.href
+  #|             : 'about:blank';
+  #|           try { return new URL(String(raw), base); } catch (_e) { return null; }
+  #|         };
+  #|         const urlProp = (prop) => function() {
+  #|           const url = resolvedUrl(this);
+  #|           if (!url) return '';
+  #|           const value = url[prop];
+  #|           return value === undefined || value === null ? '' : String(value);
+  #|         };
+  #|         Object.defineProperty(el, 'href', {
+  #|           get() {
+  #|             const url = resolvedUrl(this);
+  #|             if (url) return url.href;
+  #|             const raw = this._attrs ? this._attrs.href : undefined;
+  #|             return raw === undefined || raw === null ? '' : String(raw);
+  #|           },
+  #|           set(v) { this._attrs.href = v === undefined || v === null ? '' : String(v); },
+  #|           enumerable: true,
+  #|           configurable: true,
+  #|         });
+  #|         Object.defineProperty(el, 'protocol', { get: urlProp('protocol'), configurable: true });
+  #|         Object.defineProperty(el, 'host', { get: urlProp('host'), configurable: true });
+  #|         Object.defineProperty(el, 'hostname', { get: urlProp('hostname'), configurable: true });
+  #|         Object.defineProperty(el, 'port', { get: urlProp('port'), configurable: true });
+  #|         Object.defineProperty(el, 'pathname', { get: urlProp('pathname'), configurable: true });
+  #|         Object.defineProperty(el, 'search', { get: urlProp('search'), configurable: true });
+  #|         Object.defineProperty(el, 'hash', { get: urlProp('hash'), configurable: true });
+  #|         Object.defineProperty(el, 'origin', { get: urlProp('origin'), configurable: true });
+  #|         Object.defineProperty(el, 'username', { get: urlProp('username'), configurable: true });
+  #|         Object.defineProperty(el, 'password', { get: urlProp('password'), configurable: true });
+  #|       }
   #|       return el;
   #|     };
   #|


### PR DESCRIPTION
## Summary

- `<a>` / `<area>` / `<link>` elements in the BiDi runtime had no URL component getters — `a.href`, `a.protocol`, `a.host`, `a.origin`, `a.pathname`, `a.search`, `a.hash` all returned `undefined`.
- Real pages and framework router code depend on these (`event.target.host`, `a.protocol === "mailto:"`, comparing `a.origin` to `location.origin`, etc.); silently undefined leads to dead routing branches.
- Wire HTMLHyperlinkElementUtils-style getters keyed off the lowercased tag; resolver uses `new URL(attr, base)` with `base = location.href || "about:blank"`. `href` is also settable and writes through to the `href` attribute.

Surfaced while exercising Crater as a Playwright backend against `https://example.com` — `a.href` returned `undefined` for the IANA Learn-more link.

## Test plan

- [x] `pnpm test:playwright` — 138/138 green
- [x] `pnpm test:preact` — 49/49 green
- [x] `pnpm test:bidi-e2e` — 13/13 green
- [x] Real-URL probe: after `page.goto("https://example.com")`, `a.href === "https://iana.org/domains/example"`, `a.protocol === "https:"`, `a.host === "iana.org"`, `a.origin === "https://iana.org"`. `mailto:x@y.z` links report `protocol === "mailto:"`.

## Out of scope

- Anchor click default-action navigation (still no-op; see related findings during the same probe).
- Form submit default-action navigation (same).