### PR TITLE
Collapse inline whitespace for white-space:normal (#47 painter side)

### DIFF
--- a/renderer/renderer/text_node.mbt
+++ b/renderer/renderer/text_node.mbt
@@ -2,6 +2,66 @@
 // Text node construction helpers.
 
 ///|
+/// Collapse internal whitespace (newline/tab/CR and runs of spaces) into a
+/// single space while preserving up to one leading/trailing space so adjacent
+/// inline-level boxes still observe the implicit gap from collapsible
+/// whitespace. Used only for CSS `white-space: normal | nowrap`; preserves the
+/// original text for `pre`, `pre-wrap`, and `pre-line` whose semantics depend
+/// on the segment-break characters.
+fn collapse_inline_whitespace(text : String) -> String {
+  if text.is_empty() {
+    return text
+  }
+  let chars : Array[Char] = []
+  for c in text.iter() {
+    chars.push(c)
+  }
+  let mut leading = false
+  let mut idx = 0
+  while idx < chars.length() && is_collapsible_whitespace_char(chars[idx]) {
+    leading = true
+    idx = idx + 1
+  }
+  let mut trailing = false
+  let mut end_idx = chars.length()
+  while end_idx > idx && is_collapsible_whitespace_char(chars[end_idx - 1]) {
+    trailing = true
+    end_idx = end_idx - 1
+  }
+  let buf = StringBuilder::new()
+  if leading {
+    buf.write_char(' ')
+  }
+  let mut in_ws = false
+  for i = idx; i < end_idx; i = i + 1 {
+    let c = chars[i]
+    if is_collapsible_whitespace_char(c) {
+      if !in_ws {
+        buf.write_char(' ')
+        in_ws = true
+      }
+    } else {
+      buf.write_char(c)
+      in_ws = false
+    }
+  }
+  if trailing {
+    buf.write_char(' ')
+  }
+  buf.to_string()
+}
+
+///|
+fn white_space_preserves_segment_breaks(white_space : @style.WhiteSpace) -> Bool {
+  match white_space {
+    @style.WhiteSpace::Pre
+    | @style.WhiteSpace::PreWrap
+    | @style.WhiteSpace::PreLine => true
+    _ => false
+  }
+}
+
+///|
 /// Create a node for text content with inherited font properties
 fn create_text_node(text : String, parent_style : @style.Style) -> @node.Node {
   let normalized_text = if parent_style.display == @types.TableCell &&
@@ -9,6 +69,20 @@ fn create_text_node(text : String, parent_style : @style.Style) -> @node.Node {
     trim_trailing_collapsible_whitespace(text)
   } else {
     text
+  }
+  // CSS Text 3 §4.1.1: white-space:normal/nowrap collapse all whitespace
+  // sequences (including segment breaks U+000A) into single spaces before
+  // the line-layout / glyph-shaping stage. Without this collapse the painter
+  // sees a leading `\n` token in text like "\n      Dashboard", treats it as
+  // a hard line break, and renders the glyphs one line below the line box.
+  // pre / pre-wrap / pre-line / break-spaces preserve segment breaks per
+  // CSS so they bypass this collapse.
+  let normalized_text = if white_space_preserves_segment_breaks(
+      parent_style.white_space,
+    ) {
+    normalized_text
+  } else {
+    collapse_inline_whitespace(normalized_text)
   }
   let trimmed = trim_collapsible_whitespace_edges(normalized_text)
   let font_size = parent_style.font_size


### PR DESCRIPTION
## Summary

Implements CSS Text 3 §4.1.1 segment-break / whitespace collapse for inline text under `white-space: normal | nowrap`. Fixes the paint-vrt `svg-intrinsic-inline-replaced` fixture's "Dashboard" rendering one line below the SVG.

## Root cause

For `<h1><svg/>\n      Dashboard</h1>`, the renderer was preserving the raw HTML whitespace ("\n      Dashboard") on the `#text` Node verbatim. The painter (`painter/paint/glyph/layout.mbt`) splits text on whitespace into "words" — and the leading `"\n"` word triggers `cur_y += effective_line_height`, causing every subsequent glyph to render one line below the actual line box.

CSS Text 3 §4.1.1 requires that for `white-space: normal | nowrap` the segment-break (U+000A) and all surrounding whitespace be collapsed *before* line layout. Crater was only trimming whitespace at the edges for emptiness detection but storing the raw text on the Node passed to the painter.

## Fix

`create_text_node` now passes the inline text through a new `collapse_inline_whitespace` helper which:
1. Replaces internal runs of whitespace (space/tab/CR/LF) with a single space.
2. Preserves up to one leading/trailing space so adjacent inline boxes keep the implicit gap from collapsible whitespace (`<span>a</span> <span>b</span>` semantics).
3. Is bypassed for `pre`, `pre-wrap`, `pre-line` since those CSS modes depend on segment breaks being preserved.

## Diagnostic trace

Confirmed with a one-shot `dbg_glyph_log` injection in `layout_glyph_bitmaps` against the running BiDi server:

```
[DBG-glyph] textlen=16 text_q="\n      Dashboard" words=2 x=68 y=38 font_size=24 line_height=28.8 baseline_offset=21.73 font_family=arial max_width=108
```

`words=2` means the splitter produced `["\n", "Dashboard"]`. After the fix, `text_q="Dashboard"` and `words=1`.

## Verification

- `moon -C renderer/renderer test --target js -j 1` — **377 passed, 0 failed**.
- Rasterized pixel profile of the `svg-intrinsic-inline-replaced` fixture before/after:
  ```
  Before:  SVG y=36..62 (h=27), DARK y=72..86 (h=15)   ← text one line below the SVG
  After:   SVG y=35..62 (h=28), DARK y=43..59 (h=17)   ← text overlapping the SVG row band
  Chromium: SVG y=34..61 (h=28), DARK y=36..53 (h=18)
  ```
  Text and SVG now occupy the same line, matching Chromium. (Remaining residual is a separate `vertical-align: middle` baseline drift in the painter — follow-up.)
- `paint-vrt-*.test.ts` suite: **41 passed / 1 pre-existing failure** (`svg-intrinsic-viewbox-only`, already failing on main before this fix — verified by stashing the change and re-running).

## Test plan

- [x] Renderer unit tests green
- [x] paint-vrt-svg-intrinsic "inline svg as replaced text element preserves baseline" passes the 0.088 budget locally
- [x] No new failures in the full paint-vrt sweep
- [ ] CI confirms across the full check suite

Refs: #47

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGc56nhVU7ravBZpKJFn3E)_