### PR TITLE
Expose form / form-control IDL accessors on shim elements

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1619,6 +1619,7 @@
     "http://127.0.0.1:60320/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:61175/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:61803/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:62325/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:62734/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/.nuxt/manifest/meta/dev.json?import": "858f50a24cef1dff3ab43b9cff53db16c168dbff1ada78fc5cab0e95991cc90c",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@dotlottie_player-component.js?v=eb4b3b66": "1ce46030a500cc0383cddbf0cbb9c670fbae7dea9f0e6bcd118d789dfdcee9ba",

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -1919,6 +1919,92 @@ extern "js" fn js_evaluate_expression(
   #|       };
   #|       if (lowerTag === 'form') {
   #|         installFormSubmissionMethods(el);
+  #|         // HTMLFormElement attribute-backed getters. `action` resolves
+  #|         // against the document base URL like the spec; when missing it
+  #|         // defaults to the current location. `method` defaults to "get".
+  #|         Object.defineProperty(el, 'action', {
+  #|           get() {
+  #|             const raw = this._attrs ? this._attrs.action : undefined;
+  #|             const base = (globalThis.location && typeof globalThis.location.href === 'string' && globalThis.location.href)
+  #|               ? globalThis.location.href
+  #|               : 'about:blank';
+  #|             if (raw === undefined || raw === null || raw === '') return base;
+  #|             try { return new URL(String(raw), base).href; } catch (_e) { return String(raw); }
+  #|           },
+  #|           set(v) { this._attrs.action = v === undefined || v === null ? '' : String(v); },
+  #|           enumerable: true, configurable: true,
+  #|         });
+  #|         Object.defineProperty(el, 'method', {
+  #|           get() {
+  #|             const raw = this._attrs ? this._attrs.method : undefined;
+  #|             if (raw === undefined || raw === null) return 'get';
+  #|             const lower = String(raw).toLowerCase();
+  #|             return lower === 'post' || lower === 'dialog' ? lower : 'get';
+  #|           },
+  #|           set(v) { this._attrs.method = v === undefined || v === null ? '' : String(v); },
+  #|           enumerable: true, configurable: true,
+  #|         });
+  #|         const formAttrGetter = (name) => ({
+  #|           get() {
+  #|             const v = this._attrs ? this._attrs[name] : undefined;
+  #|             return v === undefined || v === null ? '' : String(v);
+  #|           },
+  #|           set(v) { this._attrs[name] = v === undefined || v === null ? '' : String(v); },
+  #|           enumerable: true, configurable: true,
+  #|         });
+  #|         Object.defineProperty(el, 'name', formAttrGetter('name'));
+  #|         Object.defineProperty(el, 'target', formAttrGetter('target'));
+  #|         Object.defineProperty(el, 'enctype', formAttrGetter('enctype'));
+  #|         Object.defineProperty(el, 'acceptCharset', formAttrGetter('accept-charset'));
+  #|         Object.defineProperty(el, 'autocomplete', formAttrGetter('autocomplete'));
+  #|         Object.defineProperty(el, 'noValidate', {
+  #|           get() { return this._attrs ? ('novalidate' in this._attrs) : false; },
+  #|           set(v) {
+  #|             if (v) this._attrs.novalidate = '';
+  #|             else delete this._attrs.novalidate;
+  #|           },
+  #|           enumerable: true, configurable: true,
+  #|         });
+  #|       }
+  #|       if (lowerTag === 'input' || lowerTag === 'button' || lowerTag === 'select' || lowerTag === 'textarea') {
+  #|         // Form-associated control attribute-backed getters. These mirror
+  #|         // the IDL surface real pages depend on (form serialization,
+  #|         // routing, validation). Pure attribute reflection; behavior like
+  #|         // checked/value state for checkboxes is already on the shim and
+  #|         // not touched here.
+  #|         const controlAttrGetter = (name, fallback) => ({
+  #|           get() {
+  #|             const v = this._attrs ? this._attrs[name] : undefined;
+  #|             if (v === undefined || v === null) return fallback;
+  #|             return String(v);
+  #|           },
+  #|           set(v) { this._attrs[name] = v === undefined || v === null ? '' : String(v); },
+  #|           enumerable: true, configurable: true,
+  #|         });
+  #|         // `type` defaults vary by tag: INPUT → "text", BUTTON → "submit".
+  #|         const typeDefault = lowerTag === 'button' ? 'submit' : (lowerTag === 'input' ? 'text' : '');
+  #|         Object.defineProperty(el, 'name', controlAttrGetter('name', ''));
+  #|         Object.defineProperty(el, 'type', controlAttrGetter('type', typeDefault));
+  #|         Object.defineProperty(el, 'placeholder', controlAttrGetter('placeholder', ''));
+  #|         Object.defineProperty(el, 'autocomplete', controlAttrGetter('autocomplete', ''));
+  #|         // Boolean reflections — present iff the attribute exists.
+  #|         const boolAttr = (name) => ({
+  #|           get() { return this._attrs ? (name in this._attrs) : false; },
+  #|           set(v) {
+  #|             if (v) this._attrs[name] = '';
+  #|             else delete this._attrs[name];
+  #|           },
+  #|           enumerable: true, configurable: true,
+  #|         });
+  #|         Object.defineProperty(el, 'disabled', boolAttr('disabled'));
+  #|         Object.defineProperty(el, 'required', boolAttr('required'));
+  #|         Object.defineProperty(el, 'readOnly', boolAttr('readonly'));
+  #|         Object.defineProperty(el, 'form', {
+  #|           get() {
+  #|             return typeof this.closest === 'function' ? this.closest('form') : null;
+  #|           },
+  #|           enumerable: true, configurable: true,
+  #|         });
   #|       }
   #|       if (lowerTag === 'a' || lowerTag === 'area' || lowerTag === 'link') {
   #|         // HTMLHyperlinkElementUtils — resolves `href` against the current


### PR DESCRIPTION
## Summary

- Same shape gap as #203 (anchor URL accessors): `<form>` / `<input>` / `<button>` / `<select>` / `<textarea>` had no property getters for the attributes Playwright tests and routing code read. `form.action`, `form.method`, `input.name`, `button.type` etc. returned `undefined`.
- Wire attribute-backed getters keyed off the lowercased tag:
  - HTMLFormElement: `action` (URL-resolved against `location.href`, falls back to base when missing — matches spec), `method` (defaults `"get"`; `"post"` / `"dialog"` only), `enctype`, `target`, `name`, `acceptCharset`, `autocomplete`, `noValidate` (boolean reflection of `novalidate`).
  - INPUT / BUTTON / SELECT / TEXTAREA: `name`, `type` (INPUT default `"text"`, BUTTON default `"submit"`), `placeholder`, `autocomplete`, boolean `disabled` / `required` / `readOnly`, `form` returning the closest owning `<form>`.

Surfaced while trying to drive a search-box flow through the Playwright adapter — `input.name` and `form.action` were both `null`, breaking any code that introspects form structure.

## Test plan

- [x] `pnpm test:playwright` — 138/138 green
- [x] `pnpm test:preact` — 49/49 green
- [x] `pnpm test:bidi-e2e` — 13/13 green
- [x] Probe: `<form action="/search" method="POST" novalidate>` reports `action="/search"`, `method="post"`, `noValidate=true`. `<input type=email name=email required>` reports `name="email"`, `type="email"`, `required=true`, `form === <form>`. `<button>` without `type` reports `type="submit"`, `form === <form>`. INPUT without explicit `type` reports `type="text"`.

## Out of scope

- `page.fill` actionability check rejecting visible elements on real pages (separate "visibility" gap surfaced in the same probe).