### PR TITLE
Fix test/playwright-bidi-tests + filter abspos CB + forced state selector targets

### DIFF
--- a/browser/scripts/mizchi-v8-consumer-prebuild.mjs
+++ b/browser/scripts/mizchi-v8-consumer-prebuild.mjs
@@ -103,7 +103,11 @@ export function platform_link_flags(platform, module_root) {
     case "darwin":
       return `${archive_path} -lc++ -pthread -framework CoreFoundation`
     case "linux":
-      return `${archive_path} -lstdc++ -ldl -pthread -lm`
+      // MoonBit 0.18.0 bundles its own simdutf.o (in $HOME/.moon/lib) that
+      // collides with simdutf in librusty_v8_bridge.a at link time. Use the
+      // BSD-style multiple-defs flag so the linker keeps the first definition
+      // it sees instead of erroring with "multiple definition".
+      return `${archive_path} -Wl,-z,muldefs -lstdc++ -ldl -pthread -lm`
     default:
       throw new Error(
         `mizchi/v8 consumer setup does not support host platform ${platform}`,

--- a/dom/css/responsive/computed_styles_wbtest.mbt
+++ b/dom/css/responsive/computed_styles_wbtest.mbt
@@ -102,6 +102,86 @@ test "discover_computed_styles_with_state focus state" {
 }
 
 ///|
+test "discover_computed_styles_with_state accepts focus selector target" {
+  let html =
+    #|<html><head><style>input.search { border-color: gray; } input.search:focus { border-color: blue; }</style></head><body><input class="search" type="text" /></body></html>
+  let forced = @selector.ForcedPseudoStates::{
+    ..@selector.ForcedPseudoStates::none(),
+    focus: true,
+  }
+  let result = discover_computed_styles_with_state(
+    html,
+    "input.search:focus",
+    forced,
+    ["border-color"],
+  )
+  assert_eq(result.diff.length(), 1)
+  assert_eq(result.diff[0].property, "border-color")
+  assert_eq(result.diff[0].normal, "gray")
+  assert_eq(result.diff[0].forced, "blue")
+}
+
+///|
+test "discover_computed_styles_with_state accepts active selector target" {
+  let html =
+    #|<html><head><style>.toolbar button { color: black; } .toolbar button:active { color: gray; }</style></head><body><div class="toolbar"><button>Press</button></div></body></html>
+  let forced = @selector.ForcedPseudoStates::{
+    ..@selector.ForcedPseudoStates::none(),
+    active: true,
+  }
+  let result = discover_computed_styles_with_state(
+    html,
+    ".toolbar button:active",
+    forced,
+    ["color"],
+  )
+  assert_eq(result.diff.length(), 1)
+  assert_eq(result.diff[0].property, "color")
+  assert_eq(result.diff[0].normal, "black")
+  assert_eq(result.diff[0].forced, "gray")
+}
+
+///|
+test "discover_computed_styles_with_state accepts focus-visible selector target" {
+  let html =
+    #|<html><head><style>.tab { color: black; } .tab:focus-visible { color: blue; }</style></head><body><button class="tab">Tab</button></body></html>
+  let forced = @selector.ForcedPseudoStates::{
+    ..@selector.ForcedPseudoStates::none(),
+    focus_visible: true,
+  }
+  let result = discover_computed_styles_with_state(
+    html,
+    ".tab:focus-visible",
+    forced,
+    ["color"],
+  )
+  assert_eq(result.diff.length(), 1)
+  assert_eq(result.diff[0].property, "color")
+  assert_eq(result.diff[0].normal, "black")
+  assert_eq(result.diff[0].forced, "blue")
+}
+
+///|
+test "discover_computed_styles_with_state accepts focus-within selector target" {
+  let html =
+    #|<html><head><style>.form-group { color: black; } .form-group:focus-within { color: red; }</style></head><body><div class="form-group"><input type="text" /></div></body></html>
+  let forced = @selector.ForcedPseudoStates::{
+    ..@selector.ForcedPseudoStates::none(),
+    focus_within: true,
+  }
+  let result = discover_computed_styles_with_state(
+    html,
+    ".form-group:focus-within",
+    forced,
+    ["color"],
+  )
+  assert_eq(result.diff.length(), 1)
+  assert_eq(result.diff[0].property, "color")
+  assert_eq(result.diff[0].normal, "black")
+  assert_eq(result.diff[0].forced, "red")
+}
+
+///|
 test "discover_computed_styles_with_state multiple properties" {
   let html =
     #|<html><head><style>.card { background: white; color: black; } .card:hover { background: blue; color: white; }</style></head><body><div class="card">hello</div></body></html>

--- a/renderer/renderer/absolute_position_test.mbt
+++ b/renderer/renderer/absolute_position_test.mbt
@@ -619,6 +619,10 @@ test "inline_filter_preserves_abspos_descendant_wpt_like" {
   let abs = cb.children[1]
   inspect(abs.id, content="span#abs")
   inspect(abs.style.position, content="Absolute")
+  // filter on the inline parent must establish an abspos containing block,
+  // so the abspos descendant resolves top: 0 against the filtered span rather
+  // than the outer block (issue #64, filter-cb-abspos-inline-001).
+  inspect(cb.style.has_filter, content="true")
 }
 
 ///|

--- a/renderer/renderer/absolute_position_test.mbt
+++ b/renderer/renderer/absolute_position_test.mbt
@@ -683,6 +683,26 @@ test "backdrop_filter_establishes_fixed_containing_block" {
 }
 
 ///|
+test "inline_style_attribute_filter_establishes_abspos_cb" {
+  // The inline style attribute path (not a stylesheet rule) must also
+  // surface filter: <fn> through to layout's has_filter flag, so abspos
+  // descendants of an element whose filter lives on style="..." still
+  // resolve their CB against that element.
+  let html_str =
+    #|<!DOCTYPE html>
+    #|<div><span id="cb" style="filter: blur(2px)">text<span id="abs" style="position: absolute; top: 0; left: 0; width: 5px; height: 5px"></span></span></div>
+  let ctx = @renderer.RenderContext::default()
+  let root = @renderer.render_to_node(html_str, ctx)
+  let container = root.children[0]
+  let cb = container.children[0]
+  inspect(cb.id, content="span#cb")
+  inspect(cb.style.has_filter, content="true")
+  let abs = cb.children[1]
+  inspect(abs.id, content="span#abs")
+  inspect(abs.style.position, content="Absolute")
+}
+
+///|
 test "wpt_intrinsic_percent_replaced_019_like_abspos_flex_basis_content_uses_definite_cross_chain" {
   let html_str =
     #|<!DOCTYPE html>

--- a/renderer/renderer/style_resolve.mbt
+++ b/renderer/renderer/style_resolve.mbt
@@ -1044,7 +1044,11 @@ fn compute_element_style_indexed(
     None => ()
   }
   if establishes_effect_cb {
-    style = { ..style, contain: { ..style.contain, paint: true } }
+    style = {
+      ..style,
+      has_filter: true,
+      contain: { ..style.contain, paint: true },
+    }
   }
 
   // Apply viewport dimensions if root

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -559,6 +559,16 @@ scenarios {
     reviewStatus = "approved"
     contributes { "goal.diagnostic-api"; "goal.protocol-compat" }
   }
+  new {
+    id = "diagnostic.interactive-forced-state-selector-target"
+    name = "forced focus active focus-visible focus-within selectors are targetable"
+    description =
+      "getComputedStylesWithState accepts target selectors whose subject ends in :focus, :active, :focus-visible, or :focus-within (e.g. input.search:focus, .toolbar button:active, .tab:focus-visible, .form-group:focus-within). The forced pseudo is stripped only for element lookup, and the requested forced state is applied during cascade evaluation so VRT prescanners can detect interactive-state mutations beyond hover without falling back to Chromium. See GitHub issue #225."
+    tags { "diagnostic"; "vrt"; "focus"; "active"; "issue:225" }
+    severity = "major"
+    reviewStatus = "approved"
+    contributes { "goal.diagnostic-api"; "goal.protocol-compat" }
+  }
 
   // -- CI efficiency --------------------------------------------------------
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -325,6 +325,16 @@ tests {
       "bash -lc 'set -e; grep -Fq -- \"pub fn registrable_domain(host : String) -> String\" http/psl/psl.mbt; grep -Fq -- \"@psl.registrable_domain(req_host)\" http/samesite/samesite.mbt; grep -Fq -- \"@psl.registrable_domain(a)\" http/cookie_jar/cookie_jar.mbt; grep -Fq -- \"PSL distinguishes siblings under co.uk\" http/samesite/samesite_wbtest.mbt; grep -Fq -- \"PSL distinguishes siblings under co.jp\" http/samesite/samesite_wbtest.mbt; grep -Fq -- \"PSL distinguishes siblings under github.io\" http/samesite/samesite_wbtest.mbt'"
   }
   new {
+    name = "diagnostic_interactive_forced_state_selector_target"
+    description =
+      "getComputedStylesWithState should resolve selectors whose subject ends in :focus, :active, :focus-visible, or :focus-within without falling back to Chromium."
+    tags { "diagnostic"; "vrt"; "focus"; "active"; "issue:225" }
+    specRef { "diagnostic.interactive-forced-state-selector-target" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"discover_computed_styles_with_state accepts focus selector target\" dom/css/responsive/computed_styles_wbtest.mbt; grep -Fq -- \"discover_computed_styles_with_state accepts active selector target\" dom/css/responsive/computed_styles_wbtest.mbt; grep -Fq -- \"discover_computed_styles_with_state accepts focus-visible selector target\" dom/css/responsive/computed_styles_wbtest.mbt; grep -Fq -- \"discover_computed_styles_with_state accepts focus-within selector target\" dom/css/responsive/computed_styles_wbtest.mbt; grep -Fq -- \"bidi getComputedStylesWithState accepts focus-visible selector target\" webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt'"
+  }
+  new {
     name = "protocol_bidi_content_window_nested_read"
     description =
       "The synthetic iframe contentWindow mirror should read nested property and index chains without accepting method calls or compound RHS expressions."

--- a/webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt
+++ b/webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt
@@ -328,6 +328,48 @@ test "bidi getComputedStylesWithState accepts hover selector target" {
 }
 
 ///|
+test "bidi getComputedStylesWithState accepts focus-visible selector target" {
+  let proto = BidiProtocol::new()
+  ignore(
+    proto.process_message("{\"id\":1,\"method\":\"session.new\",\"params\":{}}"),
+  )
+  ignore(proto.take_messages())
+  let html = "<!DOCTYPE html><html><head><style>.tab { color: black; } .tab:focus-visible { color: blue; }</style></head><body><button class='tab'>Tab</button></body></html>"
+  let navigate_message = "{\"id\":2,\"method\":\"browsingContext.navigate\",\"params\":{\"context\":\"session-1\",\"url\":\"" +
+    js_test_build_html_data_url(html) +
+    "\",\"wait\":\"complete\"}}"
+  ignore(proto.process_message(navigate_message))
+  ignore(proto.take_messages())
+  ignore(
+    proto.process_message(
+      "{\"id\":3,\"method\":\"browsingContext.getComputedStylesWithState\",\"params\":{\"context\":\"session-1\",\"selector\":\".tab:focus-visible\",\"forcedStates\":[\"focus-visible\"],\"properties\":[\"color\"]}}",
+    ),
+  )
+  let result = extract_success_result(proto.take_messages())
+  let diff = match result.get("diff") {
+    Some(Array(items)) => items
+    _ => []
+  }
+  assert_eq(diff.length(), 1)
+  let entry = match diff[0] {
+    Object(map) => map
+    _ => {}
+  }
+  match entry.get("property") {
+    Some(String(value)) => assert_eq(value, "color")
+    _ => assert_true(false)
+  }
+  match entry.get("normal") {
+    Some(String(value)) => assert_eq(value, "black")
+    _ => assert_true(false)
+  }
+  match entry.get("forced") {
+    Some(String(value)) => assert_eq(value, "blue")
+    _ => assert_true(false)
+  }
+}
+
+///|
 test "bidi getCssRuleUsage reports matched and overridden rules" {
   let proto = BidiProtocol::new()
   ignore(

--- a/webdriver/webdriver/bidi_protocol_frame_tree_refresh.mbt
+++ b/webdriver/webdriver/bidi_protocol_frame_tree_refresh.mbt
@@ -38,6 +38,17 @@ fn BidiProtocol::refresh_child_contexts_from_iframes(
 /// apply_effective_viewport_to_runtime_context: evaluate applies it at the
 /// start of the command, and applying it again here would drain deferred
 /// runtime bridges (notably userPromptOpened) too early.
+///
+/// This path also intentionally skips the navigate / load_data_url_content
+/// steps that the explicit-creation paths use. The BiDi runtime serves all
+/// contexts from a single shared globalThis.document, so calling
+/// load_data_url_content for an iframe whose src is "about:blank" routes
+/// through sync_runtime_html("") -> __loadHTML("") -> resetContainer(body),
+/// which would clobber the parent's just-populated DOM (the very DOM that
+/// produced this iframe in the first place). The iframe element survives in
+/// the parent's DOM tree, and BiDi only needs the child-context bookkeeping
+/// so frame-tree queries observe it; explicit navigation paths still
+/// re-enter the heavy variant when the iframe is actually targeted.
 fn BidiProtocol::refresh_child_contexts_from_runtime_iframes_after_eval(
   self : BidiProtocol,
   parent_ctx_id : String,
@@ -47,9 +58,38 @@ fn BidiProtocol::refresh_child_contexts_from_runtime_iframes_after_eval(
   if frame_sources.length() == 0 {
     return
   }
-  self.refresh_child_contexts_from_iframe_sources_with_depth(
-    parent_ctx_id, frame_sources, 0,
-  )
+  self.register_child_contexts_for_iframe_sources(parent_ctx_id, frame_sources)
+}
+
+///|
+/// Lightweight child-context registration: create+emit only.
+/// See refresh_child_contexts_from_runtime_iframes_after_eval for the
+/// rationale on why this path skips navigate/load_data_url_content.
+fn BidiProtocol::register_child_contexts_for_iframe_sources(
+  self : BidiProtocol,
+  parent_ctx_id : String,
+  frame_sources : Array[String],
+) -> Unit {
+  let existing_children = self.context_children.get(parent_ctx_id).unwrap_or([])
+  let user_ctx = self.context_user_context
+    .get(parent_ctx_id)
+    .unwrap_or("default")
+  let mut frame_index = 0
+  for _src in frame_sources {
+    if frame_index < existing_children.length() {
+      frame_index += 1
+      continue
+    }
+    let child_ctx_id = self.create_child_context(parent_ctx_id, user_ctx)
+    self.emit_context_created(
+      child_ctx_id,
+      "tab",
+      "about:blank",
+      None,
+      Some(parent_ctx_id),
+    )
+    frame_index += 1
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary

Four independent improvements bundled, rebased onto current `main`:

1. **Issue #225 regression coverage** — extend the forced-state selector target tests beyond `:hover` (covered by the earlier `6406f71`) to the rest of the user-action pseudos. Whitebox tests under `dom/css/responsive` cover `input.search:focus`, `.toolbar button:active`, `.tab:focus-visible`, and `.form-group:focus-within` against `discover_computed_styles_with_state`. A BiDi-level test covers `.tab:focus-visible` end-to-end. Pinned via the new `diagnostic.interactive-forced-state-selector-target` scenario.

2. **MoonBit 0.18.0 native build fix (#227)** — `2e573ad Bump MoonBit modules to 0.18.0` made the `test` job fail in the native V8 smoke step with `multiple definition of simdutf::westmere::implementation::*` because MoonBit 0.18.0 now ships its own `simdutf.o` in `$HOME/.moon/lib` and it collides with the `simdutf.o` already linked into `librusty_v8_bridge.a`. Pass `-Wl,-z,muldefs` in the linux `MIZCHI_V8_CC_LINK_FLAGS` so the linker keeps the first definition. macOS uses ld64 (permissive by default) so no equivalent is needed there.

3. **Issue #64 filter establishes abspos containing block** — the layout engine already reads `style.has_filter` from `block.mbt:211`, `inline.mbt:50`, and `flex.mbt:78` to establish a CB for absolute descendants, but no part of the renderer was actually setting it — only `contain.paint`. For inline elements `containment_applies()` returns false, so `contain.paint` alone never triggers the CB establishment, and `filter-cb-abspos-inline-001/002/003.html` rendered abspos descendants against the outer block (`abspos y = -19.2` instead of `1.0`). Set `has_filter: true` alongside `contain.paint` when filter or backdrop-filter is detected, plus an `inspect` on the existing `inline_filter_preserves_abspos_descendant_wpt_like` test so the flag stays asserted.

4. **playwright-bidi-tests fix** — `acfc166`'s after-eval iframe refresh reused the heavy `refresh_child_contexts_from_iframe_sources_with_depth`, which calls `load_data_url_content(child, "about:blank")` for any iframe found post-eval. Since BiDi serves every context from one shared `globalThis.document`, that path routes through `sync_runtime_html("") → __loadHTML("") → resetContainer(body)` and clobbers the parent's just-populated DOM. With `after_eval` running on every `script.evaluate`, `page.setContent(html-with-iframe)` became self-defeating: `__loadHTML` populated body, then the after_eval refresh wiped it before the next evaluate could read it. Carve a lightweight `register_child_contexts_for_iframe_sources` that does create+emit only; explicit-navigation paths still re-enter the heavy variant when the iframe is actually targeted.

Speed deliverable from issue #225 (3x prescanner target, currently 1.06x) and the remaining 5 filter-effects failures (backdrop-filter geometry × 4 + SVG subregion × 1) are explicitly out of scope.

## CI

After this branch lands, `test` and `playwright-bidi-tests` should both go green on main:
- `test` was failing at the native V8 smoke step (simdutf collision) — fixed by (2).
- `playwright-bidi-tests` was failing at `crater-playwright-adapter.test.ts:333` "supports frameLocator traversal for fixture iframe contentDocument roots" with `TypeError: Cannot set properties of null (setting 'contentDocument')` because `document.querySelector("#fixture")` returned null on the wiped body — fixed by (4).

`wasm-component` remains soft-failed per PR #229 (`continue-on-error: true`, MoonBit 0.18.0 nightly cabi_realloc regression, separate upstream issue).

## Test plan

- [x] `moon test` on `dom/css/responsive` runs the four new selector-target tests
- [x] `moon test` on `webdriver/webdriver` runs the new BiDi focus-visible test (433/433 pass on this branch including `bidi_iframe_advanced_patterns_wbtest` from acfc166)
- [x] `moon test` on `renderer/renderer` covers the extended `inline_filter_preserves_abspos_descendant_wpt_like`
- [x] `pnpm exec playwright test tests/crater-playwright-adapter.test.ts` — 68/68 pass (was 67/68 before the iframe fix)
- [x] `pnpm exec playwright test tests/playwright-adapter.test.ts tests/playwright-adapter-user-scenarios.test.ts` — 52/52 pass
- [x] `pnpm exec playwright test tests/bidi-e2e.test.ts` — 13/13 pass
- [x] `pnpm exec playwright test tests/playwright-adapter-chromium-parity.test.ts` — 21/21 pass
- [ ] `just wpt-filter-effects` recovers the 3 `filter-cb-abspos-inline-*` cases
- [ ] `moon -C browser/native test -p mizchi/crater-browser-native/js_v8 -f js_runtime_v8_wbtest.mbt --target native -j 1` links cleanly under MoonBit 0.18.0
- [ ] CI confirms `test` and `playwright-bidi-tests` are now green

https://claude.ai/code/session_01TGc56nhVU7ravBZpKJFn3E