### PR TITLE
Pin BiDi test-isolation contract for rememberSyntheticLocationHref (#150)

### DIFF
--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -905,10 +905,10 @@ scenarios {
     id = "bug.bidi.context-state-leaks-across-tests"
     name = "BiDi runtime context state leaks across test sessions"
     description =
-      "Running the existing storage.setCookie + rememberSyntheticLocationHref e2e test changes runtime state such that a subsequent navigate parses HTML correctly, while a standalone form-based test does not. Specifically rememberSyntheticLocationHref appears to leave behind something that makes the next navigate populate document.forms. This is a test-isolation smell that masks bug.bidi.navigate-http-url-not-parsed when the cookie-injection test runs first. Source: PR #138 e2e investigation."
-    tags { "bidi"; "test-isolation"; "bug" }
+      "Running the existing storage.setCookie + rememberSyntheticLocationHref e2e test changes runtime state such that a subsequent navigate parses HTML correctly, while a standalone form-based test does not. Specifically rememberSyntheticLocationHref appears to leave behind something that makes the next navigate populate document.forms. This is a test-isolation smell that masks bug.bidi.navigate-http-url-not-parsed when the cookie-injection test runs first. PR #139 fixed the underlying navigate-parse bug; this scenario pins the isolation contract at the BidiProtocol level — session.end, session.resetForTest, and a fresh BidiProtocol instance must each clear the synthetic window.location.href override from a prior script.rememberSyntheticLocationHref. Covered by webdriver/webdriver/bidi_protocol_test_isolation_wbtest.mbt. Source: PR #138 e2e investigation, GitHub issue #150."
+    tags { "bidi"; "test-isolation"; "bug"; "issue:150" }
     severity = "minor"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.protocol-compat" }
   }
 

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -325,6 +325,16 @@ tests {
       "bash -lc 'set -e; grep -Fq -- \"extract handles nested property chain after contentWindow\" webdriver/webdriver/bidi_iframe_content_window_mirror_wbtest.mbt; grep -Fq -- \"extract handles array index chain after contentWindow\" webdriver/webdriver/bidi_iframe_content_window_mirror_wbtest.mbt; grep -Fq -- \"extract rejects contentWindow method calls\" webdriver/webdriver/bidi_iframe_content_window_mirror_wbtest.mbt; grep -Fq -- \"contentWindow nested property mirror writes parent value\" webdriver/webdriver/bidi_iframe_content_window_mirror_wbtest.mbt; grep -Fq -- \"read_iframe_mirror_bracket_end\" webdriver/webdriver/bidi_iframe_content_window_mirror.mbt; grep -Fq -- \"is_iframe_mirror_rhs_terminator\" webdriver/webdriver/bidi_iframe_content_window_mirror.mbt'"
   }
   new {
+    name = "protocol_bidi_context_state_isolation"
+    description =
+      "session.end, session.resetForTest, and a fresh BidiProtocol instance must each clear the synthetic window.location.href override from a prior script.rememberSyntheticLocationHref, so a follow-up script.evaluate or browsingContext.navigate observes the default baseline rather than leaked state from a previous test."
+    tags { "protocol"; "bidi"; "test-isolation"; "issue:150" }
+    specRef { "bug.bidi.context-state-leaks-across-tests" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"bidi rememberSyntheticLocationHref does not leak across session.end\" webdriver/webdriver/bidi_protocol_test_isolation_wbtest.mbt; grep -Fq -- \"bidi rememberSyntheticLocationHref is cleared by session.resetForTest\" webdriver/webdriver/bidi_protocol_test_isolation_wbtest.mbt; grep -Fq -- \"bidi independent BidiProtocol instances do not share synthetic location state\" webdriver/webdriver/bidi_protocol_test_isolation_wbtest.mbt'"
+  }
+  new {
     name = "protocol_bidi_async_iframe_cross_evaluate"
     description =
       "script.evaluate should register iframe child contexts when creation and insertion happen in separate evaluate calls."

--- a/webdriver/webdriver/bidi_protocol_test_isolation_wbtest.mbt
+++ b/webdriver/webdriver/bidi_protocol_test_isolation_wbtest.mbt
@@ -1,0 +1,94 @@
+///|
+/// session.end on a context that previously called
+/// script.rememberSyntheticLocationHref must clear the synthetic
+/// window.location.href override so a subsequent session.new sees the
+/// default about:blank baseline. PR #138's e2e investigation observed
+/// that the rememberSyntheticLocationHref state was implicitly carried
+/// over and masked bug.bidi.navigate-http-url-not-parsed (now fixed in
+/// PR #139). This test pins the negative case: after session.end, the
+/// override is gone.
+test "bidi rememberSyntheticLocationHref does not leak across session.end" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  let _ = proto.take_messages()
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"script.rememberSyntheticLocationHref\",\"params\":{\"context\":\"session-1\",\"href\":\"http://alice.example.com:8000/seed.html\"}}",
+  )
+  let _ = proto.take_messages()
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"script.evaluate\",\"params\":{\"expression\":\"window.location.href\",\"target\":{\"context\":\"session-1\"},\"awaitPromise\":false}}",
+  )
+  let pre_end_json = proto.take_messages()[0].to_json()
+  assert_true(pre_end_json.contains("alice.example.com"))
+  let _ = proto.process_message(
+    "{\"id\":4,\"method\":\"session.end\",\"params\":{}}",
+  )
+  let _ = proto.take_messages()
+  let _ = proto.process_message(
+    "{\"id\":5,\"method\":\"session.new\",\"params\":{}}",
+  )
+  let _ = proto.take_messages()
+  let _ = proto.process_message(
+    "{\"id\":6,\"method\":\"script.evaluate\",\"params\":{\"expression\":\"window.location.href\",\"target\":{\"context\":\"session-1\"},\"awaitPromise\":false}}",
+  )
+  let post_end_json = proto.take_messages()[0].to_json()
+  assert_false(post_end_json.contains("alice.example.com"))
+}
+
+///|
+/// session.resetForTest is the explicit isolation hook used by Crater's
+/// Playwright fixtures: after it, the synthetic location override must
+/// be gone even within the same logical session, so a follow-up
+/// browsingContext.navigate sees the default base URL rather than the
+/// leaked override.
+test "bidi rememberSyntheticLocationHref is cleared by session.resetForTest" {
+  let proto = BidiProtocol::new()
+  let _ = proto.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  let _ = proto.take_messages()
+  let _ = proto.process_message(
+    "{\"id\":2,\"method\":\"script.rememberSyntheticLocationHref\",\"params\":{\"context\":\"session-1\",\"href\":\"http://bob.example.com:8000/seed.html\"}}",
+  )
+  let _ = proto.take_messages()
+  let _ = proto.process_message(
+    "{\"id\":3,\"method\":\"session.resetForTest\",\"params\":{}}",
+  )
+  let _ = proto.take_messages()
+  let _ = proto.process_message(
+    "{\"id\":4,\"method\":\"script.evaluate\",\"params\":{\"expression\":\"window.location.href\",\"target\":{\"context\":\"session-1\"},\"awaitPromise\":false}}",
+  )
+  let post_reset_json = proto.take_messages()[0].to_json()
+  assert_false(post_reset_json.contains("bob.example.com"))
+}
+
+///|
+/// Two independent BidiProtocol::new() instances must not share any
+/// per-context state. PR #138 observed that an e2e test process keeps
+/// one BidiProtocol alive across tests, so the contract verified here
+/// (a fresh BidiProtocol observes none of a sibling protocol's
+/// per-context overrides) is what the Playwright fixture relies on
+/// when it reuses session.new + session.end as the isolation boundary.
+test "bidi independent BidiProtocol instances do not share synthetic location state" {
+  let proto_a = BidiProtocol::new()
+  let _ = proto_a.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  let _ = proto_a.take_messages()
+  let _ = proto_a.process_message(
+    "{\"id\":2,\"method\":\"script.rememberSyntheticLocationHref\",\"params\":{\"context\":\"session-1\",\"href\":\"http://carol.example.com:8000/seed.html\"}}",
+  )
+  let _ = proto_a.take_messages()
+  let proto_b = BidiProtocol::new()
+  let _ = proto_b.process_message(
+    "{\"id\":1,\"method\":\"session.new\",\"params\":{}}",
+  )
+  let _ = proto_b.take_messages()
+  let _ = proto_b.process_message(
+    "{\"id\":2,\"method\":\"script.evaluate\",\"params\":{\"expression\":\"window.location.href\",\"target\":{\"context\":\"session-1\"},\"awaitPromise\":false}}",
+  )
+  let proto_b_json = proto_b.take_messages()[0].to_json()
+  assert_false(proto_b_json.contains("carol.example.com"))
+}


