### PR TITLE
Add Playwright-compatible force option to Locator/page actions

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1615,6 +1615,10 @@
     }
   },
   "remote": {
+    "http://127.0.0.1:49916/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:50116/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:50452/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
+    "http://127.0.0.1:51147/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:59872/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:60320/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",
     "http://127.0.0.1:61175/assets/nested/value.js?__crater_module_instance=crater-module-26-0-1": "c0b01d360a3bff57f9a4784e750cb895a4866ace3f4fa80c0dabf8816d9fd8ec",

--- a/webdriver/playwright/adapter.ts
+++ b/webdriver/playwright/adapter.ts
@@ -137,6 +137,13 @@ export type CraterWaitForFunctionOptions = {
 
 export type CraterLocatorActionOptions = {
   timeout?: number;
+  /**
+   * Skip the actionability check (visible + enabled + stable bounding rect).
+   * Matches Playwright's `force` option. Useful for pages where Crater's
+   * visibility heuristic incorrectly rejects an element (#207) — the caller
+   * has already decided the element is the right target.
+   */
+  force?: boolean;
 };
 
 const FULL_PAGE_SCREENSHOT_MAX_HEIGHT = 16384;
@@ -2194,7 +2201,7 @@ export class CraterLocator {
   }
 
   async click(options: CraterLocatorActionOptions = {}): Promise<void> {
-    await this.waitForActionable(options);
+    if (!options.force) await this.waitForActionable(options);
     await this.page.evaluate(`
       (() => {
         const el = ${this.queryExpr("querySelector")};
@@ -2207,7 +2214,7 @@ export class CraterLocator {
   }
 
   async hover(options: CraterLocatorActionOptions = {}): Promise<void> {
-    await this.waitForActionable(options);
+    if (!options.force) await this.waitForActionable(options);
     await this.page.evaluate(`
       (() => {
         const el = ${this.queryExpr("querySelector")};
@@ -2280,8 +2287,8 @@ export class CraterLocator {
     await markLiveDomCaptureNeeded(this.page);
   }
 
-  async focus(): Promise<void> {
-    await this.waitForActionable();
+  async focus(options: CraterLocatorActionOptions = {}): Promise<void> {
+    if (!options.force) await this.waitForActionable(options);
     await this.page.evaluate(`
       (() => {
         const el = ${this.queryExpr("querySelector")};
@@ -2297,7 +2304,7 @@ export class CraterLocator {
   }
 
   async fill(value: string, options: CraterLocatorActionOptions = {}): Promise<void> {
-    await this.waitForActionable(options);
+    if (!options.force) await this.waitForActionable(options);
     await this.page.evaluate(`
       (() => {
         ${adapterDomActionsExpr()}
@@ -2314,8 +2321,8 @@ export class CraterLocator {
     await this.fill("");
   }
 
-  async type(text: string): Promise<void> {
-    await this.waitForActionable();
+  async type(text: string, options: CraterLocatorActionOptions = {}): Promise<void> {
+    if (!options.force) await this.waitForActionable(options);
     const handled = await this.page.evaluate<boolean>(`
       (() => {
         ${adapterDomActionsExpr()}
@@ -2368,16 +2375,19 @@ export class CraterLocator {
     await markLiveDomCaptureNeeded(this.page);
   }
 
-  async check(): Promise<void> {
-    await this.setChecked(true);
+  async check(options: CraterLocatorActionOptions = {}): Promise<void> {
+    await this.setChecked(true, options);
   }
 
-  async uncheck(): Promise<void> {
-    await this.setChecked(false);
+  async uncheck(options: CraterLocatorActionOptions = {}): Promise<void> {
+    await this.setChecked(false, options);
   }
 
-  async selectOption(value: CraterSelectOptionValue): Promise<void> {
-    await this.waitForActionable();
+  async selectOption(
+    value: CraterSelectOptionValue,
+    options: CraterLocatorActionOptions = {},
+  ): Promise<void> {
+    if (!options.force) await this.waitForActionable(options);
     const requestExpr = jsValue(value);
     await this.page.evaluate(`
       (() => {
@@ -2612,8 +2622,11 @@ export class CraterLocator {
     `);
   }
 
-  private async setChecked(checked: boolean): Promise<void> {
-    await this.waitForActionable();
+  private async setChecked(
+    checked: boolean,
+    options: CraterLocatorActionOptions = {},
+  ): Promise<void> {
+    if (!options.force) await this.waitForActionable(options);
     await this.page.evaluate(`
       (() => {
         ${adapterDomActionsExpr()}
@@ -5435,8 +5448,12 @@ export class CraterBidiPage {
     await this.performPointer(pointerMoveActions(sharedId));
   }
 
-  async fill(selector: string, value: string): Promise<void> {
-    await this.locator(selector).fill(value);
+  async fill(
+    selector: string,
+    value: string,
+    options: CraterLocatorActionOptions = {},
+  ): Promise<void> {
+    await this.locator(selector).fill(value, options);
   }
 
   async type(selector: string, text: string): Promise<void> {


### PR DESCRIPTION
## Summary

Partial workaround for #207. Real pages whose visibility check rejects an element the caller knows is valid had no way to drive the interaction without timing out. Playwright's adapter exposes a `force` option that bypasses actionability; Crater's adapter didn't honor it.

## Changes

- Add `force?: boolean` to `CraterLocatorActionOptions`.
- Honor in every Locator action that runs `waitForActionable`: `click`, `hover`, `fill`, `focus`, `type`, `selectOption`, and the internal `setChecked` for `check` / `uncheck`.
- `page.fill(selector, value, options?)` now passes the option through to the locator.
- `page.click` / `page.hover` already route through `input.performActions` (server-side simulated pointer) and don't run the actionability check, so they're unaffected by this change.

## Validation

- Local fixture: `<div style="display: none"><input id="q"></div>` rejects `page.fill("#q", ...)` with "not visible"; `page.fill("#q", ..., { force: true })` succeeds and `input.value` reads back as expected.
- The root cause for real pages (DDG, etc.) where the ancestor walk decides "not visible" against actually-visible elements is still tracked in #207; this PR only gives callers an escape hatch.

## Test plan

- [x] `pnpm test:playwright` — 138/138 green
- [x] `pnpm test:preact` — 49/49 green
- [x] `pnpm test:bidi-e2e` — 13/13 green
- [x] `pnpm typecheck` clean