### PR TITLE
Render borders as mitred trapezoids (fixes border-trick triangles)

### DIFF
--- a/painter/paint/raster/raster_fill.mbt
+++ b/painter/paint/raster/raster_fill.mbt
@@ -2,6 +2,87 @@
 /// Generic clipped fill helpers for raster output.
 
 ///|
+/// Fill a horizontal border slab as a mitred trapezoid: outer edge runs the
+/// full width, the opposite edge is inset by `bl` on the left and `br` on the
+/// right. `inverted=false` means the outer edge is at the top (top border);
+/// `inverted=true` means the outer edge is at the bottom (bottom border).
+/// Each row is rendered as a 1-px-tall fill so that mitred corners produce
+/// the right diagonal — this is what lets the classic 0×0+border-trick
+/// triangle actually render as a triangle rather than as a solid rectangle.
+fn fill_horizontal_border_trapezoid_clipped(
+  fb : Framebuffer,
+  palette : DynamicPalette,
+  x : Int,
+  y : Int,
+  w : Int,
+  thickness : Int,
+  bl : Int,
+  br : Int,
+  inverted : Bool,
+  color : @types.Color,
+  opacity : Double,
+  clip : ClipRect?,
+) -> Unit {
+  if thickness <= 0 || w <= 0 {
+    return
+  }
+  for r = 0; r < thickness; r = r + 1 {
+    let t = if thickness > 0 {
+      (r.to_double() + 0.5) / thickness.to_double()
+    } else {
+      0.0
+    }
+    let inset = if inverted { 1.0 - t } else { t }
+    let lx = x + (bl.to_double() * inset).to_int()
+    let rx = x + w - (br.to_double() * inset).to_int()
+    let line_w = rx - lx
+    if line_w <= 0 {
+      continue
+    }
+    fill_rect_clipped(fb, palette, lx, y + r, line_w, 1, color, opacity, clip)
+  }
+}
+
+///|
+/// Fill a vertical border slab as a mitred trapezoid. Mirror of the horizontal
+/// helper: the outer edge runs the full height; the opposite edge is inset by
+/// `bt` on top and `bb` on the bottom. `inverted=true` places the outer edge
+/// on the right (right border); `inverted=false` places it on the left.
+fn fill_vertical_border_trapezoid_clipped(
+  fb : Framebuffer,
+  palette : DynamicPalette,
+  x : Int,
+  y : Int,
+  h : Int,
+  thickness : Int,
+  bt : Int,
+  bb : Int,
+  inverted : Bool,
+  color : @types.Color,
+  opacity : Double,
+  clip : ClipRect?,
+) -> Unit {
+  if thickness <= 0 || h <= 0 {
+    return
+  }
+  for c = 0; c < thickness; c = c + 1 {
+    let t = if thickness > 0 {
+      (c.to_double() + 0.5) / thickness.to_double()
+    } else {
+      0.0
+    }
+    let inset = if inverted { 1.0 - t } else { t }
+    let ty = y + (bt.to_double() * inset).to_int()
+    let by = y + h - (bb.to_double() * inset).to_int()
+    let col_h = by - ty
+    if col_h <= 0 {
+      continue
+    }
+    fill_rect_clipped(fb, palette, x + c, ty, 1, col_h, color, opacity, clip)
+  }
+}
+
+///|
 /// Fill a rect clipped to the given clip rectangle
 fn fill_rect_clipped(
   fb : Framebuffer,

--- a/painter/paint/raster/raster_node_box.mbt
+++ b/painter/paint/raster/raster_node_box.mbt
@@ -126,13 +126,16 @@ fn render_node_box_decorations(
   if !rounded_border_drawn &&
     bt > 0 &&
     !node.paint.border_top_color.is_transparent() {
-    fill_rect_clipped(
+    fill_horizontal_border_trapezoid_clipped(
       fb,
       palette,
       x,
       y,
       w,
       bt,
+      bl,
+      br,
+      false,
       node.paint.border_top_color,
       opacity,
       clip,
@@ -141,13 +144,16 @@ fn render_node_box_decorations(
   if !rounded_border_drawn &&
     bb > 0 &&
     !node.paint.border_bottom_color.is_transparent() {
-    fill_rect_clipped(
+    fill_horizontal_border_trapezoid_clipped(
       fb,
       palette,
       x,
       y + h - bb,
       w,
       bb,
+      bl,
+      br,
+      true,
       node.paint.border_bottom_color,
       opacity,
       clip,
@@ -156,13 +162,16 @@ fn render_node_box_decorations(
   if !rounded_border_drawn &&
     bl > 0 &&
     !node.paint.border_left_color.is_transparent() {
-    fill_rect_clipped(
+    fill_vertical_border_trapezoid_clipped(
       fb,
       palette,
       x,
-      y + bt,
+      y,
+      h,
       bl,
-      h - bt - bb,
+      bt,
+      bb,
+      false,
       node.paint.border_left_color,
       opacity,
       clip,
@@ -171,13 +180,16 @@ fn render_node_box_decorations(
   if !rounded_border_drawn &&
     br > 0 &&
     !node.paint.border_right_color.is_transparent() {
-    fill_rect_clipped(
+    fill_vertical_border_trapezoid_clipped(
       fb,
       palette,
       x + w - br,
-      y + bt,
+      y,
+      h,
       br,
-      h - bt - bb,
+      bt,
+      bb,
+      true,
       node.paint.border_right_color,
       opacity,
       clip,


### PR DESCRIPTION
## Summary

Border edges were filled as axis-aligned rectangles spanning the entire side of the box. This breaks two things:

1. **Border-trick triangles render as squares.** The classic \`width: 0; height: 0; border-left: 5px solid transparent; border-right: 5px solid transparent; border-bottom: 10px solid #828282;\` shape — used pervasively for inline arrow glyphs, including Hacker News's vote arrow — used to come out as a solid 10×10 gray square because the transparent sides were skipped and the bottom fill ran the full width.
2. **Adjacent unequal-colored borders had hard L-shaped seams** instead of the diagonal mitres CSS specifies.

This PR replaces the four \`fill_rect_clipped\` calls in \`raster_node_box\` with per-row 1-px scanlines that walk a mitred trapezoid: the outer edge spans the full side, the opposite edge is inset by the adjacent border widths. The corner seams become diagonals; the 0×0 + transparent-sides box collapses to a real triangle.

## Before / After

Before (fixture-hackernews): vote arrow rendered as a small gray rectangle next to each rank number.
After (fixture-hackernews): vote arrow renders as an upward-pointing triangle, matching Chromium.

## Test plan

- [x] \`moon test -p mizchi/crater-painter/paint/raster\` — 31/31 pass
- [x] \`moon test\` — 52/52 native pass
- [x] \`pnpm exec playwright test tests/paint-vrt.test.ts -g \"border|button|card|controls|table|navbar|hackernews\"\` — all pass (5 fixtures, no regression)
- [x] \`pnpm exec playwright test tests/paint-vrt-levels.test.ts\` — 22/22 pass
- [x] Visual: \`output/playwright/vrt/fixture-hackernews/crater.png\` shows the triangle correctly