### PR DESCRIPTION
## Summary

Closes the formal acceptance for issue #150 by pinning the BiDi test-isolation contract observed during PR #138's e2e investigation.

After `script.rememberSyntheticLocationHref` sets a synthetic `window.location.href` override on a context, that override must be cleared by:

1. `session.end`
2. `session.resetForTest`
3. starting a fresh `BidiProtocol` instance

PR #139 fixed the underlying `navigate` parse bug that this leak was masking, so the remaining gap is just pinning the negative case so a future regression on the implicit cross-test leak surfaces as a MoonBit test failure rather than as silent Playwright fixture coupling.

## Changes

- `webdriver/webdriver/bidi_protocol_test_isolation_wbtest.mbt` — three wbtests, one per isolation boundary above. Each drives `BidiProtocol::process_message` directly (mirroring the existing pattern in `bidi_protocol_storage_wbtest.mbt`), seeds a synthetic location, applies the isolation boundary, then re-evaluates `window.location.href` and asserts the leaked host is absent.
- `specs/crater.pkl` — flip `bug.bidi.context-state-leaks-across-tests` from `reviewStatus = "draft"` to `"approved"`, extend the description with what the new wbtest covers, tag with `issue:150`.
- `specs/tasks.Test.pkl` — add `protocol_bidi_context_state_isolation` task with `specRef { "bug.bidi.context-state-leaks-across-tests" }` so `pkf run spec-check` is happy.

## Test plan

- [x] `moon -C webdriver/webdriver test -p mizchi/crater-webdriver/webdriver --target js -j 1` — all 432 tests pass (3 new + 429 existing).
- [x] Spec-check wiring smoke: `grep -Fq` for each test name in the new wbtest file resolves.

Refs: #150, PR #138, PR #139

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGc56nhVU7ravBZpKJFn3E)_