### PR TITLE
Improve real-world VRT parity and static snapshot benchmarks

### DIFF
--- a/benchmarks/BASELINE.md
+++ b/benchmarks/BASELINE.md
@@ -813,3 +813,46 @@ moon bench --manifest-path benchmarks/moon.mod.json -p mizchi/crater-benchmarks 
 
 - `CRATER_VRT_STATIC_HTML_MAIN_BUDGET` defaults to 4000 chars. This keeps the direct static VRT path materially faster while preserving an env override for wider first-viewport content.
 - The same `mdn-wasm-text` VRT passes with `capturePaintData: node_layout=2127ms ... total=2216ms`; the browser path includes glyph/raster work and remains slower than the pure `moon bench` render phase.
+
+### O(n^2) Probes
+
+Command:
+
+```bash
+moon bench --manifest-path benchmarks/moon.mod.json -p mizchi/crater-benchmarks -f static_snapshot_bench.mbt --target js --release -i 12-32
+```
+
+MDN main excerpt scaling:
+
+| Benchmark | Mean |
+|-----------|------|
+| `static_snapshot_node_build_mdn_main_1k` | 15.83 ms |
+| `static_snapshot_node_build_mdn_main_4k` | 55.12 ms |
+| `static_snapshot_node_build_mdn_main_16k` | 156.57 ms |
+| `static_snapshot_layout_mdn_main_1k` | 24.04 ms |
+| `static_snapshot_layout_mdn_main_2k` | 305.51 ms |
+| `static_snapshot_layout_mdn_main_4k` | 588.61 ms |
+| `static_snapshot_layout_mdn_main_8k` | 1.19 s |
+| `static_snapshot_layout_mdn_main_16k` | 2.52 s |
+
+Synthetic layout-shape probes:
+
+| Benchmark | Mean |
+|-----------|------|
+| `static_snapshot_layout_long_text_500` | 143.89 µs |
+| `static_snapshot_layout_long_text_1000` | 273.77 µs |
+| `static_snapshot_layout_long_text_2000` | 585.54 µs |
+| `static_snapshot_layout_inline_links_100` | 584.84 µs |
+| `static_snapshot_layout_inline_links_200` | 1.19 ms |
+| `static_snapshot_layout_inline_links_400` | 2.21 ms |
+| `static_snapshot_layout_block_paragraphs_100` | 436.10 µs |
+| `static_snapshot_layout_block_paragraphs_200` | 941.41 µs |
+| `static_snapshot_layout_block_paragraphs_400` | 1.79 ms |
+| `static_snapshot_layout_whitespace_nodes_200` | 142.57 µs |
+| `static_snapshot_layout_whitespace_nodes_400` | 248.45 µs |
+| `static_snapshot_layout_whitespace_nodes_800` | 504.43 µs |
+
+Notes:
+
+- The simple long text, inline link, block paragraph, and whitespace sibling probes are roughly linear at these sizes.
+- `mdn-wasm-text` has a large 1k -> 2k step, then scales close to 2x per 2x budget. This points to a content-shape threshold rather than a broad O(n^2) pattern in the synthetic cases above.

--- a/benchmarks/BASELINE.md
+++ b/benchmarks/BASELINE.md
@@ -784,3 +784,32 @@ inline-only style cache は lookup ごとに `tag|root|viewport|inline_css` の 
   - `render_to_node applies margin-trim from stylesheet` は pass
   - `css-flexbox` は `289 / 289`
   - `css-grid` は `30 / 33` で既知の 3 failure のまま
+
+---
+
+## Static Snapshot VRT Trim Bench (2026-05-20)
+
+### Problem
+large no-script real-world snapshots can bypass runtime DOM setup, but they still need to keep the first viewport content small enough for direct MoonBit render. The previous static main excerpt was 35k chars; `mdn-wasm-text` remained layout-bound.
+
+### Command
+
+```bash
+moon bench --manifest-path benchmarks/moon.mod.json -p mizchi/crater-benchmarks -f static_snapshot_bench.mbt --target js --release
+```
+
+### Results
+
+| Benchmark | Mean |
+|-----------|------|
+| `static_snapshot_parse_mdn_full_snapshot` | 9.23 ms |
+| `static_snapshot_parse_mdn_trimmed_viewport` | 3.42 ms |
+| `static_snapshot_prepare_mdn_trimmed_viewport` | 3.70 ms |
+| `static_snapshot_node_build_mdn_trimmed_viewport` | 46.58 ms |
+| `static_snapshot_layout_mdn_trimmed_viewport` | 533.83 ms |
+| `static_snapshot_render_mdn_trimmed_viewport` | 615.84 ms |
+
+### Notes
+
+- `CRATER_VRT_STATIC_HTML_MAIN_BUDGET` defaults to 4000 chars. This keeps the direct static VRT path materially faster while preserving an env override for wider first-viewport content.
+- The same `mdn-wasm-text` VRT passes with `capturePaintData: node_layout=2127ms ... total=2216ms`; the browser path includes glyph/raster work and remains slower than the pure `moon bench` render phase.

--- a/benchmarks/static_snapshot_bench.mbt
+++ b/benchmarks/static_snapshot_bench.mbt
@@ -334,6 +334,57 @@ fn static_snapshot_pathological_whitespace_nodes(count : Int) -> @tree.Node {
 }
 
 ///|
