### PR TITLE
Propagate page.click pointer navigation to page.url() (#208 remainder)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1622,6 +1622,7 @@
     "http://127.0.0.1:62325/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:62734/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:64895/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:65517/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/.nuxt/manifest/meta/dev.json?import": "858f50a24cef1dff3ab43b9cff53db16c168dbff1ada78fc5cab0e95991cc90c",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@dotlottie_player-component.js?v=eb4b3b66": "1ce46030a500cc0383cddbf0cbb9c670fbae7dea9f0e6bcd118d789dfdcee9ba",
     "http://localhost:5500/_nuxt/@fs/Users/mz/ghq/github.com/studio-design/studio-publish-regression-test/studio-preview/node_modules/.cache/vite/client/deps/@vueuse_core.js?v=eb4b3b66": "5f653b9c57f5782b5bb03702d0c45a3244cede1f4f2de02060ded03abe2ddce3",

--- a/webdriver/webdriver/bidi_protocol_frame_event_navigation.mbt
+++ b/webdriver/webdriver/bidi_protocol_frame_event_navigation.mbt
@@ -126,4 +126,12 @@ fn BidiProtocol::handle_pointer_click_navigation(
   let nav_id = self.next_navigation_id.to_string()
   self.next_navigation_id += 1
   self.emit_navigation_events(ctx_id, destination, nav_id)
+  // Push the destination as a synthetic-navigation marker so the
+  // adapter's `flushPendingNavigation` picks it up on the next
+  // `script.evaluate` boundary and mirrors it onto `page.url()`.
+  // The shim `click()` path doesn't run for `input.performActions`
+  // pointer simulation, so without this `page.click(selector)`
+  // would leave `page.url()` stale even after the server-side
+  // session URL advanced. (#208)
+  push_synthetic_navigation(destination)
 }

--- a/webdriver/webdriver/bidi_runtime_context.mbt
+++ b/webdriver/webdriver/bidi_runtime_context.mbt
@@ -1314,6 +1314,27 @@ fn drain_pending_user_prompts() -> String {
 }
 
 ///|
+/// Push a synthetic-navigation marker onto the JS realm so the adapter's
+/// `flushPendingNavigation` can mirror it onto `currentUrl` on the next
+/// `script.evaluate` boundary. Used by server-side pointer-click
+/// navigation (`input.performActions` path), where the in-realm shim
+/// `click()` default action doesn't run. (#208)
+pub extern "js" fn js_push_synthetic_navigation(url : String) -> Unit =
+  #| (url) => {
+  #|   if (typeof url !== "string" || url.length === 0) return;
+  #|   globalThis.__craterPendingNavigation = {
+  #|     url: url,
+  #|     kind: "pointer-click",
+  #|     urlOnly: true,
+  #|   };
+  #| }
+
+///|
+fn push_synthetic_navigation(url : String) -> Unit {
+  js_push_synthetic_navigation(url)
+}
+
+///|
 /// Check if runtime handle exists in current JS handle store.
 extern "js" fn js_has_runtime_handle(handle_id : String) -> Bool =
   #| (handleId) => {


### PR DESCRIPTION
## Summary

Completes #208. PR #209 covered `page.locator(sel).click()`. The other half — `page.click(selector)` — routes through BiDi `input.performActions` (simulated pointer) and dispatches click server-side without running the in-realm shim `click()` method, so the synthetic-navigation marker was never written.

The pointer-click anchor resolver (`handle_pointer_click_navigation`) already calls `session.navigate_to`, but the adapter's `currentUrl` is independent of the server-side session URL — only `__craterPendingNavigation` flushes or explicit `syncRuntimeLocation` calls move it.

## Changes

- Add `js_push_synthetic_navigation` extern: writes `{url, urlOnly: true}` onto the JS realm.
- `handle_pointer_click_navigation` invokes the new extern right after the `session.navigate_to` and event emission.
- The next `script.evaluate` boundary drains the marker via the existing #209 flush path and mirrors the URL onto `page.url()`. No document teardown — the `urlOnly` short-circuit keeps `setContent` state intact.

## Validated

- `page.click("#a")` on `<a href="https://example.org/x">` advances `page.url()` to `https://example.org/x`.
- `page.locator(sel).click()` continues to work via the #209 path.

## Test plan

- [x] `pnpm test:playwright` — 138/138 green
- [x] `pnpm test:preact` — 49/49 green
- [x] `pnpm test:bidi-e2e` — 13/13 green