### PR TITLE
Navigate on <a> default-action click

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1617,6 +1617,7 @@
   "remote": {
     "http://127.0.0.1:59872/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:60320/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:61175/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:62734/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/.nuxt/manifest/meta/dev.json?import": "858f50a24cef1dff3ab43b9cff53db16c168dbff1ada78fc5cab0e95991cc90c",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@dotlottie_player-component.js?v=eb4b3b66": "1ce46030a500cc0383cddbf0cbb9c670fbae7dea9f0e6bcd118d789dfdcee9ba",

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -1766,7 +1766,20 @@ extern "js" fn js_evaluate_expression(
   #|           return !event.defaultPrevented;
   #|         },
   #|         click() {
-  #|           this.dispatchEvent(globalThis.__bidiCreateEvent('click', { bubbles: true }));
+  #|           const evt = globalThis.__bidiCreateEvent('click', { bubbles: true, cancelable: true });
+  #|           this.dispatchEvent(evt);
+  #|           // Default action for anchors: navigate. Skipped when a listener
+  #|           // calls preventDefault, when the anchor has no href, or when
+  #|           // target asks for a new browsing context (_blank etc. — there
+  #|           // is no second page to host it in test mode).
+  #|           if (evt && evt.defaultPrevented) return;
+  #|           const tag = String(this.tagName || '').toUpperCase();
+  #|           if (tag !== 'A' && tag !== 'AREA') return;
+  #|           const target = this._attrs ? String(this._attrs.target || '').toLowerCase() : '';
+  #|           if (target && target !== '_self') return;
+  #|           const href = typeof this.href === 'string' ? this.href : '';
+  #|           if (!href) return;
+  #|           try { globalThis.location.href = href; } catch (_e) {}
   #|         },
   #|         focus() {
   #|           focusNode(this);


### PR DESCRIPTION
## Summary

- `Element.click()` dispatched a click event but never honored the anchor default action — `<a href>` did nothing for navigation unless user code explicitly set `location.href`.
- Add the default-action navigation step inside `click()` for `<a>` / `<area>`: when the dispatched event isn't `defaultPrevented` and `href` resolves, set `location.href = this.href`.
- Skip for `target` other than `_self` / empty (no second browsing context to host a `_blank` page in test mode).

Follow-up from #203 (URL accessors). Surfaced while trying to drive `https://example.com → click Learn more → land on iana.org` through the Playwright adapter — click event ran, URL stayed put.

## Test plan

- [x] `pnpm test:playwright` — 138/138 green
- [x] `pnpm test:preact` — 49/49 green
- [x] `pnpm test:bidi-e2e` — 13/13 green
- [x] Real-URL probe: `goto("https://example.com")` → `a.click()` → URL is `https://iana.org/domains/example`. `preventDefault()` blocks navigation. `target="_blank"` leaves URL unchanged.

## Out of scope

- Form submit default-action navigation (still no-op; separate fix).