+fn bench_static_snapshot_node_build_mdn_main(
+  b : @bench.T,
+  name : String,
+  main_budget : Int,
+) -> Unit {
+  let doc = @html.parse_document(
+    static_snapshot_mdn_trimmed_with_main_budget(main_budget),
+  )
+  let ctx = static_snapshot_context()
+  let prepared = @renderer.prepare_render_document(doc, ctx, [])
+  b.bench(name~, fn() {
+    b.keep(@renderer.build_render_root_node(doc, ctx, prepared))
+  })
+}
+
+///|
+fn bench_static_snapshot_layout_node(
+  b : @bench.T,
+  name : String,
+  node : @tree.Node,
+) -> Unit {
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name~, fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+fn bench_static_snapshot_layout_html(
+  b : @bench.T,
+  name : String,
+  html : String,
+) -> Unit {
+  bench_static_snapshot_layout_node(b, name, static_snapshot_layout_node(html))
+}
+
+///|
+fn bench_static_snapshot_layout_mdn_main(
+  b : @bench.T,
+  name : String,
+  main_budget : Int,
+) -> Unit {
+  bench_static_snapshot_layout_node(
+    b,
+    name,
+    static_snapshot_mdn_node_for_main_budget(main_budget),
+  )
+}
+
+///|
 test "bench_static_snapshot_parse_full_reference" (b : @bench.T) {
   let html = static_snapshot_full_reference_html()
   b.bench(name="static_snapshot_parse_full_reference", fn() {
@@ -436,228 +487,173 @@ test "bench_static_snapshot_layout_mdn_trimmed_viewport" (b : @bench.T) {
   let doc = @html.parse_document(static_snapshot_mdn_trimmed_html())
   let ctx = static_snapshot_context()
   let prepared = @renderer.prepare_render_document(doc, ctx, [])
-  let node = @renderer.build_render_root_node(doc, ctx, prepared)
-  let layout_ctx = default_layout_ctx(ctx)
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_mdn_trimmed_viewport", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_node(
+    b,
+    "static_snapshot_layout_mdn_trimmed_viewport",
+    @renderer.build_render_root_node(doc, ctx, prepared),
+  )
 }
 
 ///|
 test "bench_static_snapshot_node_build_mdn_main_1k" (b : @bench.T) {
-  let doc = @html.parse_document(
-    static_snapshot_mdn_trimmed_with_main_budget(1000),
+  bench_static_snapshot_node_build_mdn_main(
+    b, "static_snapshot_node_build_mdn_main_1k", 1000,
   )
-  let ctx = static_snapshot_context()
-  let prepared = @renderer.prepare_render_document(doc, ctx, [])
-  b.bench(name="static_snapshot_node_build_mdn_main_1k", fn() {
-    b.keep(@renderer.build_render_root_node(doc, ctx, prepared))
-  })
 }
 
 ///|
 test "bench_static_snapshot_node_build_mdn_main_4k" (b : @bench.T) {
-  let doc = @html.parse_document(
-    static_snapshot_mdn_trimmed_with_main_budget(4000),
+  bench_static_snapshot_node_build_mdn_main(
+    b, "static_snapshot_node_build_mdn_main_4k", 4000,
   )
-  let ctx = static_snapshot_context()
-  let prepared = @renderer.prepare_render_document(doc, ctx, [])
-  b.bench(name="static_snapshot_node_build_mdn_main_4k", fn() {
-    b.keep(@renderer.build_render_root_node(doc, ctx, prepared))
-  })
 }
 
 ///|
 test "bench_static_snapshot_node_build_mdn_main_16k" (b : @bench.T) {
-  let doc = @html.parse_document(
-    static_snapshot_mdn_trimmed_with_main_budget(16000),
+  bench_static_snapshot_node_build_mdn_main(
+    b, "static_snapshot_node_build_mdn_main_16k", 16000,
   )
-  let ctx = static_snapshot_context()
-  let prepared = @renderer.prepare_render_document(doc, ctx, [])
-  b.bench(name="static_snapshot_node_build_mdn_main_16k", fn() {
-    b.keep(@renderer.build_render_root_node(doc, ctx, prepared))
-  })
 }
 
 ///|
 test "bench_static_snapshot_layout_mdn_main_1k" (b : @bench.T) {
-  let node = static_snapshot_mdn_node_for_main_budget(1000)
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_mdn_main_1k", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_mdn_main(
+    b, "static_snapshot_layout_mdn_main_1k", 1000,
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_mdn_main_2k" (b : @bench.T) {
-  let node = static_snapshot_mdn_node_for_main_budget(2000)
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_mdn_main_2k", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_mdn_main(
+    b, "static_snapshot_layout_mdn_main_2k", 2000,
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_mdn_main_4k" (b : @bench.T) {
-  let node = static_snapshot_mdn_node_for_main_budget(4000)
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_mdn_main_4k", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_mdn_main(
+    b, "static_snapshot_layout_mdn_main_4k", 4000,
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_mdn_main_8k" (b : @bench.T) {
-  let node = static_snapshot_mdn_node_for_main_budget(8000)
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_mdn_main_8k", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_mdn_main(
+    b, "static_snapshot_layout_mdn_main_8k", 8000,
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_mdn_main_16k" (b : @bench.T) {
-  let node = static_snapshot_mdn_node_for_main_budget(16000)
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_mdn_main_16k", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_mdn_main(
+    b, "static_snapshot_layout_mdn_main_16k", 16000,
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_long_text_500" (b : @bench.T) {
-  let node = static_snapshot_layout_node(
+  bench_static_snapshot_layout_html(
+    b,
+    "static_snapshot_layout_long_text_500",
     static_snapshot_long_paragraph_html(500),
   )
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_long_text_500", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
 }
 
 ///|
 test "bench_static_snapshot_layout_long_text_1000" (b : @bench.T) {
-  let node = static_snapshot_layout_node(
+  bench_static_snapshot_layout_html(
+    b,
+    "static_snapshot_layout_long_text_1000",
     static_snapshot_long_paragraph_html(1000),
   )
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_long_text_1000", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
 }
 
 ///|
 test "bench_static_snapshot_layout_long_text_2000" (b : @bench.T) {
-  let node = static_snapshot_layout_node(
+  bench_static_snapshot_layout_html(
+    b,
+    "static_snapshot_layout_long_text_2000",
     static_snapshot_long_paragraph_html(2000),
   )
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_long_text_2000", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
 }
 
 ///|
 test "bench_static_snapshot_layout_inline_links_100" (b : @bench.T) {
-  let node = static_snapshot_layout_node(static_snapshot_inline_links_html(100))
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_inline_links_100", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_html(
+    b,
+    "static_snapshot_layout_inline_links_100",
+    static_snapshot_inline_links_html(100),
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_inline_links_200" (b : @bench.T) {
-  let node = static_snapshot_layout_node(static_snapshot_inline_links_html(200))
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_inline_links_200", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_html(
+    b,
+    "static_snapshot_layout_inline_links_200",
+    static_snapshot_inline_links_html(200),
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_inline_links_400" (b : @bench.T) {
-  let node = static_snapshot_layout_node(static_snapshot_inline_links_html(400))
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_inline_links_400", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_html(
+    b,
+    "static_snapshot_layout_inline_links_400",
+    static_snapshot_inline_links_html(400),
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_block_paragraphs_100" (b : @bench.T) {
-  let node = static_snapshot_layout_node(
+  bench_static_snapshot_layout_html(
+    b,
+    "static_snapshot_layout_block_paragraphs_100",
     static_snapshot_block_paragraphs_html(100),
   )
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_block_paragraphs_100", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
 }
 
 ///|
 test "bench_static_snapshot_layout_block_paragraphs_200" (b : @bench.T) {
-  let node = static_snapshot_layout_node(
+  bench_static_snapshot_layout_html(
+    b,
+    "static_snapshot_layout_block_paragraphs_200",
     static_snapshot_block_paragraphs_html(200),
   )
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_block_paragraphs_200", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
 }
 
 ///|
 test "bench_static_snapshot_layout_block_paragraphs_400" (b : @bench.T) {
-  let node = static_snapshot_layout_node(
+  bench_static_snapshot_layout_html(
+    b,
+    "static_snapshot_layout_block_paragraphs_400",
     static_snapshot_block_paragraphs_html(400),
   )
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_block_paragraphs_400", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
 }
 
 ///|
 test "bench_static_snapshot_layout_whitespace_nodes_200" (b : @bench.T) {
-  let node = static_snapshot_pathological_whitespace_nodes(200)
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_whitespace_nodes_200", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_node(
+    b,
+    "static_snapshot_layout_whitespace_nodes_200",
+    static_snapshot_pathological_whitespace_nodes(200),
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_whitespace_nodes_400" (b : @bench.T) {
-  let node = static_snapshot_pathological_whitespace_nodes(400)
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_whitespace_nodes_400", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_node(
+    b,
+    "static_snapshot_layout_whitespace_nodes_400",
+    static_snapshot_pathological_whitespace_nodes(400),
+  )
 }
 
 ///|
 test "bench_static_snapshot_layout_whitespace_nodes_800" (b : @bench.T) {
-  let node = static_snapshot_pathological_whitespace_nodes(800)
-  let layout_ctx = default_layout_ctx(static_snapshot_context())
-  @tree.setup()
-  b.bench(name="static_snapshot_layout_whitespace_nodes_800", fn() {
-    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
-  })
+  bench_static_snapshot_layout_node(
+    b,
+    "static_snapshot_layout_whitespace_nodes_800",
+    static_snapshot_pathological_whitespace_nodes(800),
+  )
 }

--- a/benchmarks/static_snapshot_bench.mbt
+++ b/benchmarks/static_snapshot_bench.mbt
@@ -1,0 +1,333 @@
+///|
+fn static_snapshot_viewport() -> @types.Size[Double] {
+  @types.Size::new(1280.0, 900.0)
+}
+
+///|
+fn static_snapshot_context() -> @renderer.RenderContext {
+  {
+    ..@renderer.RenderContext::default(),
+    viewport_width: static_snapshot_viewport().width,
+    viewport_height: static_snapshot_viewport().height,
+  }
+}
+
+///|
+fn static_snapshot_head(buf : StringBuilder) -> Unit {
+  buf.write_string("<!DOCTYPE html><html><head><meta charset=\"utf-8\">")
+  buf.write_string("<title>Static snapshot benchmark</title>")
+  buf.write_string("<style>")
+  buf.write_string(
+    "html{font-family:Arial,sans-serif;font-size:16px;line-height:1.45;color:#1b1f24;background:#fff}",
+  )
+  buf.write_string("body{margin:0;background:#fff}")
+  buf.write_string(
+    ".page{display:grid;grid-template-columns:280px minmax(0,1fr)260px;gap:24px;max-width:1280px;margin:0 auto;padding:20px}",
+  )
+  buf.write_string(
+    ".topbar{height:56px;border-bottom:1px solid #d9dee3;display:flex;align-items:center;padding:0 18px;background:#f8f9fb}",
+  )
+  buf.write_string(
+    ".sidebar{display:flex;flex-direction:column;gap:4px;font-size:13px}",
+  )
+  buf.write_string(
+    ".nav-link{display:flex;justify-content:space-between;gap:10px;color:#334155;text-decoration:none;padding:5px 8px;border-radius:4px}",
+  )
+  buf.write_string(".nav-link:hover{background:#eef2f7}")
+  buf.write_string(
+    "main{min-width:0;max-width:760px}.crumbs{font-size:12px;color:#64748b;margin-bottom:10px}",
+  )
+  buf.write_string(
+    "h1{font-size:38px;line-height:1.1;margin:0 0 18px}h2{font-size:25px;margin:28px 0 12px}",
+  )
+  buf.write_string(
+    "p{margin:0 0 14px}.note{border-left:4px solid #3b82f6;background:#eff6ff;padding:12px 14px;margin:16px 0}",
+  )
+  buf.write_string(
+    "code{font-family:Menlo,monospace;background:#f1f5f9;border-radius:4px;padding:1px 4px}",
+  )
+  buf.write_string(
+    ".cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px;margin:18px 0}",
+  )
+  buf.write_string(
+    ".card{border:1px solid #d9dee3;border-radius:6px;padding:12px;background:#fff}.related{font-size:13px}",
+  )
+  buf.write_string("</style></head>")
+}
+
+///|
+fn static_snapshot_topbar(buf : StringBuilder) -> Unit {
+  buf.write_string("<body><header class=\"topbar\">")
+  buf.write_string("<strong>Developer Docs</strong>")
+  buf.write_string(
+    "<span style=\"margin-left:auto;color:#64748b\">reference snapshot</span>",
+  )
+  buf.write_string("</header><div class=\"page\">")
+}
+
+///|
+fn static_snapshot_sidebar(buf : StringBuilder, count : Int) -> Unit {
+  buf.write_string(
+    "<nav class=\"sidebar\" aria-label=\"Reference navigation\">",
+  )
+  for i = 0; i < count; i = i + 1 {
+    buf.write_string("<a class=\"nav-link\" href=\"/docs/static/")
+    buf.write_string(i.to_string())
+    buf.write_string("\"><span>Reference item ")
+    buf.write_string(i.to_string())
+    buf.write_string("</span><span>API</span></a>")
+  }
+  buf.write_string("</nav>")
+}
+
+///|
+fn static_snapshot_article(buf : StringBuilder, sections : Int) -> Unit {
+  buf.write_string("<main>")
+  buf.write_string(
+    "<div class=\"crumbs\">Docs / Web platform / Static snapshot</div>",
+  )
+  buf.write_string("<h1>Static document rendering benchmark</h1>")
+  buf.write_string(
+    "<p>This page models a no-script documentation snapshot with a large navigation tree and a content column that should fit inside the first viewport.</p>",
+  )
+  buf.write_string("<div class=\"note\">")
+  buf.write_string(
+    "The benchmark keeps the relevant body prefix and article content, mirroring the viewport-oriented static HTML path used by VRT.",
+  )
+  buf.write_string("</div>")
+  for i = 0; i < sections; i = i + 1 {
+    buf.write_string("<section><h2>Section ")
+    buf.write_string(i.to_string())
+    buf.write_string("</h2>")
+    for p = 0; p < 4; p = p + 1 {
+      buf.write_string("<p>")
+      buf.write_string(
+        "Rendering a captured document requires tokenization, tree construction, CSS cascade, layout, and paint data extraction. ",
+      )
+      buf.write_string(
+        "The static path intentionally avoids unrelated deferred application markup while preserving the first viewport content. ",
+      )
+      buf.write_string("Example ")
+      buf.write_string(i.to_string())
+      buf.write_string(".")
+      buf.write_string(p.to_string())
+      buf.write_string(
+        " uses <code>display:flex</code>, <code>min-width:0</code>, and inline text wrapping.</p>",
+      )
+    }
+    buf.write_string("<div class=\"cards\">")
+    for c = 0; c < 4; c = c + 1 {
+      buf.write_string("<article class=\"card\"><strong>Card ")
+      buf.write_string(c.to_string())
+      buf.write_string(
+        "</strong><p>Compact metadata for the article viewport.</p></article>",
+      )
+    }
+    buf.write_string("</div></section>")
+  }
+  buf.write_string("</main>")
+}
+
+///|
+fn static_snapshot_related(buf : StringBuilder, count : Int) -> Unit {
+  buf.write_string("<aside class=\"related\" aria-label=\"Related pages\">")
+  for i = 0; i < count; i = i + 1 {
+    buf.write_string("<section class=\"card\"><strong>Related ")
+    buf.write_string(i.to_string())
+    buf.write_string(
+      "</strong><p>Additional static content outside the viewport article.</p></section>",
+    )
+  }
+  buf.write_string("</aside>")
+}
+
+///|
+fn static_snapshot_html(
+  nav_items : Int,
+  sections : Int,
+  related_items : Int,
+) -> String {
+  let buf = StringBuilder::new()
+  static_snapshot_head(buf)
+  static_snapshot_topbar(buf)
+  static_snapshot_sidebar(buf, nav_items)
+  static_snapshot_article(buf, sections)
+  static_snapshot_related(buf, related_items)
+  buf.write_string("</div></body></html>")
+  buf.to_string()
+}
+
+///|
+fn static_snapshot_full_reference_html() -> String {
+  static_snapshot_html(320, 14, 120)
+}
+
+///|
+fn static_snapshot_trimmed_viewport_html() -> String {
+  static_snapshot_html(8, 4, 0)
+}
+
+///|
+extern "js" fn js_load_real_world_snapshot_html(name : String) -> String =
+  #| (name) => {
+  #|   const fs = require("node:fs");
+  #|   const path = require("node:path");
+  #|   const candidates = [
+  #|     path.join(process.cwd(), "real-world", name, "index.html"),
+  #|     path.join(process.cwd(), "..", "real-world", name, "index.html"),
+  #|   ];
+  #|   const resolved = candidates.find((candidate) => fs.existsSync(candidate));
+  #|   if (!resolved) {
+  #|     throw new Error(
+  #|       `real-world snapshot not found: ${name}; searched ${candidates.join(", ")}`,
+  #|     );
+  #|   }
+  #|   return fs.readFileSync(resolved, "utf8");
+  #| }
+
+///|
+extern "js" fn js_trim_static_html_for_viewport(
+  html : String,
+  body_budget : Int,
+  main_budget : Int,
+) -> String =
+  #| (html, bodyBudget, mainBudget) => {
+  #|   const bodyMatch = /<body\b[^>]*>/i.exec(html);
+  #|   if (!bodyMatch) return html;
+  #|   const bodyStart = bodyMatch.index;
+  #|   const keepUntil = Math.min(html.length, bodyStart + Math.max(1000, bodyBudget));
+  #|   if (keepUntil === html.length) return html;
+  #|   const mainIndex = html.toLowerCase().indexOf("<main", keepUntil);
+  #|   if (mainIndex >= 0) {
+  #|     const mainEnd = Math.min(html.length, mainIndex + Math.max(1000, mainBudget));
+  #|     return `${html.slice(0, keepUntil)}
+  #| <!-- crater-vrt-skipped-static-html -->
+  #| ${html.slice(mainIndex, mainEnd)}
+  #| <!-- crater-vrt-truncated-static-html -->
+  #| </body></html>`;
+  #|   }
+  #|   return html;
+  #| }
+
+///|
+fn static_snapshot_mdn_full_html() -> String {
+  js_load_real_world_snapshot_html("mdn-wasm-text")
+}
+
+///|
+fn static_snapshot_mdn_trimmed_html() -> String {
+  js_trim_static_html_for_viewport(static_snapshot_mdn_full_html(), 1000, 4000)
+}
+
+///|
+test "bench_static_snapshot_parse_full_reference" (b : @bench.T) {
+  let html = static_snapshot_full_reference_html()
+  b.bench(name="static_snapshot_parse_full_reference", fn() {
+    b.keep(@html.parse_document(html))
+  })
+}
+
+///|
+test "bench_static_snapshot_parse_trimmed_viewport" (b : @bench.T) {
+  let html = static_snapshot_trimmed_viewport_html()
+  b.bench(name="static_snapshot_parse_trimmed_viewport", fn() {
+    b.keep(@html.parse_document(html))
+  })
+}
+
+///|
+test "bench_static_snapshot_node_layout_full_reference" (b : @bench.T) {
+  let doc = @html.parse_document(static_snapshot_full_reference_html())
+  let ctx = static_snapshot_context()
+  b.bench(name="static_snapshot_node_layout_full_reference", fn() {
+    b.keep(@renderer.render_to_node_and_layout_with_document(doc, ctx, []))
+  })
+}
+
+///|
+test "bench_static_snapshot_node_layout_trimmed_viewport" (b : @bench.T) {
+  let doc = @html.parse_document(static_snapshot_trimmed_viewport_html())
+  let ctx = static_snapshot_context()
+  b.bench(name="static_snapshot_node_layout_trimmed_viewport", fn() {
+    b.keep(@renderer.render_to_node_and_layout_with_document(doc, ctx, []))
+  })
+}
+
+///|
+test "bench_static_snapshot_render_trimmed_viewport" (b : @bench.T) {
+  let html = static_snapshot_trimmed_viewport_html()
+  let ctx = static_snapshot_context()
+  b.bench(name="static_snapshot_render_trimmed_viewport", fn() {
+    b.keep(@renderer.render_to_node_and_layout(html, ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_paint_tree_trimmed_viewport" (b : @bench.T) {
+  let viewport = static_snapshot_viewport()
+  let ctx = static_snapshot_context()
+  let html = static_snapshot_trimmed_viewport_html()
+  b.bench(name="static_snapshot_paint_tree_trimmed_viewport", fn() {
+    let (node, layout) = @renderer.render_to_node_and_layout(html, ctx)
+    b.keep(build_vrt_paint_tree(node, layout, viewport))
+  })
+}
+
+///|
+test "bench_static_snapshot_parse_mdn_full_snapshot" (b : @bench.T) {
+  let html = static_snapshot_mdn_full_html()
+  b.bench(name="static_snapshot_parse_mdn_full_snapshot", fn() {
+    b.keep(@html.parse_document(html))
+  })
+}
+
+///|
+test "bench_static_snapshot_parse_mdn_trimmed_viewport" (b : @bench.T) {
+  let html = static_snapshot_mdn_trimmed_html()
+  b.bench(name="static_snapshot_parse_mdn_trimmed_viewport", fn() {
+    b.keep(@html.parse_document(html))
+  })
+}
+
+///|
+test "bench_static_snapshot_render_mdn_trimmed_viewport" (b : @bench.T) {
+  let html = static_snapshot_mdn_trimmed_html()
+  let ctx = static_snapshot_context()
+  b.bench(name="static_snapshot_render_mdn_trimmed_viewport", fn() {
+    b.keep(@renderer.render_to_node_and_layout(html, ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_prepare_mdn_trimmed_viewport" (b : @bench.T) {
+  let doc = @html.parse_document(static_snapshot_mdn_trimmed_html())
+  let ctx = static_snapshot_context()
+  b.bench(name="static_snapshot_prepare_mdn_trimmed_viewport", fn() {
+    b.keep(@renderer.prepare_render_document(doc, ctx, []))
+  })
+}
+
+///|
+test "bench_static_snapshot_node_build_mdn_trimmed_viewport" (b : @bench.T) {
+  let doc = @html.parse_document(static_snapshot_mdn_trimmed_html())
+  let ctx = static_snapshot_context()
+  let prepared = @renderer.prepare_render_document(doc, ctx, [])
+  b.bench(name="static_snapshot_node_build_mdn_trimmed_viewport", fn() {
+    b.keep(@renderer.build_render_root_node(doc, ctx, prepared))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_mdn_trimmed_viewport" (b : @bench.T) {
+  let doc = @html.parse_document(static_snapshot_mdn_trimmed_html())
+  let ctx = static_snapshot_context()
+  let prepared = @renderer.prepare_render_document(doc, ctx, [])
+  let node = @renderer.build_render_root_node(doc, ctx, prepared)
+  let layout_ctx = default_layout_ctx(ctx)
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_mdn_trimmed_viewport", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|

--- a/benchmarks/static_snapshot_bench.mbt
+++ b/benchmarks/static_snapshot_bench.mbt
@@ -216,7 +216,121 @@ fn static_snapshot_mdn_full_html() -> String {
 
 ///|
 fn static_snapshot_mdn_trimmed_html() -> String {
-  js_trim_static_html_for_viewport(static_snapshot_mdn_full_html(), 1000, 4000)
+  static_snapshot_mdn_trimmed_with_main_budget(4000)
+}
+
+///|
+fn static_snapshot_mdn_trimmed_with_main_budget(main_budget : Int) -> String {
+  js_trim_static_html_for_viewport(
+    static_snapshot_mdn_full_html(),
+    1000,
+    main_budget,
+  )
+}
+
+///|
+fn static_snapshot_mdn_node_for_main_budget(main_budget : Int) -> @tree.Node {
+  let doc = @html.parse_document(
+    static_snapshot_mdn_trimmed_with_main_budget(main_budget),
+  )
+  let ctx = static_snapshot_context()
+  let prepared = @renderer.prepare_render_document(doc, ctx, [])
+  @renderer.build_render_root_node(doc, ctx, prepared)
+}
+
+///|
+fn static_snapshot_scale_shell(inner : String) -> String {
+  "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>" +
+  "body{margin:0;font-family:Arial,sans-serif;font-size:16px;line-height:20px}" +
+  "main{width:680px;padding:16px}.links a{color:#0645ad;text-decoration:underline}" +
+  "p{margin:0 0 8px}" +
+  "</style></head><body><main>" +
+  inner +
+  "</main></body></html>"
+}
+
+///|
+fn static_snapshot_long_paragraph_html(words : Int) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string("<p>")
+  for i = 0; i < words; i = i + 1 {
+    buf.write_string("inlineword")
+    buf.write_string(i.to_string())
+    buf.write_string(" ")
+  }
+  buf.write_string("</p>")
+  static_snapshot_scale_shell(buf.to_string())
+}
+
+///|
+fn static_snapshot_inline_links_html(count : Int) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string("<p class=\"links\">")
+  for i = 0; i < count; i = i + 1 {
+    buf.write_string("<a href=\"#")
+    buf.write_string(i.to_string())
+    buf.write_string("\"><b>Link ")
+    buf.write_string(i.to_string())
+    buf.write_string("</b></a> ")
+  }
+  buf.write_string("</p>")
+  static_snapshot_scale_shell(buf.to_string())
+}
+
+///|
+fn static_snapshot_block_paragraphs_html(count : Int) -> String {
+  let buf = StringBuilder::new()
+  for i = 0; i < count; i = i + 1 {
+    buf.write_string("<p>Paragraph ")
+    buf.write_string(i.to_string())
+    buf.write_string(
+      " has a short run of text that should remain simple block flow.</p>",
+    )
+  }
+  static_snapshot_scale_shell(buf.to_string())
+}
+
+///|
+fn static_snapshot_layout_node(html : String) -> @tree.Node {
+  @renderer.render_to_node(html, static_snapshot_context())
+}
+
+///|
+fn static_snapshot_inline_measure(
+  width : Double,
+  height : Double,
+) -> @layout_types.MeasureFunc {
+  {
+    func: fn(
+      _available_width : Double,
+      _available_height : Double,
+    ) -> @layout_types.IntrinsicSize {
+      {
+        min_width: width,
+        max_width: width,
+        min_height: height,
+        max_height: height,
+      }
+    },
+  }
+}
+
+///|
+fn static_snapshot_pathological_whitespace_nodes(count : Int) -> @tree.Node {
+  let default_style = @style.Style::default()
+  let inline_style = { ..default_style, display: @types.Inline }
+  let space_measure = static_snapshot_inline_measure(0.0, 20.0)
+  let children : Array[@tree.Node] = []
+  for i = 0; i < count; i = i + 1 {
+    children.push(
+      @tree.Node::with_measure("#text", inline_style, space_measure, text=" "),
+    )
+  }
+  @tree.Node::new(
+    "pathological-whitespace",
+    { ..default_style, width: @types.Length(680.0) },
+    children,
+  )
 }
 
 ///|
@@ -331,3 +445,219 @@ test "bench_static_snapshot_layout_mdn_trimmed_viewport" (b : @bench.T) {
 }
 
 ///|
+test "bench_static_snapshot_node_build_mdn_main_1k" (b : @bench.T) {
+  let doc = @html.parse_document(
+    static_snapshot_mdn_trimmed_with_main_budget(1000),
+  )
+  let ctx = static_snapshot_context()
+  let prepared = @renderer.prepare_render_document(doc, ctx, [])
+  b.bench(name="static_snapshot_node_build_mdn_main_1k", fn() {
+    b.keep(@renderer.build_render_root_node(doc, ctx, prepared))
+  })
+}
+
+///|
+test "bench_static_snapshot_node_build_mdn_main_4k" (b : @bench.T) {
+  let doc = @html.parse_document(
+    static_snapshot_mdn_trimmed_with_main_budget(4000),
+  )
+  let ctx = static_snapshot_context()
+  let prepared = @renderer.prepare_render_document(doc, ctx, [])
+  b.bench(name="static_snapshot_node_build_mdn_main_4k", fn() {
+    b.keep(@renderer.build_render_root_node(doc, ctx, prepared))
+  })
+}
+
+///|
+test "bench_static_snapshot_node_build_mdn_main_16k" (b : @bench.T) {
+  let doc = @html.parse_document(
+    static_snapshot_mdn_trimmed_with_main_budget(16000),
+  )
+  let ctx = static_snapshot_context()
+  let prepared = @renderer.prepare_render_document(doc, ctx, [])
+  b.bench(name="static_snapshot_node_build_mdn_main_16k", fn() {
+    b.keep(@renderer.build_render_root_node(doc, ctx, prepared))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_mdn_main_1k" (b : @bench.T) {
+  let node = static_snapshot_mdn_node_for_main_budget(1000)
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_mdn_main_1k", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_mdn_main_2k" (b : @bench.T) {
+  let node = static_snapshot_mdn_node_for_main_budget(2000)
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_mdn_main_2k", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_mdn_main_4k" (b : @bench.T) {
+  let node = static_snapshot_mdn_node_for_main_budget(4000)
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_mdn_main_4k", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_mdn_main_8k" (b : @bench.T) {
+  let node = static_snapshot_mdn_node_for_main_budget(8000)
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_mdn_main_8k", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_mdn_main_16k" (b : @bench.T) {
+  let node = static_snapshot_mdn_node_for_main_budget(16000)
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_mdn_main_16k", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_long_text_500" (b : @bench.T) {
+  let node = static_snapshot_layout_node(
+    static_snapshot_long_paragraph_html(500),
+  )
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_long_text_500", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_long_text_1000" (b : @bench.T) {
+  let node = static_snapshot_layout_node(
+    static_snapshot_long_paragraph_html(1000),
+  )
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_long_text_1000", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_long_text_2000" (b : @bench.T) {
+  let node = static_snapshot_layout_node(
+    static_snapshot_long_paragraph_html(2000),
+  )
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_long_text_2000", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_inline_links_100" (b : @bench.T) {
+  let node = static_snapshot_layout_node(static_snapshot_inline_links_html(100))
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_inline_links_100", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_inline_links_200" (b : @bench.T) {
+  let node = static_snapshot_layout_node(static_snapshot_inline_links_html(200))
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_inline_links_200", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_inline_links_400" (b : @bench.T) {
+  let node = static_snapshot_layout_node(static_snapshot_inline_links_html(400))
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_inline_links_400", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_block_paragraphs_100" (b : @bench.T) {
+  let node = static_snapshot_layout_node(
+    static_snapshot_block_paragraphs_html(100),
+  )
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_block_paragraphs_100", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_block_paragraphs_200" (b : @bench.T) {
+  let node = static_snapshot_layout_node(
+    static_snapshot_block_paragraphs_html(200),
+  )
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_block_paragraphs_200", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_block_paragraphs_400" (b : @bench.T) {
+  let node = static_snapshot_layout_node(
+    static_snapshot_block_paragraphs_html(400),
+  )
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_block_paragraphs_400", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_whitespace_nodes_200" (b : @bench.T) {
+  let node = static_snapshot_pathological_whitespace_nodes(200)
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_whitespace_nodes_200", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_whitespace_nodes_400" (b : @bench.T) {
+  let node = static_snapshot_pathological_whitespace_nodes(400)
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_whitespace_nodes_400", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}
+
+///|
+test "bench_static_snapshot_layout_whitespace_nodes_800" (b : @bench.T) {
+  let node = static_snapshot_pathological_whitespace_nodes(800)
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  @tree.setup()
+  b.bench(name="static_snapshot_layout_whitespace_nodes_800", fn() {
+    b.keep(@tree.compute_layout_in_context(node, layout_ctx))
+  })
+}

--- a/benchmarks/static_snapshot_bench_wbtest.mbt
+++ b/benchmarks/static_snapshot_bench_wbtest.mbt
@@ -1,0 +1,23 @@
+///|
+test "static snapshot benchmark fixtures are renderable and trimmed" {
+  let full = static_snapshot_full_reference_html()
+  let trimmed = static_snapshot_trimmed_viewport_html()
+  assert_true(full.length() > 60000)
+  assert_true(trimmed.length() > 8000)
+  assert_true(trimmed.length() * 4 < full.length())
+  let _ = @renderer.render_to_node_and_layout(
+    trimmed,
+    static_snapshot_context(),
+  )
+}
+
+///|
+test "mdn static snapshot benchmark fixture uses viewport trim" {
+  let full = static_snapshot_mdn_full_html()
+  let trimmed = static_snapshot_mdn_trimmed_html()
+  assert_true(full.length() > 100000)
+  assert_true(trimmed.length() > 10000)
+  assert_true(trimmed.length() < full.length())
+  assert_true(trimmed.contains("crater-vrt-truncated-static-html"))
+  let _ = @html.parse_document(trimmed)
+}

--- a/benchmarks/static_snapshot_bench_wbtest.mbt
+++ b/benchmarks/static_snapshot_bench_wbtest.mbt
@@ -12,12 +12,34 @@ test "static snapshot benchmark fixtures are renderable and trimmed" {
 }
 
 ///|
-test "mdn static snapshot benchmark fixture uses viewport trim" {
-  let full = static_snapshot_mdn_full_html()
-  let trimmed = static_snapshot_mdn_trimmed_html()
-  assert_true(full.length() > 100000)
-  assert_true(trimmed.length() > 10000)
+fn synthetic_main_trim_fixture() -> String {
+  let before_main = StringBuilder::new()
+  for i = 0; i < 260; i = i + 1 {
+    before_main.write_string("<div>preface ")
+    before_main.write_string(i.to_string())
+    before_main.write_string("</div>")
+  }
+  let main = StringBuilder::new()
+  for i = 0; i < 260; i = i + 1 {
+    main.write_string("<p>main paragraph ")
+    main.write_string(i.to_string())
+    main.write_string(" keeps enough content for first viewport sizing.</p>")
+  }
+  "<!DOCTYPE html><html><body>" +
+  before_main.to_string() +
+  "<main>" +
+  main.to_string() +
+  "</main></body></html>"
+}
+
+///|
+test "static snapshot viewport trim keeps body and main excerpts" {
+  let full = synthetic_main_trim_fixture()
+  let trimmed = js_trim_static_html_for_viewport(full, 1000, 4000)
+  assert_true(full.length() > 10000)
+  assert_true(trimmed.length() > 5000)
   assert_true(trimmed.length() < full.length())
+  assert_true(trimmed.contains("crater-vrt-skipped-static-html"))
   assert_true(trimmed.contains("crater-vrt-truncated-static-html"))
   let _ = @html.parse_document(trimmed)
 }

--- a/benchmarks/static_snapshot_bench_wbtest.mbt
+++ b/benchmarks/static_snapshot_bench_wbtest.mbt
@@ -21,3 +21,24 @@ test "mdn static snapshot benchmark fixture uses viewport trim" {
   assert_true(trimmed.contains("crater-vrt-truncated-static-html"))
   let _ = @html.parse_document(trimmed)
 }
+
+///|
+test "static snapshot scale fixtures are renderable" {
+  let long_text = static_snapshot_long_paragraph_html(500)
+  let links = static_snapshot_inline_links_html(100)
+  let blocks = static_snapshot_block_paragraphs_html(100)
+  assert_true(long_text.length() > 5000)
+  assert_true(links.length() > 3000)
+  assert_true(blocks.length() > 6000)
+  let _ = @renderer.render_to_node(long_text, static_snapshot_context())
+  let _ = @renderer.render_to_node(links, static_snapshot_context())
+  let _ = @renderer.render_to_node(blocks, static_snapshot_context())
+}
+
+///|
+test "pathological whitespace node fixture is renderable" {
+  let node = static_snapshot_pathological_whitespace_nodes(10)
+  assert_eq(node.children.length(), 10)
+  let layout_ctx = default_layout_ctx(static_snapshot_context())
+  let _ = @tree.compute_layout_in_context(node, layout_ctx)
+}

--- a/browser/shell/source_dom.mbt
+++ b/browser/shell/source_dom.mbt
@@ -340,7 +340,12 @@ fn build_render_document_from_dom_tree(dom : @dom.DomTree) -> @html.Document {
   let stylesheets : Array[String] = []
   let stylesheet_links : Array[String] = []
   collect_render_document_resources(root, stylesheets, stylesheet_links)
-  @html.assign_synthetic_ids({ root, stylesheets, stylesheet_links })
+  @html.assign_synthetic_ids({
+    root,
+    stylesheets,
+    stylesheet_links,
+    quirks_mode: false,
+  })
 }
 
 ///|

--- a/dom/html/insertion_mode.mbt
+++ b/dom/html/insertion_mode.mbt
@@ -163,8 +163,14 @@ fn TreeBuilder::handle_after_head(self : TreeBuilder, token : Token) -> Unit {
 /// Handle in body insertion mode - this is the main handler
 fn TreeBuilder::handle_in_body(self : TreeBuilder, token : Token) -> Unit {
   match token {
-    Token::Character(c) => self.insert_character(c)
-    Token::Characters(s) => self.insert_characters(s)
+    Token::Character(c) => {
+      self.reconstruct_active_formatting_elements()
+      self.insert_character(c)
+    }
+    Token::Characters(s) => {
+      self.reconstruct_active_formatting_elements()
+      self.insert_characters(s)
+    }
     Token::Comment(_) => () // Ignore comments for now
     Token::Doctype(_) => () // Parse error, ignore
     Token::StartTag(tag, attrs, self_closing) =>
@@ -314,6 +320,10 @@ fn TreeBuilder::handle_in_body_start_tag(
     }
     "a" => {
       // Check for active anchor and close if needed
+      if self.has_active_formatting_element("a") {
+        self.run_adoption_agency("a")
+      }
+      self.reconstruct_active_formatting_elements()
       let elem = create_element(tag, attrs)
       self.insert_element(elem)
       self.active_formatting.push(FormattingElement::Element(elem))
@@ -330,6 +340,7 @@ fn TreeBuilder::handle_in_body_start_tag(
     | "strong"
     | "tt"
     | "u" => {
+      self.reconstruct_active_formatting_elements()
       let elem = create_element(tag, attrs)
       self.insert_element(elem)
       self.active_formatting.push(FormattingElement::Element(elem))
@@ -339,6 +350,7 @@ fn TreeBuilder::handle_in_body_start_tag(
         // Run adoption agency
         self.pop_until("nobr")
       }
+      self.reconstruct_active_formatting_elements()
       let elem = create_element(tag, attrs)
       self.insert_element(elem)
       self.active_formatting.push(FormattingElement::Element(elem))
@@ -404,6 +416,7 @@ fn TreeBuilder::handle_in_body_start_tag(
       // These are table-only elements, ignore if not in table context
       ()
     _ => {
+      self.reconstruct_active_formatting_elements()
       let elem = create_element(tag, attrs)
       self.insert_element(elem)
       if self_closing {
@@ -530,13 +543,7 @@ fn TreeBuilder::handle_in_body_end_tag(
     | "strike"
     | "strong"
     | "tt"
-    | "u" =>
-      // Simple close - full adoption agency needed for complete spec
-      if self.has_element_in_scope(tag) {
-        self.generate_implied_end_tags()
-        self.pop_until(tag)
-        self.remove_from_active_formatting(tag)
-      }
+    | "u" => self.run_adoption_agency(tag)
     "br" => {
       // </br> is treated as <br>
       let elem = create_element("br", {})
@@ -1160,6 +1167,222 @@ fn TreeBuilder::remove_from_active_formatting(
       }
       _ => ()
     }
+  }
+}
+
+///|
+fn TreeBuilder::has_active_formatting_element(
+  self : TreeBuilder,
+  tag : String,
+) -> Bool {
+  for i = self.active_formatting.length() - 1; i >= 0; i = i - 1 {
+    match self.active_formatting[i] {
+      FormattingElement::Element(e) if e.tag == tag => return true
+      FormattingElement::Marker => return false
+      _ => ()
+    }
+  }
+  false
+}
+
+///|
+fn TreeBuilder::has_open_element_match(
+  self : TreeBuilder,
+  element : Element,
+) -> Bool {
+  for open in self.open_elements {
+    if same_tree_builder_element(open, element) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn TreeBuilder::reconstruct_active_formatting_elements(
+  self : TreeBuilder,
+) -> Unit {
+  if self.active_formatting.is_empty() {
+    return
+  }
+  let mut entry_index = self.active_formatting.length() - 1
+  match self.active_formatting[entry_index] {
+    FormattingElement::Marker => return
+    FormattingElement::Element(e) if self.has_open_element_match(e) => return
+    _ => ()
+  }
+  while entry_index > 0 {
+    entry_index = entry_index - 1
+    match self.active_formatting[entry_index] {
+      FormattingElement::Marker => {
+        entry_index = entry_index + 1
+        break
+      }
+      FormattingElement::Element(e) if self.has_open_element_match(e) => {
+        entry_index = entry_index + 1
+        break
+      }
+      _ => ()
+    }
+  }
+  while entry_index < self.active_formatting.length() {
+    match self.active_formatting[entry_index] {
+      FormattingElement::Element(e) => {
+        let reconstructed = clone_element_without_children(e)
+        self.insert_element(reconstructed)
+        self.active_formatting[entry_index] = FormattingElement::Element(
+          reconstructed,
+        )
+      }
+      FormattingElement::Marker => ()
+    }
+    entry_index = entry_index + 1
+  }
+}
+
+///|
+fn TreeBuilder::find_open_element_index(
+  self : TreeBuilder,
+  tag : String,
+) -> Int {
+  for i = self.open_elements.length() - 1; i >= 0; i = i - 1 {
+    if self.open_elements[i].tag == tag {
+      return i
+    }
+  }
+  -1
+}
+
+///|
+fn TreeBuilder::find_furthest_special_after(
+  self : TreeBuilder,
+  stack_index : Int,
+) -> Int {
+  for i = stack_index + 1; i < self.open_elements.length(); i = i + 1 {
+    if is_special_element(self.open_elements[i].tag) {
+      return i
+    }
+  }
+  -1
+}
+
+///|
+fn same_tree_builder_element(a : Element, b : Element) -> Bool {
+  a.tag == b.tag && a.id == b.id
+}
+
+///|
+fn remove_last_matching_child(parent : Element, target : Element) -> Unit {
+  for i = parent.children.length() - 1; i >= 0; i = i - 1 {
+    match parent.children[i] {
+      Node::Element(e) if same_tree_builder_element(e, target) => {
+        let _ = parent.children.remove(i)
+        return
+      }
+      _ => ()
+    }
+  }
+}
+
+///|
+fn insert_after_matching_child(
+  parent : Element,
+  anchor : Element,
+  child : Element,
+) -> Unit {
+  for i = parent.children.length() - 1; i >= 0; i = i - 1 {
+    match parent.children[i] {
+      Node::Element(e) if same_tree_builder_element(e, anchor) => {
+        parent.children.insert(i + 1, Node::Element(child))
+        return
+      }
+      _ => ()
+    }
+  }
+  parent.children.push(Node::Element(child))
+}
+
+///|
+fn clone_element_without_children(element : Element) -> Element {
+  {
+    tag: element.tag,
+    id: element.id,
+    classes: element.classes,
+    style: element.style,
+    attributes: element.attributes,
+    children: [],
+  }
+}
+
+///|
+fn wrap_children_in_formatting_clone(
+  block : Element,
+  formatting : Element,
+) -> Unit {
+  let reconstructed = clone_element_without_children(formatting)
+  for child in block.children {
+    reconstructed.children.push(child)
+  }
+  block.children.clear()
+  block.children.push(Node::Element(reconstructed))
+}
+
+///|
+fn TreeBuilder::reparent_formatting_around_block(
+  self : TreeBuilder,
+  formatting_index : Int,
+  block_index : Int,
+) -> Unit {
+  if formatting_index <= 0 ||
+    block_index <= formatting_index ||
+    block_index >= self.open_elements.length() {
+    return
+  }
+  let common_ancestor = self.open_elements[formatting_index - 1]
+  let formatting = self.open_elements[formatting_index]
+  let block = self.open_elements[block_index]
+  let block_parent = self.open_elements[block_index - 1]
+  remove_last_matching_child(block_parent, block)
+  wrap_children_in_formatting_clone(block, formatting)
+  insert_after_matching_child(common_ancestor, formatting, block)
+  let _ = self.open_elements.remove(formatting_index)
+}
+
+///|
+fn TreeBuilder::run_adoption_agency(self : TreeBuilder, tag : String) -> Unit {
+  let mut attempt = 0
+  while attempt < 8 {
+    attempt = attempt + 1
+    let formatting_index = self.find_open_element_index(tag)
+    if formatting_index < 0 {
+      self.any_other_end_tag(tag)
+      return
+    }
+    if !self.has_element_in_scope(tag) {
+      self.remove_from_active_formatting(tag)
+      return
+    }
+    match self.current_node() {
+      Some(e) if e.tag == tag => {
+        let _ = self.open_elements.pop()
+        self.remove_from_active_formatting(tag)
+        return
+      }
+      _ => ()
+    }
+    let furthest_block_index = self.find_furthest_special_after(
+      formatting_index,
+    )
+    if furthest_block_index < 0 {
+      self.pop_until(tag)
+      self.remove_from_active_formatting(tag)
+      return
+    }
+    self.reparent_formatting_around_block(
+      formatting_index, furthest_block_index,
+    )
+    self.remove_from_active_formatting(tag)
+    return
   }
 }
 

--- a/dom/html/parser.mbt
+++ b/dom/html/parser.mbt
@@ -19,6 +19,7 @@ pub(all) struct Document {
   root : Element
   stylesheets : Array[String] // CSS content from <style> tags
   stylesheet_links : Array[String] // URLs from <link rel="stylesheet">
+  quirks_mode : Bool
 }
 
 ///|
@@ -225,6 +226,25 @@ fn Parser::skip_doctype(self : Parser) -> Unit {
     // Not a DOCTYPE, reset position
     self.pos = start_pos
   }
+}
+
+///|
+/// Detect the small no-quirks doctype shape that Crater currently supports.
+fn has_html_no_quirks_doctype(html : String) -> Bool {
+  let parser = Parser::new(html)
+  parser.skip_whitespace()
+  while parser.skip_comment() {
+    parser.skip_whitespace()
+  }
+  guard parser.peek() is Some('<') && parser.peek_at(1) is Some('!') else {
+    return false
+  }
+  let _ = parser.consume() // <
+  let _ = parser.consume() // !
+  let word = parser.consume_name().to_lower()
+  guard word == "doctype" else { return false }
+  parser.skip_whitespace()
+  parser.consume_name().to_lower() == "html"
 }
 
 ///|
@@ -848,6 +868,7 @@ pub fn parse_document_v2(html : String) -> Element {
 ///|
 /// Parse HTML and extract stylesheets
 pub fn parse_document(html : String) -> Document {
+  let quirks_mode = !has_html_no_quirks_doctype(html)
   let root = parse_document_v2(html)
   let resource_html = strip_noscript_blocks(html)
   let resource_root = if resource_html == html {
@@ -858,7 +879,7 @@ pub fn parse_document(html : String) -> Document {
   let stylesheets : Array[String] = []
   let stylesheet_links : Array[String] = []
   extract_stylesheets(resource_root, stylesheets, stylesheet_links, false)
-  { root, stylesheets, stylesheet_links }
+  { root, stylesheets, stylesheet_links, quirks_mode }
 }
 
 ///|

--- a/dom/html/parser_test.mbt
+++ b/dom/html/parser_test.mbt
@@ -146,6 +146,16 @@ test "parse_document with style tag" {
 }
 
 ///|
+test "parse_document records no-doctype quirks mode" {
+  let quirks_doc = @html.parse_document("<html><body><p>old</p></body></html>")
+  let standards_doc = @html.parse_document(
+    "<!doctype html><html><body><p>modern</p></body></html>",
+  )
+  inspect(quirks_doc.quirks_mode, content="true")
+  inspect(standards_doc.quirks_mode, content="false")
+}
+
+///|
 test "parse_document wraps style media attribute into media rule" {
   let html =
     #|<html>

--- a/dom/html/pkg.generated.mbti
+++ b/dom/html/pkg.generated.mbti
@@ -25,6 +25,7 @@ pub(all) struct Document {
   root : Element
   stylesheets : Array[String]
   stylesheet_links : Array[String]
+  quirks_mode : Bool
 }
 
 pub(all) struct Element {

--- a/dom/html/streaming_tree_builder.mbt
+++ b/dom/html/streaming_tree_builder.mbt
@@ -603,5 +603,10 @@ pub fn parse_document_streaming(html : String, chunk_size : Int) -> Document {
     offset = end
   }
   let root = builder.finish()
-  { root, stylesheets: [], stylesheet_links: [] }
+  {
+    root,
+    stylesheets: [],
+    stylesheet_links: [],
+    quirks_mode: !has_html_no_quirks_doctype(html),
+  }
 }

--- a/dom/html/tree_builder_test.mbt
+++ b/dom/html/tree_builder_test.mbt
@@ -22,6 +22,93 @@ fn find_body_v2(elem : @html.Element) -> @html.Element {
 }
 
 ///|
+fn expect_element_node(
+  node : @html.Node,
+  tag : String,
+) -> @html.Element raise Error {
+  match node {
+    @html.Node::Element(e) => {
+      if e.tag != tag {
+        fail("expected <" + tag + ">")
+      }
+      e
+    }
+    @html.Node::Text(_) => fail("expected <" + tag + ">")
+  }
+}
+
+///|
+fn expect_text_node(node : @html.Node, expected : String) -> Unit raise Error {
+  match node {
+    @html.Node::Text(t) =>
+      if t != expected {
+        fail("expected text " + expected)
+      }
+    @html.Node::Element(_) => fail("expected text " + expected)
+  }
+}
+
+///|
+fn assert_formatting_reparented_across_paragraph(
+  tag : String,
+) -> Unit raise Error {
+  let html = "<" + tag + ">1<p>2</" + tag + ">3</p>"
+  let result = @html.parse_fragment_v2(html)
+  let body = find_body_v2(result)
+  if body.children.length() != 2 {
+    fail("expected original formatting element and paragraph")
+  }
+  let original = expect_element_node(body.children[0], tag)
+  if original.children.length() != 1 {
+    fail("expected original formatting element to keep only leading text")
+  }
+  expect_text_node(original.children[0], "1")
+  let paragraph = expect_element_node(body.children[1], "p")
+  if paragraph.children.length() != 2 {
+    fail("expected paragraph to contain reconstructed formatting and text")
+  }
+  let reconstructed = expect_element_node(paragraph.children[0], tag)
+  if reconstructed.children.length() != 1 {
+    fail("expected reconstructed formatting element to keep text")
+  }
+  expect_text_node(reconstructed.children[0], "2")
+  expect_text_node(paragraph.children[1], "3")
+}
+
+///|
+fn count_direct_element_children(elem : @html.Element, tag : String) -> Int {
+  let mut count = 0
+  for child in elem.children {
+    match child {
+      @html.Node::Element(e) if e.tag == tag => count = count + 1
+      _ => ()
+    }
+  }
+  count
+}
+
+///|
+fn hn_submission_rows(id : String, rank : String, title : String) -> String {
+  "<tr class=\"athing submission\" id=\"" +
+  id +
+  "\"><td align=\"right\" class=\"title\">" +
+  rank +
+  ".</td><td class=\"votelinks\" valign=\"top\"><center><a id=\"up_" +
+  id +
+  "\" href=\"vote?id=" +
+  id +
+  "&amp;how=up\"><div class=\"votearrow\" title=\"upvote\"></div></a></center></td><td class=\"title\"><span class=\"titleline\"><a href=\"item?id=" +
+  id +
+  "\">" +
+  title +
+  "</a></span></td></tr><tr><td colspan=\"2\"></td><td class=\"subtext\"><span class=\"subline\"><a href=\"item?id=" +
+  id +
+  "\">1 point</a> | <a href=\"hide?id=" +
+  id +
+  "\">hide</a></span></td></tr><tr class=\"spacer\" style=\"height:5px\"></tr>"
+}
+
+///|
 test "tree_builder/simple text" {
   let html = "Test"
   let result = @html.parse_fragment_v2(html)
@@ -163,6 +250,101 @@ test "tree_builder/foster parenting anchor" {
   // With foster parenting, the anchor should come first
   // Without it, the table comes first
   inspect(first_tag, content="a")
+}
+
+///|
+test "tree_builder/adoption agency reparents anchor across paragraph" {
+  let html = "<a>1<p>2</a>3</p>"
+  let result = @html.parse_fragment_v2(html)
+  let body = find_body_v2(result)
+  let tags : Array[String] = []
+  for child in body.children {
+    match child {
+      @html.Node::Element(e) => tags.push(e.tag)
+      @html.Node::Text(t) => if !t.trim().is_empty() { tags.push("#text:" + t) }
+    }
+  }
+  debug_inspect(tags, content="[\"a\", \"p\"]")
+  match body.children[0] {
+    @html.Node::Element(anchor) => {
+      inspect(anchor.tag, content="a")
+      inspect(anchor.children.length(), content="1")
+      match anchor.children[0] {
+        @html.Node::Text(t) => inspect(t, content="1")
+        _ => fail("expected text in original anchor")
+      }
+    }
+    _ => fail("expected original anchor")
+  }
+  match body.children[1] {
+    @html.Node::Element(paragraph) => {
+      inspect(paragraph.tag, content="p")
+      inspect(paragraph.children.length(), content="2")
+      match paragraph.children[0] {
+        @html.Node::Element(anchor) => {
+          inspect(anchor.tag, content="a")
+          match anchor.children[0] {
+            @html.Node::Text(t) => inspect(t, content="2")
+            _ => fail("expected text in reconstructed anchor")
+          }
+        }
+        _ => fail("expected reconstructed anchor in paragraph")
+      }
+      match paragraph.children[1] {
+        @html.Node::Text(t) => inspect(t, content="3")
+        _ => fail("expected trailing paragraph text")
+      }
+    }
+    _ => fail("expected paragraph")
+  }
+}
+
+///|
+test "tree_builder/adoption agency handles common formatting elements" {
+  for tag in ["b", "i", "font", "nobr"] {
+    assert_formatting_reparented_across_paragraph(tag)
+  }
+}
+
+///|
+test "tree_builder/reconstructs active formatting after paragraph close" {
+  let result = @html.parse_fragment_v2("<p><b>foo</p>bar")
+  let body = find_body_v2(result)
+  inspect(body.children.length(), content="2")
+  let paragraph = expect_element_node(body.children[0], "p")
+  let paragraph_bold = expect_element_node(paragraph.children[0], "b")
+  expect_text_node(paragraph_bold.children[0], "foo")
+  let trailing_bold = expect_element_node(body.children[1], "b")
+  expect_text_node(trailing_bold.children[0], "bar")
+}
+
+///|
+test "tree_builder/reconstructs active formatting before phrasing start tag" {
+  let result = @html.parse_fragment_v2("<p><b>foo</p><span>bar</span>")
+  let body = find_body_v2(result)
+  inspect(body.children.length(), content="2")
+  let paragraph = expect_element_node(body.children[0], "p")
+  let paragraph_bold = expect_element_node(paragraph.children[0], "b")
+  expect_text_node(paragraph_bold.children[0], "foo")
+  let trailing_bold = expect_element_node(body.children[1], "b")
+  let span = expect_element_node(trailing_bold.children[0], "span")
+  expect_text_node(span.children[0], "bar")
+}
+
+///|
+test "tree_builder/hackernews vote anchor div keeps rows in tbody" {
+  let html = "<table><tbody>" +
+    hn_submission_rows("1", "1", "First story") +
+    hn_submission_rows("2", "2", "Second story") +
+    hn_submission_rows("3", "3", "Third story") +
+    "</tbody></table>"
+  let result = @html.parse_fragment_v2(html)
+  let body = find_body_v2(result)
+  inspect(body.children.length(), content="1")
+  let table = expect_element_node(body.children[0], "table")
+  inspect(table.children.length(), content="1")
+  let tbody = expect_element_node(table.children[0], "tbody")
+  inspect(count_direct_element_children(tbody, "tr"), content="9")
 }
 
 ///|

--- a/dom/scheduler/layout_integration.mbt
+++ b/dom/scheduler/layout_integration.mbt
@@ -397,6 +397,7 @@ pub fn DocumentRenderCoordinator::process_html(
     root: parse_result.root,
     stylesheets: [],
     stylesheet_links: [],
+    quirks_mode: false,
   }
   self.layout_manager.build_tree_from_html(doc, viewport_width, viewport_height)
 

--- a/justfile
+++ b/justfile
@@ -468,6 +468,14 @@ vrt-report-summary input_dir label="vrt-artifacts" output_dir="vrt-report-summar
     mkdir -p {{output_dir}}
     if [ -n "{{collect_task_id}}" ]; then node --import tsx scripts/vrt-report-summary.ts --input {{input_dir}} --label {{label}} --collect-task-id {{collect_task_id}} --json {{output_dir}}/{{label}}.json --markdown {{output_dir}}/{{label}}.md; else node --import tsx scripts/vrt-report-summary.ts --input {{input_dir}} --label {{label}} --json {{output_dir}}/{{label}}.json --markdown {{output_dir}}/{{label}}.md; fi | tee {{output_dir}}/{{label}}.log
 
+# Regenerate the local current paint VRT summary while ignoring stale WPT/url scratch reports
+paint-vrt-current-summary input_dir="output/playwright/vrt" output_prefix="output/playwright/vrt-current-summary":
+    node --import tsx scripts/vrt-report-summary.ts --input {{input_dir}} --label paint-vrt-current --include-task-id paint-vrt --include-task-id paint-vrt-font-fallback --include-task-id paint-vrt-gradients --include-task-id paint-vrt-svg-intrinsic --exclude-filter wikipedia --json {{output_prefix}}.json --markdown {{output_prefix}}.md
+
+# Check that the local current paint VRT summary is newer than all selected report.json files
+paint-vrt-current-summary-check input_dir="output/playwright/vrt" output_prefix="output/playwright/vrt-current-summary":
+    node --import tsx scripts/vrt-report-summary.ts --input {{input_dir}} --label paint-vrt-current --include-task-id paint-vrt --include-task-id paint-vrt-font-fallback --include-task-id paint-vrt-gradients --include-task-id paint-vrt-svg-intrinsic --exclude-filter wikipedia --json {{output_prefix}}.json --markdown {{output_prefix}}.md --check-fresh
+
 # Capture a live site into real-world/ (gitignored)
 capture-realworld *args:
     pnpm capture:realworld -- {{args}}

--- a/layout/block/block.mbt
+++ b/layout/block/block.mbt
@@ -2223,8 +2223,22 @@ fn compute_root_layout(
   let layout = result.layout
 
   let adjusted_for_margin = if node.id == "body" {
-    // Browser compatibility: body box metrics should remain content-based.
-    layout
+    // Browser compatibility: a first child's collapsed top margin moves the
+    // body border box in the viewport, but it collapses with body margin and
+    // must not expand body box metrics.
+    match result.collapsed.top {
+      Some(escaped_margin_set) => {
+        let escaped_margin = collapsed_margin_value(escaped_margin_set)
+        let body_margin = @types.resolve_rect(
+          node.style.margin,
+          ctx.viewport_width,
+        )
+        let collapsed_offset = collapse_margins(body_margin.top, escaped_margin) -
+          body_margin.top
+        { ..layout, y: layout.y + collapsed_offset }
+      }
+      None => layout
+    }
   } else {
     // For non-body roots, preserve escaped margin behavior used by internal layout tests.
     match result.collapsed.top {

--- a/painter/paint/glyph/layout.mbt
+++ b/painter/paint/glyph/layout.mbt
@@ -16,9 +16,14 @@ pub(all) struct GlyphPlacement {
 pub fn resolve_text_wrap_tolerance(
   max_width : Int,
   font_size : Double,
+  line_height? : Double = 0.0,
+  text_length? : Int = 0,
 ) -> Double {
   if max_width <= 0 {
     return text_wrap_tolerance
+  }
+  if font_size > 0.0 && line_height > font_size * 1.35 && text_length > 72 {
+    return 1.0
   }
   let width_tolerance = max_width.to_double() * 0.2
   let font_tolerance = if font_size > 0.0 {
@@ -159,7 +164,12 @@ pub fn layout_glyph_bitmaps(
       get_ascent(font_family) * font_size
     _ => provider.ascent_ratio * font_size
   }
-  let wrap_tolerance = resolve_text_wrap_tolerance(max_width, font_size)
+  let wrap_tolerance = resolve_text_wrap_tolerance(
+    max_width,
+    font_size,
+    line_height~,
+    text_length=text.length(),
+  )
   let max_x_limit = if max_width > 0 {
     (x + max_width).to_double() + wrap_tolerance
   } else {

--- a/painter/paint/glyph/layout_wbtest.mbt
+++ b/painter/paint/glyph/layout_wbtest.mbt
@@ -37,3 +37,15 @@ test "layout_glyph_bitmaps places wrapped glyphs outside raster" {
   inspect((placements[2].y - 10.0).abs() < 0.01, content="true")
   inspect(used_height, content="20")
 }
+
+///|
+test "resolve_text_wrap_tolerance tightens only long paragraph text" {
+  inspect(
+    resolve_text_wrap_tolerance(440, 14.0, line_height=22.0, text_length=100),
+    content="1",
+  )
+  inspect(
+    resolve_text_wrap_tolerance(27, 14.0, line_height=22.0, text_length=8) > 1.0,
+    content="true",
+  )
+}

--- a/painter/paint/glyph/pkg.generated.mbti
+++ b/painter/paint/glyph/pkg.generated.mbti
@@ -38,7 +38,7 @@ pub fn rasterize_glyph_to_bitmap(Array[@svg.PathCommand], Double) -> GlyphBitmap
 
 pub fn resolve_effective_font_weight(Bool, Double) -> Double
 
-pub fn resolve_text_wrap_tolerance(Int, Double) -> Double
+pub fn resolve_text_wrap_tolerance(Int, Double, line_height? : Double, text_length? : Int) -> Double
 
 pub fn set_glyph_provider(GlyphProvider) -> Unit
 

--- a/renderer/renderer/document_prepare.mbt
+++ b/renderer/renderer/document_prepare.mbt
@@ -274,8 +274,89 @@ pub struct PreparedRenderDocument {
   render_root : @html.Element
   render_root_tag : String
   body_uses_document_root_style : Bool
+  suppress_quirks_body_ua_top_margin : Bool
   before_index : PseudoRuleIndex
   after_index : PseudoRuleIndex
+}
+
+///|
+fn text_is_whitespace_only(s : String) -> Bool {
+  for i = 0; i < s.length(); i = i + 1 {
+    let c = s[i].to_int().unsafe_to_char()
+    if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn tag_has_ua_top_margin(tag : String) -> Bool {
+  match tag.to_lower() {
+    "p"
+    | "h1"
+    | "h2"
+    | "h3"
+    | "h4"
+    | "h5"
+    | "h6"
+    | "ul"
+    | "ol"
+    | "menu"
+    | "dl"
+    | "pre"
+    | "blockquote"
+    | "figure" => true
+    _ => false
+  }
+}
+
+///|
+fn leading_margin_is_ua_default(elem : @html.Element) -> Bool {
+  if elem.style is Some(_) {
+    return false
+  }
+  if tag_has_ua_top_margin(elem.tag) {
+    return true
+  }
+  for child in elem.children {
+    match child {
+      @html.Node::Text(t) => if !text_is_whitespace_only(t) { return false }
+      @html.Node::Element(child_elem) =>
+        if leading_margin_is_ua_default(child_elem) {
+          return true
+        } else if child_elem.style is Some(_) {
+          return false
+        }
+    }
+  }
+  false
+}
+
+///|
+fn should_suppress_quirks_body_ua_top_margin(
+  doc : @html.Document,
+  render_root : @html.Element,
+  external_bundle : PreparedExternalCss,
+) -> Bool {
+  if !doc.quirks_mode ||
+    render_root.tag.to_lower() != "body" ||
+    !doc.stylesheets.is_empty() ||
+    external_bundle.total_rules > 0 {
+    return false
+  }
+  for child in render_root.children {
+    match child {
+      @html.Node::Text(t) => if !text_is_whitespace_only(t) { return false }
+      @html.Node::Element(elem) =>
+        if leading_margin_is_ua_default(elem) {
+          return true
+        } else if elem.style is Some(_) {
+          return false
+        }
+    }
+  }
+  false
 }
 
 ///|
@@ -327,6 +408,12 @@ fn prepare_render_document_with_external_css_bundle(
     indexed_stylesheets.push(@css.IndexedStylesheet::new(stylesheet))
   }
   let _t1 = perf_clock_us()
+  maybe_log_perf(
+    "[perf] css_parse=" +
+    ((_t1 - t0) / 1000L).to_string() +
+    "ms rules=" +
+    total_rules.to_string(),
+  )
   let _t2 = perf_clock_us()
   let css_vars = collect_root_css_variables(stylesheets, ctx)
   let doc_root_selector = if indexed_stylesheets.length() == 0 {
@@ -345,6 +432,9 @@ fn prepare_render_document_with_external_css_bundle(
   )
   let render_root = select_render_root(doc.root, doc_root_style)
   let render_root_tag = render_root.tag.to_lower()
+  let suppress_quirks_body_ua_top_margin = should_suppress_quirks_body_ua_top_margin(
+    doc, render_root, external_bundle,
+  )
   let prepared : PreparedRenderDocument = {
     stylesheets,
     indexed_stylesheets,
@@ -355,6 +445,7 @@ fn prepare_render_document_with_external_css_bundle(
     render_root_tag,
     body_uses_document_root_style: render_root_tag == "body" &&
     doc.root.tag.to_lower() != "body",
+    suppress_quirks_body_ua_top_margin,
     before_index: if doc.stylesheets.is_empty() {
       external_bundle.before_index
     } else {

--- a/renderer/renderer/flex_render_test.mbt
+++ b/renderer/renderer/flex_render_test.mbt
@@ -1010,6 +1010,21 @@ test "hn_flex_nav_name_link_keeps_single_line_auto_min_width" {
 }
 
 ///|
+test "flex_drops_whitespace_only_text_between_icon_links" {
+  let html =
+    #|<!DOCTYPE html>
+    #|<style>
+    #|body { margin: 0; font-family: monospace; font-size: 16px; line-height: 1; }
+    #|.nav { display: inline-flex; }
+    #|.icon { display: block; width: 10px; height: 10px; }
+    #|</style>
+    #|<div class="nav"><a><span class="icon"></span></a> <a><span class="icon"></span></a></div>
+  let layout = @renderer.render(html, @renderer.RenderContext::default())
+  let nav = layout.children[0]
+  inspect(nav.width, content="20")
+}
+
+///|
 test "wpt_flex_child_percent_basis_resize_1_like" {
   let html_str =
     #|<!DOCTYPE html>

--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -120,6 +120,7 @@ pub struct PreparedRenderDocument {
   render_root : @html.Element
   render_root_tag : String
   body_uses_document_root_style : Bool
+  suppress_quirks_body_ua_top_margin : Bool
   before_index : PseudoRuleIndex
   after_index : PseudoRuleIndex
 }

--- a/renderer/renderer/render_api.mbt
+++ b/renderer/renderer/render_api.mbt
@@ -14,7 +14,10 @@ pub fn render_with_external_css(
   ctx : RenderContext,
   external_css : Array[String],
 ) -> @layout_types.Layout {
+  let t0 = perf_clock_us()
   let doc = @html.parse_document(html)
+  let t1 = perf_clock_us()
+  maybe_log_perf("[perf] html_parse=" + ((t1 - t0) / 1000L).to_string() + "ms")
   render_document_with_external_css(doc, ctx, external_css)
 }
 
@@ -91,7 +94,10 @@ pub fn render_to_node_and_layout_with_external_css(
   ctx : RenderContext,
   external_css : Array[String],
 ) -> (@node.Node, @layout_types.Layout) {
+  let t0 = perf_clock_us()
   let doc = @html.parse_document(html)
+  let t1 = perf_clock_us()
+  maybe_log_perf("[perf] html_parse=" + ((t1 - t0) / 1000L).to_string() + "ms")
   render_to_node_and_layout_with_document(doc, ctx, external_css)
 }
 

--- a/renderer/renderer/render_root.mbt
+++ b/renderer/renderer/render_root.mbt
@@ -470,10 +470,15 @@ pub fn compute_layout_from_render_root(
   } else {
     root_margin.left
   }
+  let y_offset = if prepared.suppress_quirks_body_ua_top_margin {
+    root_margin.top
+  } else {
+    root_margin.top + scaled_layout.y
+  }
   {
     id: scaled_layout.id,
     x: x_offset,
-    y: root_margin.top,
+    y: y_offset,
     width: scaled_layout.width,
     height: scaled_layout.height,
     margin: scaled_layout.margin,

--- a/renderer/renderer/root_body_render_test.mbt
+++ b/renderer/renderer/root_body_render_test.mbt
@@ -93,7 +93,59 @@ test "body_collapsed_top_margin_does_not_expand_body_box" {
   let child = layout.children[0]
 
   inspect(layout.id, content="body")
+  inspect(layout.y, content="10")
   inspect(layout.height, content="50")
+  inspect(child.y, content="0")
+}
+
+///|
+test "body_margin_collapses_with_first_child_top_margin" {
+  let html_str =
+    #|<!DOCTYPE html>
+    #|<style>
+    #|body { margin: 16px; }
+    #|div { margin-top: 16px; height: 50px; }
+    #|</style>
+    #|<div></div>
+  let ctx = @renderer.RenderContext::default()
+  let layout = @renderer.render(html_str, ctx)
+  let child = layout.children[0]
+
+  inspect(layout.id, content="body")
+  inspect(layout.y, content="16")
+  inspect(layout.height, content="50")
+  inspect(child.y, content="0")
+}
+
+///|
+test "quirks_body_ua_top_margin_stays_at_body_margin" {
+  let html_str =
+    #|<html><body>
+    #|  <header><title>old page</title></header>
+    #|  <h1>Old page heading</h1>
+    #|  <p>Intro text</p>
+    #|</body></html>
+  let ctx = @renderer.RenderContext::default()
+  let layout = @renderer.render(html_str, ctx)
+  let h1 = layout.children[1]
+
+  inspect(layout.id, content="body")
+  inspect(layout.y, content="8")
+  inspect(h1.y, content="0")
+}
+
+///|
+test "quirks_author_top_margin_still_moves_body" {
+  let html_str =
+    #|<html><body>
+    #|  <div style="margin-top: 24px; height: 50px;"></div>
+    #|</body></html>
+  let ctx = @renderer.RenderContext::default()
+  let layout = @renderer.render(html_str, ctx)
+  let child = layout.children[0]
+
+  inspect(layout.id, content="body")
+  inspect(layout.y, content="24")
   inspect(child.y, content="0")
 }
 

--- a/renderer/renderer/viewport_skeleton.mbt
+++ b/renderer/renderer/viewport_skeleton.mbt
@@ -19,7 +19,7 @@ let viewport_skeleton_count : Ref[Int] = { val: 0 }
 let viewport_full_node_count : Ref[Int] = { val: 0 }
 
 ///|
-let viewport_full_node_cutoff : Ref[Int] = { val: 300 }
+let viewport_full_node_cutoff : Ref[Int] = { val: 2000 }
 
 ///|
 let viewport_skeleton_enabled : Ref[Bool] = { val: true }

--- a/renderer/renderer/viewport_skeleton_wbtest.mbt
+++ b/renderer/renderer/viewport_skeleton_wbtest.mbt
@@ -73,3 +73,11 @@ test "full document render disables viewport skeleton culling" {
   assert_eq(full_skeletons, 0)
   assert_eq(full_images, 360)
 }
+
+///|
+test "viewport skeleton keeps dense above fold content before y cutoff" {
+  let html = many_image_document(120)
+  let ctx = RenderContext::default()
+  ignore(render_to_node_and_layout(html, ctx))
+  assert_eq(viewport_skeleton_count.val, 0)
+}

--- a/scripts/text-intrinsic.ts
+++ b/scripts/text-intrinsic.ts
@@ -14,7 +14,18 @@ export type ExternalTextIntrinsicFn = (
   availableHeight: number,
 ) => { minWidth: number; maxWidth: number; minHeight: number; maxHeight: number };
 
-type TextIntrinsicResult = ReturnType<ExternalTextIntrinsicFn>;
+export type TextIntrinsicResult = ReturnType<ExternalTextIntrinsicFn>;
+
+export interface TextIntrinsicCallOptions {
+  text: string;
+  fontSize: number;
+  lineHeight: number;
+  whiteSpace: string;
+  writingMode: string;
+  fontFamily: string;
+  availableWidth: number;
+  availableHeight: number;
+}
 
 const TEXT_MEASURE_CACHE_LIMIT = 20_000;
 const TEXT_INTRINSIC_CACHE_LIMIT = 10_000;
@@ -173,4 +184,20 @@ export function createTextIntrinsicFnFromMeasureText(
       return { minWidth: minWordWidth, maxWidth, minHeight, maxHeight };
     });
   };
+}
+
+export function callTextIntrinsicFn(
+  fn: ExternalTextIntrinsicFn,
+  options: TextIntrinsicCallOptions,
+): TextIntrinsicResult {
+  return fn(
+    options.text,
+    options.fontSize,
+    options.lineHeight,
+    options.whiteSpace,
+    options.writingMode,
+    options.fontFamily,
+    options.availableWidth,
+    options.availableHeight,
+  );
 }

--- a/scripts/vrt-report-loader.ts
+++ b/scripts/vrt-report-loader.ts
@@ -9,6 +9,12 @@ import {
   type VrtStableIdentity,
 } from "./vrt-report-contract.ts";
 
+export interface VrtArtifactReportFilterOptions {
+  includeTaskIds?: string[];
+  excludeFilters?: string[];
+  requireIdentity?: boolean;
+}
+
 function collectReportFiles(rootDir: string): string[] {
   if (!fs.existsSync(rootDir)) {
     return [];
@@ -48,6 +54,49 @@ function readJsonReport(filePath: string): VrtArtifactRawReport | null {
 function normalizeLabel(rootDir: string, reportPath: string): string {
   const relativeDir = path.relative(rootDir, path.dirname(reportPath));
   return relativeDir.length > 0 ? relativeDir : ".";
+}
+
+function normalizeFilterValues(values: string[] | undefined): Set<string> {
+  return new Set((values ?? [])
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0));
+}
+
+function matchesReportFilter(
+  input: {
+    title: string;
+    fallbackLabel: string;
+    identity?: VrtStableIdentity;
+  },
+  options: VrtArtifactReportFilterOptions | undefined,
+): boolean {
+  if (!options) {
+    return true;
+  }
+
+  if (options.requireIdentity && !input.identity) {
+    return false;
+  }
+
+  const includeTaskIds = normalizeFilterValues(options.includeTaskIds);
+  if (includeTaskIds.size > 0 && !includeTaskIds.has(input.identity?.taskId ?? "")) {
+    return false;
+  }
+
+  const excludeFilters = normalizeFilterValues(options.excludeFilters);
+  if (excludeFilters.size > 0) {
+    const filterCandidates = [
+      input.identity?.filter,
+      input.identity?.title,
+      input.title,
+      input.fallbackLabel,
+    ].filter((value): value is string => typeof value === "string" && value.length > 0);
+    if (filterCandidates.some((value) => excludeFilters.has(value))) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function collectVariantKeys(identities: Array<VrtStableIdentity | undefined>): string[] {
@@ -144,7 +193,10 @@ function disambiguateReportLabels(
   });
 }
 
-export function loadVrtArtifactReports(inputDir: string): LoadedVrtArtifactReport[] {
+export function loadVrtArtifactReports(
+  inputDir: string,
+  options?: VrtArtifactReportFilterOptions,
+): LoadedVrtArtifactReport[] {
   const rows: Array<LoadedVrtArtifactReport & {
     fallbackLabel: string;
     identity?: VrtStableIdentity;
@@ -155,12 +207,17 @@ export function loadVrtArtifactReports(inputDir: string): LoadedVrtArtifactRepor
       continue;
     }
     const fallbackLabel = normalizeLabel(inputDir, reportPath);
+    const label = readVrtArtifactTitle(report, fallbackLabel);
+    const identity = readVrtArtifactIdentity(report);
+    if (!matchesReportFilter({ title: label, fallbackLabel, identity }, options)) {
+      continue;
+    }
     rows.push({
-      label: readVrtArtifactTitle(report, fallbackLabel),
+      label,
       fallbackLabel,
       reportPath,
       report,
-      identity: readVrtArtifactIdentity(report),
+      identity,
     });
   }
   return disambiguateReportLabels(rows)

--- a/scripts/vrt-report-summary-cli.test.ts
+++ b/scripts/vrt-report-summary-cli.test.ts
@@ -296,4 +296,189 @@ describe("runVrtReportSummaryCli", () => {
       },
     });
   });
+
+  it("filters current paint VRT summaries by task id and excluded filter", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "crater-vrt-report-current-filter-"));
+    const inputDir = path.join(root, "output", "playwright", "vrt");
+    fs.mkdirSync(path.join(inputDir, "mdn-wasm-text"), { recursive: true });
+    fs.mkdirSync(path.join(inputDir, "wikipedia"), { recursive: true });
+    fs.mkdirSync(path.join(inputDir, "wpt", "css-display", "display-contents"), { recursive: true });
+    fs.mkdirSync(path.join(inputDir, "font-fallback-ja-system"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "mdn-wasm-text", "report.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        suite: "vrt-artifact",
+        status: "pass",
+        title: "real-world snapshot: mdn-wasm-text stays within loose visual diff budget",
+        identity: {
+          key: "paint-mdn",
+          taskId: "paint-vrt",
+          spec: "tests/paint-vrt.test.ts",
+          filter: "mdn-wasm-text",
+          title: "real-world snapshot: mdn-wasm-text stays within loose visual diff budget",
+          variant: { backend: "sixel", snapshotKind: "real-world" },
+        },
+        metadata: {
+          width: 1440,
+          height: 960,
+          diffRatio: 0.03,
+          maxDiffRatio: 0.04,
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(inputDir, "font-fallback-ja-system", "report.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        suite: "vrt-artifact",
+        status: "pass",
+        title: "Japanese text uses system fallback glyphs",
+        identity: {
+          key: "paint-font",
+          taskId: "paint-vrt-font-fallback",
+          spec: "tests/paint-vrt-font-fallback.test.ts",
+          filter: "font-fallback-ja-system",
+          title: "Japanese text uses system fallback glyphs",
+          variant: { backend: "sixel" },
+        },
+        metadata: {
+          diffRatio: 0.08,
+          maxDiffRatio: 0.095,
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(inputDir, "wikipedia", "report.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        suite: "vrt-artifact",
+        status: "pass",
+        title: "url snapshot: wikipedia visual diff within budget",
+        identity: {
+          key: "paint-wikipedia",
+          taskId: "paint-vrt",
+          spec: "tests/paint-vrt.test.ts",
+          filter: "wikipedia",
+          title: "url snapshot: wikipedia visual diff within budget",
+          variant: { backend: "sixel" },
+        },
+        metadata: {
+          diffRatio: 0.2,
+          maxDiffRatio: 0.25,
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(inputDir, "wpt", "css-display", "display-contents", "report.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        suite: "vrt-artifact",
+        status: "fail",
+        title: "display contents WPT",
+        identity: {
+          key: "wpt-display",
+          taskId: "wpt-vrt",
+          spec: "tests/wpt-vrt.test.ts",
+          filter: "css-display/display-contents.html",
+          title: "display contents WPT",
+          variant: { backend: "sixel", snapshotKind: "wpt" },
+        },
+        metadata: {
+          diffRatio: 0.9,
+          maxDiffRatio: 0.15,
+        },
+      }),
+      "utf8",
+    );
+
+    const result = runVrtReportSummaryCli([
+      "--input",
+      "output/playwright/vrt",
+      "--label",
+      "paint-vrt-current",
+      "--include-task-id",
+      "paint-vrt",
+      "--include-task-id",
+      "paint-vrt-font-fallback",
+      "--exclude-filter",
+      "wikipedia",
+      "--json",
+      "out/vrt-current.json",
+    ], {
+      cwd: root,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const jsonWrite = result.writes?.find((write) => write.path.endsWith("vrt-current.json"));
+    expect(jsonWrite).toBeDefined();
+    const parsed = JSON.parse(jsonWrite!.content) as {
+      total: number;
+      rows: Array<{ label: string; status: string; diffRatio: number }>;
+    };
+    expect(parsed.total).toBe(2);
+    expect(parsed.rows.map((row) => row.label).sort()).toEqual([
+      "Japanese text uses system fallback glyphs",
+      "real-world snapshot: mdn-wasm-text stays within loose visual diff budget",
+    ]);
+  });
+
+  it("fails freshness check when an existing summary is older than selected reports", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "crater-vrt-report-fresh-check-"));
+    const inputDir = path.join(root, "output", "playwright", "vrt", "google");
+    const outDir = path.join(root, "output", "playwright");
+    fs.mkdirSync(inputDir, { recursive: true });
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const reportPath = path.join(inputDir, "report.json");
+    const summaryPath = path.join(outDir, "vrt-current-summary.json");
+    fs.writeFileSync(
+      reportPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        suite: "vrt-artifact",
+        status: "pass",
+        title: "url snapshot: google visual diff within budget",
+        identity: {
+          key: "paint-google",
+          taskId: "paint-vrt",
+          spec: "tests/paint-vrt.test.ts",
+          filter: "google",
+          title: "url snapshot: google visual diff within budget",
+          variant: { backend: "sixel" },
+        },
+        metadata: {
+          diffRatio: 0.006,
+          maxDiffRatio: 0.02,
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(summaryPath, "{}\n", "utf8");
+    fs.utimesSync(summaryPath, new Date("2026-01-01T00:00:00Z"), new Date("2026-01-01T00:00:00Z"));
+    fs.utimesSync(reportPath, new Date("2026-01-02T00:00:00Z"), new Date("2026-01-02T00:00:00Z"));
+
+    const result = runVrtReportSummaryCli([
+      "--input",
+      "output/playwright/vrt",
+      "--label",
+      "paint-vrt-current",
+      "--include-task-id",
+      "paint-vrt",
+      "--json",
+      "output/playwright/vrt-current-summary.json",
+      "--check-fresh",
+    ], {
+      cwd: root,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("VRT summary is stale");
+    expect(result.stderr).toContain("google/report.json");
+    expect(result.writes).toEqual([]);
+  });
 });

--- a/scripts/vrt-report-summary.ts
+++ b/scripts/vrt-report-summary.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env npx tsx
 
+import fs from "node:fs";
 import path from "node:path";
 import {
+  createBooleanFlagHandler,
   createReportOutputHandlers,
   parseCliFlags,
   renderUsage,
@@ -28,6 +30,9 @@ interface VrtReportSummaryCliArgs extends ReportOutputCliOptions {
   inputDir?: string;
   label?: string;
   collectTaskId?: string;
+  includeTaskIds?: string[];
+  excludeFilters?: string[];
+  checkFresh?: boolean;
 }
 
 function usage(): string {
@@ -38,11 +43,72 @@ function usage(): string {
       `  --input <dir>       Directory containing VRT artifact report.json files (default: ${DEFAULT_INPUT})`,
       "  --label <name>      Summary label override",
       "  --collect-task-id <task-id>  Task id used for collect-compatible copies (defaults to label)",
+      "  --include-task-id <task-id>  Include only reports with this stable task id (repeatable)",
+      "  --exclude-filter <filter>    Exclude reports with this stable filter/title/label (repeatable)",
+      "  --check-fresh       Do not write; fail if summary outputs are older than selected reports",
       "  --json <file>       Write JSON summary",
       "  --markdown <file>   Write markdown summary",
     ],
     helpLine: "  --help              Show this help",
   });
+}
+
+function pushOptionValue(target: string[] | undefined, value: string | undefined): string[] {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return target ?? [];
+  }
+  return [...(target ?? []), trimmed];
+}
+
+function toDisplayPath(cwd: string, filePath: string): string {
+  const relative = path.relative(cwd, filePath);
+  return relative.length > 0 && !relative.startsWith("..") ? relative : filePath;
+}
+
+function statMtimeMs(filePath: string): number | undefined {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return undefined;
+  }
+}
+
+function checkSummaryFreshness(input: {
+  cwd: string;
+  outputPaths: string[];
+  reportPaths: string[];
+}): string | null {
+  if (input.outputPaths.length === 0) {
+    return "--check-fresh requires --json or --markdown output path";
+  }
+
+  let latestReport: { path: string; mtimeMs: number } | undefined;
+  for (const reportPath of input.reportPaths) {
+    const mtimeMs = statMtimeMs(reportPath);
+    if (mtimeMs === undefined) {
+      continue;
+    }
+    if (!latestReport || mtimeMs > latestReport.mtimeMs) {
+      latestReport = { path: reportPath, mtimeMs };
+    }
+  }
+
+  for (const outputPath of input.outputPaths) {
+    const outputMtimeMs = statMtimeMs(outputPath);
+    if (outputMtimeMs === undefined) {
+      return `VRT summary is stale: ${toDisplayPath(input.cwd, outputPath)} does not exist`;
+    }
+    if (latestReport && outputMtimeMs < latestReport.mtimeMs) {
+      return [
+        "VRT summary is stale:",
+        `${toDisplayPath(input.cwd, outputPath)} is older than`,
+        toDisplayPath(input.cwd, latestReport.path),
+      ].join(" ");
+    }
+  }
+
+  return null;
 }
 
 export function parseVrtReportSummaryArgs(args: string[]): VrtReportSummaryCliArgs {
@@ -64,6 +130,19 @@ export function parseVrtReportSummaryArgs(args: string[]): VrtReportSummaryCliAr
           target.collectTaskId = value;
         },
       },
+      "--include-task-id": {
+        set: (target, value) => {
+          target.includeTaskIds = pushOptionValue(target.includeTaskIds, value);
+        },
+      },
+      "--exclude-filter": {
+        set: (target, value) => {
+          target.excludeFilters = pushOptionValue(target.excludeFilters, value);
+        },
+      },
+      "--check-fresh": createBooleanFlagHandler((target) => {
+        target.checkFresh = true;
+      }),
       ...createReportOutputHandlers(),
     },
   });
@@ -84,9 +163,37 @@ export function runVrtReportSummaryCli(
     const parsed = parseVrtReportSummaryArgs(args);
     const cwd = options?.cwd ?? process.cwd();
     const inputDir = path.resolve(cwd, parsed.inputDir ?? DEFAULT_INPUT);
-    const reports = loadVrtArtifactReports(inputDir);
+    const reports = loadVrtArtifactReports(inputDir, {
+      includeTaskIds: parsed.includeTaskIds,
+      excludeFilters: parsed.excludeFilters,
+    });
     const label = parsed.label ?? (path.basename(inputDir) || "vrt");
     const collectTaskId = parsed.collectTaskId?.trim() || label;
+    if (parsed.checkFresh) {
+      const outputPaths = [
+        parsed.jsonOutput,
+        parsed.markdownOutput,
+      ]
+        .filter((value): value is string => typeof value === "string" && value.length > 0)
+        .map((value) => path.resolve(cwd, value));
+      const staleMessage = checkSummaryFreshness({
+        cwd,
+        outputPaths,
+        reportPaths: reports.map((report) => report.reportPath),
+      });
+      if (staleMessage) {
+        return {
+          exitCode: 1,
+          stderr: `${staleMessage}\n`,
+          writes: [],
+        };
+      }
+      return {
+        exitCode: 0,
+        stdout: `VRT summary is fresh: ${outputPaths.map((filePath) => toDisplayPath(cwd, filePath)).join(", ")} covers ${reports.length} report(s).\n`,
+        writes: [],
+      };
+    }
     const summary = buildVrtArtifactSummary(reports, label);
     const markdown = renderVrtArtifactSummaryMarkdown(summary);
     const jsonContent = `${JSON.stringify(summary, null, 2)}\n`;

--- a/scripts/wpt-runner.test.ts
+++ b/scripts/wpt-runner.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   createHtmlRootComparisonLayout,
   createFocusedComparisonRoot,
+  callTextIntrinsicFn,
   createTextIntrinsicFnFromMeasureText,
   isScriptMutationDependentTest,
   LOCAL_WPT_RUNTIME_BUILD_COMMAND,
@@ -70,6 +71,22 @@ describe("withTimeout", () => {
 });
 
 describe("createTextIntrinsicFnFromMeasureText", () => {
+  it("keeps fontFamily before availableWidth when calling intrinsic providers", () => {
+    const fn = createTextIntrinsicFnFromMeasureText((text) => text.length * 10);
+    const result = callTextIntrinsicFn(fn, {
+      text: "alpha beta gamma",
+      fontSize: 16,
+      lineHeight: 20,
+      whiteSpace: "normal",
+      writingMode: "horizontal-tb",
+      fontFamily: "Arial",
+      availableWidth: 100,
+      availableHeight: 600,
+    });
+
+    expect(result.maxHeight).toBe(40);
+  });
+
   it("falls back to char-based widths when measureText returns 0", () => {
     const fn = createTextIntrinsicFnFromMeasureText(() => 0);
     const result = fn(

--- a/scripts/wpt-runner.ts
+++ b/scripts/wpt-runner.ts
@@ -26,7 +26,10 @@ import {
 } from './wpt-html-utils.ts';
 import { createTextIntrinsicFnFromMeasureText } from './text-intrinsic.ts';
 
-export { createTextIntrinsicFnFromMeasureText } from './text-intrinsic.ts';
+export {
+  callTextIntrinsicFn,
+  createTextIntrinsicFnFromMeasureText,
+} from './text-intrinsic.ts';
 
 // Load config from wpt.json
 const wptConfig = loadWptConfig();

--- a/tests/crater-playwright-adapter.test.ts
+++ b/tests/crater-playwright-adapter.test.ts
@@ -107,6 +107,15 @@ test.describe("Crater Playwright adapter package", () => {
     expect(items).toBe("one,two");
   });
 
+  test("preserves inline sibling whitespace in loaded HTML textContent", async () => {
+    await page.setContentWithScripts(`<div id="x"><a>foo</a> <span>bar</span></div>`);
+
+    await expect(page.locator("#x").textContent()).resolves.toBe("foo bar");
+
+    await page.setContentWithScripts(`<a>foo</a> <span>bar</span>`);
+    await expect(page.locator("body").textContent()).resolves.toBe("foo bar");
+  });
+
   test("exposes WebMCP modelContext tools to the browser-side adapter", async () => {
     await page.setContentWithScripts(`
       <html>

--- a/tests/helpers/crater-vrt.test.ts
+++ b/tests/helpers/crater-vrt.test.ts
@@ -391,6 +391,136 @@ describe("renderCraterHtml", () => {
       sameAsFallbackRules: 1,
     });
   });
+
+  it("captures large static html directly without loading runtime DOM", async () => {
+    delete process.env.CRATER_PAINT_BACKEND;
+
+    const calls: string[] = [];
+    const html = `<main>${"x".repeat(100_001)}</main>`;
+    const fakePage = {
+      async setViewport(width: number, height: number) {
+        calls.push(`viewport:${width}x${height}`);
+      },
+      async setContentWithScripts() {
+        calls.push("content");
+      },
+      async capturePaintData(options?: { html?: string }) {
+        calls.push(`paint:${options?.html?.length ?? 0}`);
+        return {
+          width: 320,
+          height: 240,
+          data: new Uint8Array([255, 255, 255, 255]),
+        };
+      },
+      async getCssRuleUsageDetails() {
+        calls.push("css");
+        return { rules: [], elements: {} };
+      },
+    };
+
+    const image = await renderCraterHtml(fakePage as never, html, {
+      width: 320,
+      height: 240,
+    });
+
+    expect(calls).toEqual([
+      "viewport:320x240",
+      `paint:${html.length}`,
+    ]);
+    expect(image.cssRuleUsage).toBeUndefined();
+  });
+
+  it("trims large static body html before direct capture", async () => {
+    delete process.env.CRATER_PAINT_BACKEND;
+    const previousMainBudget = process.env.CRATER_VRT_STATIC_HTML_MAIN_BUDGET;
+    delete process.env.CRATER_VRT_STATIC_HTML_MAIN_BUDGET;
+
+    const calls: string[] = [];
+    const html = `<html><head><style>body{margin:0}</style></head><body><nav>${"n".repeat(2_000)}</nav><main>${"x".repeat(120_000)}</main></body></html>`;
+    const fakePage = {
+      async setViewport(width: number, height: number) {
+        calls.push(`viewport:${width}x${height}`);
+      },
+      async setContentWithScripts() {
+        calls.push("content");
+      },
+      async capturePaintData(options?: { html?: string }) {
+        calls.push(`paint:${options?.html?.length ?? 0}`);
+        expect(options?.html).toContain("crater-vrt-truncated-static-html");
+        return {
+          width: 320,
+          height: 240,
+          data: new Uint8Array([255, 255, 255, 255]),
+        };
+      },
+      async getCssRuleUsageDetails() {
+        calls.push("css");
+        return { rules: [], elements: {} };
+      },
+    };
+
+    try {
+      await renderCraterHtml(fakePage as never, html, {
+        width: 320,
+        height: 240,
+      });
+    } finally {
+      if (previousMainBudget === undefined) {
+        delete process.env.CRATER_VRT_STATIC_HTML_MAIN_BUDGET;
+      } else {
+        process.env.CRATER_VRT_STATIC_HTML_MAIN_BUDGET = previousMainBudget;
+      }
+    }
+
+    expect(calls[0]).toBe("viewport:320x240");
+    expect(calls[1]).toMatch(/^paint:[4-6]\d{3}$/);
+  });
+
+  it("allows static html main trim budget override", async () => {
+    delete process.env.CRATER_PAINT_BACKEND;
+    const previousMainBudget = process.env.CRATER_VRT_STATIC_HTML_MAIN_BUDGET;
+    process.env.CRATER_VRT_STATIC_HTML_MAIN_BUDGET = "12000";
+
+    const calls: string[] = [];
+    const html = `<html><head><style>body{margin:0}</style></head><body><nav>${"n".repeat(2_000)}</nav><main>${"x".repeat(120_000)}</main></body></html>`;
+    const fakePage = {
+      async setViewport(width: number, height: number) {
+        calls.push(`viewport:${width}x${height}`);
+      },
+      async setContentWithScripts() {
+        calls.push("content");
+      },
+      async capturePaintData(options?: { html?: string }) {
+        calls.push(`paint:${options?.html?.length ?? 0}`);
+        expect(options?.html).toContain("crater-vrt-truncated-static-html");
+        return {
+          width: 320,
+          height: 240,
+          data: new Uint8Array([255, 255, 255, 255]),
+        };
+      },
+      async getCssRuleUsageDetails() {
+        calls.push("css");
+        return { rules: [], elements: {} };
+      },
+    };
+
+    try {
+      await renderCraterHtml(fakePage as never, html, {
+        width: 320,
+        height: 240,
+      });
+    } finally {
+      if (previousMainBudget === undefined) {
+        delete process.env.CRATER_VRT_STATIC_HTML_MAIN_BUDGET;
+      } else {
+        process.env.CRATER_VRT_STATIC_HTML_MAIN_BUDGET = previousMainBudget;
+      }
+    }
+
+    expect(calls[0]).toBe("viewport:320x240");
+    expect(calls[1]).toMatch(/^paint:1[2-4]\d{3}$/);
+  });
 });
 
 describe("reference fixtures", () => {

--- a/tests/helpers/crater-vrt.ts
+++ b/tests/helpers/crater-vrt.ts
@@ -950,8 +950,39 @@ export async function renderCraterHtml(
     return renderCraterHtmlNative(html, viewport);
   }
   await page.setViewport(viewport.width, viewport.height);
+  if (shouldCaptureStaticHtmlDirectly(html)) {
+    return await page.capturePaintData({ html: trimStaticHtmlForViewport(html) });
+  }
   await page.setContentWithScripts(html);
   return await captureCraterPageImage(page);
+}
+
+function shouldCaptureStaticHtmlDirectly(html: string): boolean {
+  return html.length > 100_000 && !/<script[\s>]/i.test(html);
+}
+
+function trimStaticHtmlForViewport(html: string): string {
+  const bodyMatch = /<body\b[^>]*>/i.exec(html);
+  if (!bodyMatch) {
+    return html;
+  }
+  const bodyStart = bodyMatch.index;
+  const bodyBudget = Number(process.env.CRATER_VRT_STATIC_HTML_BODY_BUDGET ?? 1_000);
+  const mainBudget = Number(process.env.CRATER_VRT_STATIC_HTML_MAIN_BUDGET ?? 4_000);
+  const keepUntil = Math.min(html.length, bodyStart + Math.max(1_000, bodyBudget));
+  if (keepUntil === html.length) {
+    return html;
+  }
+  const mainIndex = html.toLowerCase().indexOf("<main", keepUntil);
+  if (mainIndex >= 0) {
+    const mainEnd = Math.min(html.length, mainIndex + Math.max(1_000, mainBudget));
+    return `${html.slice(0, keepUntil)}
+<!-- crater-vrt-skipped-static-html -->
+${html.slice(mainIndex, mainEnd)}
+<!-- crater-vrt-truncated-static-html -->
+</body></html>`;
+  }
+  return html;
 }
 
 export async function captureCraterPageImage(

--- a/tests/paint-vrt-responsive.test.ts
+++ b/tests/paint-vrt-responsive.test.ts
@@ -149,7 +149,7 @@ test.describe("Responsive VRT", () => {
     </body></html>`;
 
     const results = await compareAtViewports(browser, "R3-max-width-center", html, {
-      maxDiffRatio: 0.076,
+      maxDiffRatio: 0.05,
     });
     for (const r of results) {
       expect(r.result.diffRatio, `${r.viewport}`).toBeLessThanOrEqual(r.result.maxDiffRatio);
@@ -224,7 +224,7 @@ test.describe("Responsive VRT", () => {
     </body></html>`;
 
     const results = await compareAtViewports(browser, "R6-text-wrapping", html, {
-      maxDiffRatio: 0.125,
+      maxDiffRatio: 0.097,
     });
     for (const r of results) {
       expect(r.result.diffRatio, `${r.viewport}`).toBeLessThanOrEqual(r.result.maxDiffRatio);

--- a/tests/paint-vrt.test.ts
+++ b/tests/paint-vrt.test.ts
@@ -831,9 +831,9 @@ test.describe("Paint VRT", () => {
   }[] = [
     { name: "info-cern-ch", maxDiffRatio: 0.08 },
     { name: "google", maxDiffRatio: 0.02 },
-    // HN still has the parser-side rank 12+ block fall-back tracked by #214.
-    // Keep the current VRT green, then ratchet maxLayoutShiftPx back toward 300.
-    { name: "hackernews", maxDiffRatio: 0.075, maxLayoutShiftPx: 820 },
+    // HN now renders rank 12+ content instead of viewport skeleton fallbacks.
+    // Text/glyph residuals keep diffRatio higher, but layoutShift can tighten.
+    { name: "hackernews", maxDiffRatio: 0.085, maxLayoutShiftPx: 800 },
     {
       name: "wikipedia",
       maxDiffRatio: 0.25,

--- a/tests/playwright-adapter-user-scenarios.test.ts
+++ b/tests/playwright-adapter-user-scenarios.test.ts
@@ -216,8 +216,8 @@ test.describe("Crater Playwright adapter user scenarios", () => {
     const firstRow = await page.$(".row");
     await expect(firstRow?.getAttribute("data-id")).resolves.toBe("a");
     await expect(
-      page.$eval("#rows", (element) => element.textContent?.replace(/\\s+/g, " ").trim()),
-    ).resolves.toBe("AlphaBeta");
+      page.$eval("#rows", (element) => element.textContent?.replace(/\s+/g, " ").trim()),
+    ).resolves.toBe("Alpha Beta");
 
     await page.selectOption("#mode", "advanced");
     await expect(page.locator("#selected").textContent()).resolves.toBe("mode:advanced");

--- a/webdriver/bidi_main/start-with-font.ts
+++ b/webdriver/bidi_main/start-with-font.ts
@@ -6,7 +6,10 @@
  * Usage: deno run -A webdriver/bidi_main/start-with-font.ts
  * Optional: CRATER_BIDI_HOST=127.0.0.1 CRATER_BIDI_PORT=9223
  */
-import { createTextIntrinsicFnFromMeasureText } from "../../scripts/text-intrinsic.ts";
+import {
+  callTextIntrinsicFn,
+  createTextIntrinsicFnFromMeasureText,
+} from "../../scripts/text-intrinsic.ts";
 import {
   DEFAULT_TEXT_FONT_FAMILY,
   resolveEffectiveFontFamily,
@@ -662,7 +665,16 @@ if (!defaultFont) {
     const font = getFontInstance(fontFamily, isBold);
     if (!font) return null;
     const fn = getFallbackIntrinsicFn(fontFamily, isBold);
-    return fn(text, fontSize, lineHeight, whiteSpace, writingMode, availableWidth, availableHeight);
+    return callTextIntrinsicFn(fn, {
+      text,
+      fontSize,
+      lineHeight,
+      whiteSpace,
+      writingMode,
+      fontFamily,
+      availableWidth,
+      availableHeight,
+    });
   };
 
   // Simple multi-font text metrics (backward compat)
@@ -677,7 +689,16 @@ if (!defaultFont) {
     // Use full intrinsic measurement (with word-wrap calculation)
     const fn = getFallbackIntrinsicFn(fontFamily, isBold);
     const lineHeight = fontSize > 0 ? fontSize * 1.2 : 16;
-    return fn(text, fontSize, lineHeight, "normal", "horizontal-tb", 9999, 9999);
+    return callTextIntrinsicFn(fn, {
+      text,
+      fontSize,
+      lineHeight,
+      whiteSpace: "normal",
+      writingMode: "horizontal-tb",
+      fontFamily,
+      availableWidth: 9999,
+      availableHeight: 9999,
+    });
   };
 
   // Ascent ratio (default font)

--- a/webdriver/playwright/adapter.ts
+++ b/webdriver/playwright/adapter.ts
@@ -5795,10 +5795,11 @@ export class CraterBidiPage {
     return buffer;
   }
 
-  async capturePaintData(): Promise<{ width: number; height: number; data: Uint8Array }> {
+  async capturePaintData(options: { html?: string } = {}): Promise<{ width: number; height: number; data: Uint8Array }> {
     const resp = await this.sendBidi("browsingContext.capturePaintData", {
       context: this.requireContextId(),
       origin: "viewport",
+      ...(options.html === undefined ? {} : { html: options.html }),
     });
     if (resp.type === "error") {
       throw new Error(resp.message || resp.error || "capturePaintData failed");

--- a/webdriver/rendering/actual_paint.mbt
+++ b/webdriver/rendering/actual_paint.mbt
@@ -236,6 +236,10 @@ pub fn can_use_actual_paint_for_screenshot_data(
 pub fn normalize_capture_paint_data_options(
   params : Map[String, Json],
 ) -> Result[String, RenderingValidationError] {
+  match params.get("html") {
+    None | Some(String(_)) => ()
+    Some(_) => return Err(InvalidArgument("html must be a string"))
+  }
   match params.get("origin") {
     None | Some(String("viewport")) => Ok("viewport")
     Some(String(_)) =>

--- a/webdriver/rendering/actual_paint_test.mbt
+++ b/webdriver/rendering/actual_paint_test.mbt
@@ -72,6 +72,21 @@ test "capture paint data options validate viewport only origin" {
       inspect(error.message(), content="origin must be 'viewport'")
     }
   }
+  match
+    normalize_capture_paint_data_options({
+      "origin": Json::string("viewport"),
+      "html": Json::string("<p>static</p>"),
+    }) {
+    Ok(origin) => inspect(origin, content="viewport")
+    Err(error) => fail("unexpected html option error: " + error.message())
+  }
+  match normalize_capture_paint_data_options({ "html": Json::number(1.0) }) {
+    Ok(_) => fail("expected invalid html")
+    Err(error) => {
+      inspect(error.name(), content="invalid argument")
+      inspect(error.message(), content="html must be a string")
+    }
+  }
 }
 
 ///|

--- a/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
+++ b/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
@@ -36,7 +36,7 @@ extern "js" fn call_font_aware_text_provider(
   #|  const fn = isBold ? (globalThis.__craterMeasureTextIntrinsicBold || globalThis.__craterMeasureTextIntrinsic) : globalThis.__craterMeasureTextIntrinsic;
   #|  if (typeof fn !== "function") return "";
   #|  try {
-  #|    const result = fn(text, fontSize, lineHeight, whiteSpace, writingMode, availableWidth, availableHeight);
+  #|    const result = fn(text, fontSize, lineHeight, whiteSpace, writingMode, fontFamily, availableWidth, availableHeight);
   #|    let minWidth, maxWidth, minHeight, maxHeight;
   #|    if (result && typeof result === "object") {
   #|      minWidth = Number(result.minWidth ?? result.min_width);
@@ -57,14 +57,15 @@ extern "js" fn call_paint_text_provider(
   line_height : Double,
   white_space : String,
   writing_mode : String,
+  font_family : String,
   available_width : Double,
   available_height : Double,
 ) -> String =
-  #|(text, fontSize, lineHeight, whiteSpace, writingMode, availableWidth, availableHeight) => {
+  #|(text, fontSize, lineHeight, whiteSpace, writingMode, fontFamily, availableWidth, availableHeight) => {
   #|  const fn = globalThis.__craterMeasureTextIntrinsic;
   #|  if (typeof fn !== "function") return "";
   #|  try {
-  #|    const result = fn(text, fontSize, lineHeight, whiteSpace, writingMode, availableWidth, availableHeight);
+  #|    const result = fn(text, fontSize, lineHeight, whiteSpace, writingMode, fontFamily, availableWidth, availableHeight);
   #|    let minWidth, maxWidth, minHeight, maxHeight;
   #|    if (Array.isArray(result) && result.length >= 4) {
   #|      minWidth = Number(result[0]); maxWidth = Number(result[1]);
@@ -367,14 +368,15 @@ extern "js" fn call_bold_text_provider(
   line_height : Double,
   white_space : String,
   writing_mode : String,
+  font_family : String,
   available_width : Double,
   available_height : Double,
 ) -> String =
-  #|(text, fontSize, lineHeight, whiteSpace, writingMode, availableWidth, availableHeight) => {
+  #|(text, fontSize, lineHeight, whiteSpace, writingMode, fontFamily, availableWidth, availableHeight) => {
   #|  const fn = globalThis.__craterMeasureTextIntrinsicBold;
   #|  if (typeof fn !== "function") return "";
   #|  try {
-  #|    const result = fn(text, fontSize, lineHeight, whiteSpace, writingMode, availableWidth, availableHeight);
+  #|    const result = fn(text, fontSize, lineHeight, whiteSpace, writingMode, fontFamily, availableWidth, availableHeight);
   #|    let minWidth, maxWidth, minHeight, maxHeight;
   #|    if (result && typeof result === "object") {
   #|      minWidth = Number(result.minWidth ?? result.min_width);
@@ -414,20 +416,20 @@ fn ensure_paint_text_provider() -> Unit {
               multi
             } else if is_bold && has_bold_text_provider() {
               call_bold_text_provider(
-                text, font_size, line_height, ws, wm, available_width, available_height,
+                text, font_size, line_height, ws, wm, ff, available_width, available_height,
               )
             } else {
               call_paint_text_provider(
-                text, font_size, line_height, ws, wm, available_width, available_height,
+                text, font_size, line_height, ws, wm, ff, available_width, available_height,
               )
             }
           } else if is_bold && has_bold_text_provider() {
             call_bold_text_provider(
-              text, font_size, line_height, ws, wm, available_width, available_height,
+              text, font_size, line_height, ws, wm, ff, available_width, available_height,
             )
           } else {
             call_paint_text_provider(
-              text, font_size, line_height, ws, wm, available_width, available_height,
+              text, font_size, line_height, ws, wm, ff, available_width, available_height,
             )
           }
           @rendering.resolve_text_intrinsic_size_from_provider_payload(
@@ -848,7 +850,10 @@ fn BidiProtocol::resolve_capture_paint_data(
   set_runtime_context(ctx_id)
   self.apply_effective_viewport_to_runtime_context(ctx_id, ctx_id)
 
-  let html = capture_current_paint_html()
+  let html = match params.get("html") {
+    Some(String(html)) => html
+    _ => capture_current_paint_html()
+  }
   let frame = match
     self.build_actual_paint_frame(
       request_id,

--- a/webdriver/webdriver/bidi_runtime_eval.mbt
+++ b/webdriver/webdriver/bidi_runtime_eval.mbt
@@ -2217,7 +2217,6 @@ extern "js" fn js_evaluate_expression(
   #|           continue;
   #|         }
   #|         if (token[0] !== "<") {
-  #|           if (token.trim() === "") continue;
   #|           const decoded = decodeHtmlEntities(token);
   #|           const textNode = createMockTextNode(decoded);
   #|           textNode.ownerDocument = ownerDocument;
@@ -5021,9 +5020,7 @@ extern "js" fn js_evaluate_expression(
   #|               while (i < len && htmlStr[i] !== '<') {
   #|                 text += htmlStr[i++];
   #|               }
-  #|               if (text.trim()) {
-  #|                 el.appendChild(globalThis.document.createTextNode(decodeEntitiesLocal(text)));
-  #|               }
+  #|               el.appendChild(globalThis.document.createTextNode(decodeEntitiesLocal(text)));
   #|             }
   #|           }
   #|
@@ -5032,17 +5029,17 @@ extern "js" fn js_evaluate_expression(
   #|
   #|         // Parse all top-level elements
   #|         while (i < len) {
-  #|           skipWhitespace();
-  #|           if (i >= len) break;
-  #|
   #|           if (htmlStr[i] === '<') {
   #|             const el = parseElement();
   #|             if (el && el.nodeType) {
   #|               nodes.push(el);
   #|             }
   #|           } else {
-  #|             // Skip text at top level
-  #|             while (i < len && htmlStr[i] !== '<') i++;
+  #|             let text = '';
+  #|             while (i < len && htmlStr[i] !== '<') {
+  #|               text += htmlStr[i++];
+  #|             }
+  #|             nodes.push(globalThis.document.createTextNode(decodeEntitiesLocal(text)));
   #|           }
   #|         }
   #|


### PR DESCRIPTION
## Summary
- improve real-world VRT rendering parity and static no-script snapshot handling
- add moon bench coverage for static snapshot parse/render phases
- add scaling probes for MDN excerpts and synthetic layout shapes to surface O(n^2)-like behavior

## Validation
- moon test --manifest-path benchmarks/moon.mod.json -p mizchi/crater-benchmarks --target js
- moon bench --manifest-path benchmarks/moon.mod.json -p mizchi/crater-benchmarks -f static_snapshot_bench.mbt --target js --release
- moon bench --manifest-path benchmarks/moon.mod.json -p mizchi/crater-benchmarks -f static_snapshot_bench.mbt --target js --release -i 12-32
- moon check --manifest-path benchmarks/moon.mod.json --target js
- git diff --check