### PR TITLE
Add layout-shift metric to paint VRT comparison (closes #212)

### DIFF
--- a/scripts/vrt-report-contract.ts
+++ b/scripts/vrt-report-contract.ts
@@ -30,6 +30,14 @@ export interface VrtCssRuleUsageMetrics {
   sameAsFallbackRules?: number;
 }
 
+export interface VrtLayoutShiftMetrics {
+  avgLeftShiftPx?: number;
+  maxLeftShiftPx?: number;
+  avgRightShiftPx?: number;
+  maxRightShiftPx?: number;
+  contentRowCount?: number;
+}
+
 export interface VrtArtifactMetrics {
   width?: number;
   height?: number;
@@ -44,6 +52,8 @@ export interface VrtArtifactMetrics {
   viewport?: VrtArtifactViewport;
   snapshotKind?: string;
   cssRuleUsage?: VrtCssRuleUsageMetrics;
+  maxLayoutShiftPx?: number;
+  layoutShift?: VrtLayoutShiftMetrics;
 }
 
 export interface VrtStableIdentity {
@@ -186,6 +196,19 @@ function asCssRuleUsageMetrics(value: unknown): VrtCssRuleUsageMetrics | undefin
     : undefined;
 }
 
+function asLayoutShiftMetrics(value: unknown): VrtLayoutShiftMetrics | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  const metrics: VrtLayoutShiftMetrics = {
+    avgLeftShiftPx: asFiniteNumber(record.avgLeftShiftPx),
+    maxLeftShiftPx: asFiniteNumber(record.maxLeftShiftPx),
+    avgRightShiftPx: asFiniteNumber(record.avgRightShiftPx),
+    maxRightShiftPx: asFiniteNumber(record.maxRightShiftPx),
+    contentRowCount: asFiniteNumber(record.contentRowCount),
+  };
+  return Object.values(metrics).some((v) => v !== undefined) ? metrics : undefined;
+}
+
 function normalizeMetrics(record: Record<string, unknown>): VrtArtifactMetrics {
   return {
     width: asFiniteNumber(record.width),
@@ -203,6 +226,8 @@ function normalizeMetrics(record: Record<string, unknown>): VrtArtifactMetrics {
       ? record.snapshotKind
       : undefined,
     cssRuleUsage: asCssRuleUsageMetrics(record.cssRuleUsage),
+    maxLayoutShiftPx: asFiniteNumber(record.maxLayoutShiftPx),
+    layoutShift: asLayoutShiftMetrics(record.layoutShift),
   };
 }
 
@@ -431,10 +456,16 @@ export function createNormalizedVrtArtifactReport(
     variant,
     shard: input.shard,
   });
+  const layoutShiftPass = metadata.maxLayoutShiftPx === undefined
+    ? true
+    : metadata.layoutShift === undefined
+    ? false
+    : (metadata.layoutShift.maxLeftShiftPx ?? 0) <= metadata.maxLayoutShiftPx
+      && (metadata.layoutShift.maxRightShiftPx ?? 0) <= metadata.maxLayoutShiftPx;
   const derivedStatus = input.status ?? (
     metadata.diffRatio === undefined || metadata.maxDiffRatio === undefined
       ? "unknown"
-      : metadata.diffRatio <= metadata.maxDiffRatio
+      : metadata.diffRatio <= metadata.maxDiffRatio && layoutShiftPass
       ? "pass"
       : "fail"
   );

--- a/tests/helpers/crater-vrt.ts
+++ b/tests/helpers/crater-vrt.ts
@@ -61,6 +61,14 @@ export interface VisualDiffOptions {
   backgroundTolerance?: number;
   maskToVisibleContent?: boolean;
   maskPadding?: number;
+  /**
+   * Optional cap on the per-row left/right content-edge displacement between
+   * chromium and crater (in pixels). When set, the comparison fails if any
+   * row's left or right edge is shifted by more than this many pixels. Catches
+   * cases where `diffRatio` stays low because shifted content lands on a same-
+   * colored background (e.g. when a whole table column is offset).
+   */
+  maxLayoutShiftPx?: number;
   report?: VrtArtifactReportContext;
 }
 
@@ -74,6 +82,8 @@ export interface VisualDiffResult {
   maskPixels?: number;
   threshold: number;
   maxDiffRatio: number;
+  layoutShift?: LayoutShiftMetrics;
+  maxLayoutShiftPx?: number;
   chromiumPath: string;
   craterPath: string;
   diffPath: string;
@@ -243,6 +253,7 @@ export function buildVrtArtifactReportJson(
     roi?: RoiRect;
     maskPixels?: number;
     cssRuleUsage?: VrtCssRuleUsageMetrics;
+    layoutShift?: LayoutShiftMetrics;
   },
 ): string {
   const title = resolveReportTitle(options);
@@ -287,6 +298,8 @@ export function buildVrtArtifactReportJson(
       maskPixels: metrics.maskPixels,
       threshold: options.threshold,
       maxDiffRatio: options.maxDiffRatio,
+      maxLayoutShiftPx: options.maxLayoutShiftPx,
+      layoutShift: metrics.layoutShift,
       backend,
       viewport: {
         width: metrics.width,
@@ -404,6 +417,97 @@ function detectContentRoi(
     y,
     width: Math.max(1, right - x),
     height: Math.max(1, bottom - y),
+  };
+}
+
+export interface LayoutShiftMetrics {
+  avgLeftShiftPx: number;
+  maxLeftShiftPx: number;
+  avgRightShiftPx: number;
+  maxRightShiftPx: number;
+  contentRowCount: number;
+}
+
+/**
+ * Per-row "earliest x where chromium and crater disagree". Catches layout
+ * displacement that pixelmatch's diffRatio under-weighs when the displaced
+ * content lands on a same-colored region (e.g. a whole table column offset
+ * inside a same-colored background band).
+ *
+ * For each row, we walk both images side by side and find the first and last
+ * x at which the two pixels differ by more than `tolerance`. We then report
+ * the x-distance from the nearest image edge so that a row with no diff
+ * contributes 0 and a row with diff at the very edge contributes 0 too —
+ * only diffs that have travelled inward count as a layout shift.
+ */
+export function computeLayoutShiftMetrics(
+  chromium: DecodedImage,
+  crater: DecodedImage,
+  options: { tolerance?: number } = {},
+): LayoutShiftMetrics {
+  if (chromium.width !== crater.width || chromium.height !== crater.height) {
+    throw new Error(
+      "computeLayoutShiftMetrics requires images of identical dimensions",
+    );
+  }
+  const tolerance = options.tolerance ?? 18;
+  const w = chromium.width;
+  const h = chromium.height;
+  let sumLeft = 0;
+  let sumRight = 0;
+  let maxLeft = 0;
+  let maxRight = 0;
+  let rows = 0;
+  for (let y = 0; y < h; y += 1) {
+    const rowStart = y * w * 4;
+    let firstDiff = -1;
+    let lastDiff = -1;
+    for (let x = 0; x < w; x += 1) {
+      const off = rowStart + x * 4;
+      const dr = Math.abs(
+        (chromium.data[off] ?? 0) - (crater.data[off] ?? 0),
+      );
+      const dg = Math.abs(
+        (chromium.data[off + 1] ?? 0) - (crater.data[off + 1] ?? 0),
+      );
+      const db = Math.abs(
+        (chromium.data[off + 2] ?? 0) - (crater.data[off + 2] ?? 0),
+      );
+      const da = Math.abs(
+        (chromium.data[off + 3] ?? 0) - (crater.data[off + 3] ?? 0),
+      );
+      const delta = dr + dg + db + da;
+      if (delta <= tolerance) continue;
+      if (firstDiff < 0) firstDiff = x;
+      lastDiff = x;
+    }
+    if (firstDiff < 0) continue;
+    // firstDiff = how far from the left edge the first mismatch sits.
+    // (w - 1 - lastDiff) = how far from the right edge the last mismatch sits.
+    // Both grow when content has been shifted inward on one side.
+    const leftShift = firstDiff;
+    const rightShift = w - 1 - lastDiff;
+    sumLeft += leftShift;
+    sumRight += rightShift;
+    if (leftShift > maxLeft) maxLeft = leftShift;
+    if (rightShift > maxRight) maxRight = rightShift;
+    rows += 1;
+  }
+  if (rows === 0) {
+    return {
+      avgLeftShiftPx: 0,
+      maxLeftShiftPx: 0,
+      avgRightShiftPx: 0,
+      maxRightShiftPx: 0,
+      contentRowCount: 0,
+    };
+  }
+  return {
+    avgLeftShiftPx: sumLeft / rows,
+    maxLeftShiftPx: maxLeft,
+    avgRightShiftPx: sumRight / rows,
+    maxRightShiftPx: maxRight,
+    contentRowCount: rows,
   };
 }
 
@@ -766,6 +870,12 @@ export async function compareReferenceFixtureToImage(
     data: result.output,
   };
 
+  const layoutShift = options.maxLayoutShiftPx !== undefined
+    ? computeLayoutShiftMetrics(chromiumImage, craterImage, {
+        tolerance: options.backgroundTolerance ?? 18,
+      })
+    : undefined;
+
   await fs.mkdir(options.outputDir, { recursive: true });
   const chromiumPath = path.join(options.outputDir, "chromium.png");
   const craterPath = path.join(options.outputDir, "crater.png");
@@ -785,6 +895,7 @@ export async function compareReferenceFixtureToImage(
       roi,
       maskPixels: compareMask ? maskPixelCount(compareMask) : undefined,
       cssRuleUsage: craterImage.cssRuleUsage,
+      layoutShift,
     }),
   );
 
@@ -798,6 +909,8 @@ export async function compareReferenceFixtureToImage(
     maskPixels: compareMask ? maskPixelCount(compareMask) : undefined,
     threshold: options.threshold,
     maxDiffRatio: options.maxDiffRatio,
+    layoutShift,
+    maxLayoutShiftPx: options.maxLayoutShiftPx,
     chromiumPath,
     craterPath,
     diffPath,

--- a/tests/paint-vrt.test.ts
+++ b/tests/paint-vrt.test.ts
@@ -35,6 +35,7 @@ async function expectHtmlWithinBudget(
     outputDirName: string;
     threshold: number;
     maxDiffRatio: number;
+    maxLayoutShiftPx?: number;
     reportTitle: string;
     prepareChromiumPage?: (page: Page) => Promise<void>;
     prepareCraterPage?: (page: Awaited<ReturnType<typeof connectCraterPageForVrt>>) => Promise<void>;
@@ -63,6 +64,7 @@ async function expectHtmlWithinBudget(
       outputDir: path.join(OUTPUT_ROOT, options.outputDirName),
       threshold: options.threshold,
       maxDiffRatio: options.maxDiffRatio,
+      maxLayoutShiftPx: options.maxLayoutShiftPx,
       report: paintVrtReport(options.reportTitle),
       cropToContent: true,
       contentPadding: 12,
@@ -72,6 +74,17 @@ async function expectHtmlWithinBudget(
     });
 
     expect(result.diffRatio).toBeLessThanOrEqual(result.maxDiffRatio);
+    if (
+      options.maxLayoutShiftPx !== undefined &&
+      result.layoutShift !== undefined
+    ) {
+      expect(result.layoutShift.maxLeftShiftPx).toBeLessThanOrEqual(
+        options.maxLayoutShiftPx,
+      );
+      expect(result.layoutShift.maxRightShiftPx).toBeLessThanOrEqual(
+        options.maxLayoutShiftPx,
+      );
+    }
   } finally {
     await craterPage.close();
   }
@@ -79,7 +92,12 @@ async function expectHtmlWithinBudget(
 
 async function expectSnapshotWithinBudget(
   snapshotName: string,
-  options: { threshold: number; maxDiffRatio: number; reportTitle: string },
+  options: {
+    threshold: number;
+    maxDiffRatio: number;
+    maxLayoutShiftPx?: number;
+    reportTitle: string;
+  },
 ): Promise<void> {
   const snapshot = loadRealWorldSnapshot(snapshotName);
   await expectHtmlWithinBudget({
@@ -89,6 +107,7 @@ async function expectSnapshotWithinBudget(
     outputDirName: snapshot.name,
     threshold: options.threshold,
     maxDiffRatio: options.maxDiffRatio,
+    maxLayoutShiftPx: options.maxLayoutShiftPx,
     reportTitle: options.reportTitle,
   });
 }
@@ -802,10 +821,14 @@ test.describe("Paint VRT", () => {
 
   // --- URL VRT snapshots: real websites captured with capture-real-world-snapshot.ts ---
 
-  const urlSnapshots: { name: string; maxDiffRatio: number }[] = [
+  const urlSnapshots: {
+    name: string;
+    maxDiffRatio: number;
+    maxLayoutShiftPx?: number;
+  }[] = [
     { name: "info-cern-ch", maxDiffRatio: 0.12 },
     { name: "google", maxDiffRatio: 0.10 },
-    { name: "hackernews", maxDiffRatio: 0.20 },
+    { name: "hackernews", maxDiffRatio: 0.20, maxLayoutShiftPx: 300 },
     { name: "wikipedia", maxDiffRatio: 0.25 },
     { name: "craigslist", maxDiffRatio: 0.15 },
     { name: "lobsters", maxDiffRatio: 0.20 },
@@ -813,7 +836,7 @@ test.describe("Paint VRT", () => {
     { name: "npmjs-express", maxDiffRatio: 0.25 },
   ];
 
-  for (const { name: snapshotName, maxDiffRatio } of urlSnapshots) {
+  for (const { name: snapshotName, maxDiffRatio, maxLayoutShiftPx } of urlSnapshots) {
     test(`url snapshot: ${snapshotName} visual diff within budget`, async () => {
       test.slow();
       test.skip(
@@ -827,9 +850,21 @@ test.describe("Paint VRT", () => {
           `${snapshotName} snapshot is not available locally`,
         ),
       );
+      // The hackernews snapshot fails the layout-shift gate because of the
+      // parser-side adoption-agency bug (#214): rank 12+ rows escape the
+      // table and block-fall back, displacing content by ~500px. Once #214
+      // lands and rank 12+ renders in the table column again, this fixme
+      // can be removed.
+      if (snapshotName === "hackernews") {
+        test.fail(
+          true,
+          "rank 12+ block fall-back exceeds layout-shift budget (#214)",
+        );
+      }
       await expectSnapshotWithinBudget(snapshotName, {
         threshold: 0.3,
         maxDiffRatio,
+        maxLayoutShiftPx,
         reportTitle: `url snapshot: ${snapshotName} visual diff within budget`,
       });
     });


### PR DESCRIPTION
## Summary

Pixel-diff \`diffRatio\` is insensitive to layout displacement when the shifted content lands on a same-colored region. The hackernews snapshot ships green at \`diffRatio ≈ 7%\` even though rank 12+ has block-fallen back hundreds of pixels off its expected column. This PR adds a complementary metric that catches that class of regression and wires it into the hackernews snapshot as an expected fail until #214 lands.

## What's added

- \`computeLayoutShiftMetrics(chromium, crater)\` — per-row first/last x at which the two images disagree by more than \`tolerance\`. Emits \`{avgLeftShiftPx, maxLeftShiftPx, avgRightShiftPx, maxRightShiftPx, contentRowCount}\` into \`report.json\` under \`metadata.layoutShift\`.
- \`VisualDiffOptions.maxLayoutShiftPx\` — optional cap. When set, pass derivation in \`createNormalizedVrtArtifactReport\` requires both max left/right shift to fit the budget, on top of the existing \`diffRatio\` check.
- \`VrtArtifactMetrics\` extended with \`maxLayoutShiftPx\` and \`layoutShift\` (both optional, additive — pre-existing reports still parse).

## Wired into

\`tests/paint-vrt.test.ts\` — \`url snapshot: hackernews\` (budget 300 px). It is marked \`test.fail()\` because the parser-side adoption-agency bug (#214) leaks rank 12+ content out of the table and shifts it ~535 px from its column. The marker can be removed once #214 lands.

Other fixtures and snapshots are unaffected: \`maxLayoutShiftPx\` is opt-in, no other call site sets it.

## Numbers observed

- \`url/hackernews\` (today): \`maxLeftShiftPx=535\`, \`maxRightShiftPx=790\` — caught
- \`fixture-hackernews\` (today): \`maxRightShiftPx=780\` — not gated for now because the residual flex-item text-wrap and vote-arrow paint bugs are tracked separately

## Test plan

- [x] \`pnpm exec vitest run scripts/vrt-report-contract.test.ts ...\` — 20/20 pass (schema)
- [x] \`pnpm exec playwright test tests/paint-vrt.test.ts -g \"hackernews\"\` — fixture passes, url marks expected fail and is reported as passed
- [x] Other paint-vrt fixtures un-touched (opt-in metric)

Closes #212. Related: #214 (will lift the test.fail mark).