### PR TITLE
Propagate Locator.click anchor navigation to page.url() (partial #208)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1621,6 +1621,7 @@
     "http://127.0.0.1:61803/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:62325/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:62734/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:64895/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/.nuxt/manifest/meta/dev.json?import": "858f50a24cef1dff3ab43b9cff53db16c168dbff1ada78fc5cab0e95991cc90c",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@dotlottie_player-component.js?v=eb4b3b66": "1ce46030a500cc0383cddbf0cbb9c670fbae7dea9f0e6bcd118d789dfdcee9ba",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@vueuse_core.js?v=eb4b3b66": "5f653b9c57f5782b5bb03702d0c45a3244cede1f4f2de02060ded03abe2ddce3",

--- a/webdriver/playwright/adapter.ts
+++ b/webdriver/playwright/adapter.ts
@@ -725,6 +725,32 @@ function adapterDomActionsExpr(): string {
       };
       const clickElement = (element) => {
         recordFileChooser(element);
+        // Pre-record anchor default-action navigation. The in-realm
+        // shim click() would do this, but the element returned by
+        // the Locator-path querySelectorAll is not always the same
+        // object the runtime shim attached methods to, so the override
+        // never fires. Recording here is a no-op when the shim does
+        // run (same URL gets written twice). See issue 208.
+        try {
+          const tag = String(element.tagName || "").toUpperCase();
+          if (tag === "A" || tag === "AREA") {
+            const targetAttr = element._attrs && element._attrs.target;
+            const targetGet = (typeof element.getAttribute === "function") ? element.getAttribute("target") : "";
+            const target = String(targetAttr || targetGet || "").toLowerCase();
+            if (!target || target === "_self") {
+              const hrefProp = element.href;
+              const hrefAttr = element._attrs && element._attrs.href;
+              const href = hrefProp || hrefAttr || "";
+              if (href) {
+                globalThis.__craterPendingNavigation = {
+                  url: String(href),
+                  kind: "anchor",
+                  urlOnly: true,
+                };
+              }
+            }
+          }
+        } catch (_e) {}
         element.click();
       };
       const hoverElement = (element) => {
@@ -4972,8 +4998,16 @@ export class CraterBidiPage {
         if (!raw) {
           return;
         }
-        const pending = JSON.parse(raw) as { url?: string };
+        const pending = JSON.parse(raw) as { url?: string; urlOnly?: boolean };
         if (!pending.url) {
+          continue;
+        }
+        if (pending.urlOnly) {
+          // Synthetic URL update — anchor / form default action recorded
+          // a new in-realm location but didn't request a real fetch.
+          // Mirror it onto `currentUrl` so `page.url()` reflects the
+          // new location without tearing down the document. (#208)
+          this.currentUrl = pending.url;
           continue;
         }
         await this.loadPage(pending.url);
@@ -5122,7 +5156,15 @@ export class CraterBidiPage {
         return;
       }
       const value = deserializeBidiValue(result.result);
-      if (typeof value === "string" && value) {
+      // Skip overwriting `currentUrl` with the in-realm
+      // `about:blank` default — the realm starts there for every fresh
+      // context and never gets the synthetic post-click URL written
+      // back because the click happens in a different context-window
+      // instance (see #208 attempt notes). A real navigation calls
+      // `syncRuntimeLocation` directly, which sets `currentUrl` ahead
+      // of the realm read, so skipping `about:blank` here only loses
+      // information when the truth was already `about:blank`.
+      if (typeof value === "string" && value && value !== "about:blank") {
         this.currentUrl = value;
       }
     } catch (_error) {}

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -1138,6 +1138,10 @@ extern "js" fn js_evaluate_expression(
   #|           try { globalThis.location.href = target; } catch (_e) {}
   #|         }
   #|         globalThis.__pageUrl = target;
+  #|         // Record a synthetic navigation for the adapter, in case the
+  #|         // __loadPage path below isn't wired (test mode without a
+  #|         // network). (#208)
+  #|         globalThis.__craterPendingNavigation = { url: target, kind: 'form-get', urlOnly: true };
   #|         if (typeof globalThis.__loadPageWithScripts === 'function') {
   #|           try {
   #|             const np = globalThis.__loadPageWithScripts(target);
@@ -1778,6 +1782,11 @@ extern "js" fn js_evaluate_expression(
   #|             const href = typeof this.href === 'string' ? this.href : '';
   #|             if (!href) return;
   #|             try { globalThis.location.href = href; } catch (_e) {}
+  #|             // Record a synthetic navigation so the adapter can mirror
+  #|             // the new URL onto `page.url()`. `urlOnly` skips the full
+  #|             // fetch+reload path and just updates the tracked URL,
+  #|             // leaving the document in place. (#208)
+  #|             globalThis.__craterPendingNavigation = { url: href, kind: 'anchor', urlOnly: true };
   #|             return;
   #|           }
   #|           // Button / input default action: trigger the owning form's


### PR DESCRIPTION
## Summary

Partial resolution of #208. Anchor and form-GET default actions from #204 / #205 wrote `location.href` in-realm but `page.url()` kept the old value. Reasons:

- The shim `click()` override doesn't fire reliably on the Locator-path query instance.
- `refreshCurrentUrl` would unconditionally overwrite `currentUrl` with whatever `location.href` reads back — `about:blank` on misses — erasing whatever a flush had set.

## Changes

- `flushPendingNavigation` honors `urlOnly: true` on `__craterPendingNavigation`: just mirror the URL onto `currentUrl`, skip `loadPage`. No fetch / no document teardown.
- Shim `click()` (anchor branch) and form GET path now write `{url, urlOnly: true}` alongside the existing `location.href` assignment.
- `adapterDomActionsExpr().clickElement` pre-records the same `{url, urlOnly: true}` when the target is `<a>` / `<area>` — covers the Locator-path query mismatch.
- `refreshCurrentUrl` skips overwriting `currentUrl` with `about:blank` (the realm's pre-navigation default).

## What works

- `page.locator("#a").click()` against `<a href="https://example.org/x">` advances `page.url()` to `https://example.org/x`.
- `location.assign("...")` / `location.replace("...")` continue to work (covered by the existing `__craterPendingNavigation` mechanism).
- Form GET submission via `page.locator("button[type=submit]").click()` reaches `page.url()` updates.

## What does NOT (yet)

- `page.click(selector)` — this routes through BiDi `input.performActions` (simulated pointer), which dispatches a click event without going through the shim `click()` method. Default-action navigation needs to happen server-side in MoonBit's BiDi input handler. Filed as a follow-up.

## Test plan

- [x] `pnpm test:playwright` — 138/138 green
- [x] `pnpm test:preact` — 49/49 green
- [x] `pnpm test:bidi-e2e` — 13/13 green