### PR TITLE
Submit/reset owning form on submit-typed button click

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1618,6 +1618,7 @@
     "http://127.0.0.1:59872/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:60320/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:61175/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:61803/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:62734/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/.nuxt/manifest/meta/dev.json?import": "858f50a24cef1dff3ab43b9cff53db16c168dbff1ada78fc5cab0e95991cc90c",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@dotlottie_player-component.js?v=eb4b3b66": "1ce46030a500cc0383cddbf0cbb9c670fbae7dea9f0e6bcd118d789dfdcee9ba",

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -1768,18 +1768,38 @@ extern "js" fn js_evaluate_expression(
   #|         click() {
   #|           const evt = globalThis.__bidiCreateEvent('click', { bubbles: true, cancelable: true });
   #|           this.dispatchEvent(evt);
-  #|           // Default action for anchors: navigate. Skipped when a listener
-  #|           // calls preventDefault, when the anchor has no href, or when
-  #|           // target asks for a new browsing context (_blank etc. — there
-  #|           // is no second page to host it in test mode).
   #|           if (evt && evt.defaultPrevented) return;
   #|           const tag = String(this.tagName || '').toUpperCase();
-  #|           if (tag !== 'A' && tag !== 'AREA') return;
-  #|           const target = this._attrs ? String(this._attrs.target || '').toLowerCase() : '';
-  #|           if (target && target !== '_self') return;
-  #|           const href = typeof this.href === 'string' ? this.href : '';
-  #|           if (!href) return;
-  #|           try { globalThis.location.href = href; } catch (_e) {}
+  #|           // Anchor default action: navigate. Skipped for target != _self
+  #|           // (no second browsing context in test mode) and empty href.
+  #|           if (tag === 'A' || tag === 'AREA') {
+  #|             const target = this._attrs ? String(this._attrs.target || '').toLowerCase() : '';
+  #|             if (target && target !== '_self') return;
+  #|             const href = typeof this.href === 'string' ? this.href : '';
+  #|             if (!href) return;
+  #|             try { globalThis.location.href = href; } catch (_e) {}
+  #|             return;
+  #|           }
+  #|           // Button / input default action: trigger the owning form's
+  #|           // submit / reset path so a Playwright-driven `page.click("#go")`
+  #|           // mirrors a real form interaction. BUTTON without `type` is
+  #|           // implicitly type=submit per WHATWG; INPUT requires an explicit
+  #|           // type=submit or type=reset.
+  #|           if (tag === 'BUTTON' || tag === 'INPUT') {
+  #|             const rawType = this._attrs && typeof this._attrs.type === 'string'
+  #|               ? this._attrs.type.toLowerCase()
+  #|               : '';
+  #|             let buttonType = rawType;
+  #|             if (tag === 'BUTTON' && !buttonType) buttonType = 'submit';
+  #|             if (buttonType !== 'submit' && buttonType !== 'reset') return;
+  #|             const owningForm = typeof this.closest === 'function' ? this.closest('form') : null;
+  #|             if (!owningForm) return;
+  #|             if (buttonType === 'submit' && typeof owningForm.requestSubmit === 'function') {
+  #|               try { owningForm.requestSubmit(this); } catch (_e) {}
+  #|             } else if (buttonType === 'reset' && typeof owningForm.reset === 'function') {
+  #|               try { owningForm.reset(); } catch (_e) {}
+  #|             }
+  #|           }
   #|         },
   #|         focus() {
   #|           focusNode(this);


### PR DESCRIPTION
## Summary

- `form.submit()` already navigated correctly when called directly, but `<button type="submit">` click was a no-op — the click event fired, no submit dispatched, no navigation.
- Wire the click() default action for `<button>` / `<input>` to call `form.requestSubmit(this)` (or `form.reset()` for `type="reset"`) on the closest owning form.
- BUTTON without a `type` attribute is treated as `type=submit` per WHATWG.
- `requestSubmit` already dispatches a cancelable submit event, so user code that calls `preventDefault` still wins.

Follow-up from #204 (anchor click navigation). Surfaced trying to drive a form-based search through the Playwright adapter — `page.click("button[type=submit]")` returned but the URL stayed put.

## Test plan

- [x] `pnpm test:playwright` — 138/138 green
- [x] `pnpm test:preact` — 49/49 green
- [x] `pnpm test:bidi-e2e` — 13/13 green
- [x] Real-form probe: `<form action="https://example.org" method="GET"><button type="submit">` → button click navigates to `https://example.org/?q=hi`.
- [x] `<button type="reset">` restores input default value.
- [x] Submit-event `preventDefault` keeps URL unchanged.