### PR TITLE
Resolve var() before establishing filter abspos containing block (#236)

### DIFF
--- a/renderer/renderer/absolute_position_test.mbt
+++ b/renderer/renderer/absolute_position_test.mbt
@@ -703,6 +703,75 @@ test "inline_style_attribute_filter_establishes_abspos_cb" {
 }
 
 ///|
+test "filter_var_resolving_to_none_does_not_establish_abspos_cb" {
+  // issue #236: filter: var(--fx) where --fx is none must NOT establish an
+  // abspos containing block — it computes to filter: none. Reading the raw
+  // cascaded text ("var(--fx)") used to mis-set has_filter here.
+  let html_str =
+    #|<!DOCTYPE html>
+    #|<style>
+    #|#cb { --fx: none; filter: var(--fx); }
+    #|</style>
+    #|<div><span id="cb">text</span></div>
+  let ctx = @renderer.RenderContext::default()
+  let root = @renderer.render_to_node(html_str, ctx)
+  let cb = root.children[0].children[0]
+  inspect(cb.id, content="span#cb")
+  inspect(cb.style.has_filter, content="false")
+}
+
+///|
+test "filter_var_unresolved_does_not_establish_abspos_cb" {
+  // issue #236: filter: var(--undef) with no fallback is an unresolved var,
+  // which computes to the initial value none and must NOT establish the CB.
+  let html_str =
+    #|<!DOCTYPE html>
+    #|<style>
+    #|#cb { filter: var(--undef); }
+    #|</style>
+    #|<div><span id="cb">text</span></div>
+  let ctx = @renderer.RenderContext::default()
+  let root = @renderer.render_to_node(html_str, ctx)
+  let cb = root.children[0].children[0]
+  inspect(cb.id, content="span#cb")
+  inspect(cb.style.has_filter, content="false")
+}
+
+///|
+test "filter_var_resolving_to_non_filter_token_does_not_establish_abspos_cb" {
+  // issue #236: filter: var(--fx) where --fx holds a non-filter token is an
+  // invalid filter value, computing to none; it must NOT establish the CB.
+  let html_str =
+    #|<!DOCTYPE html>
+    #|<style>
+    #|#cb { --fx: invalid-token; filter: var(--fx); }
+    #|</style>
+    #|<div><span id="cb">text</span></div>
+  let ctx = @renderer.RenderContext::default()
+  let root = @renderer.render_to_node(html_str, ctx)
+  let cb = root.children[0].children[0]
+  inspect(cb.id, content="span#cb")
+  inspect(cb.style.has_filter, content="false")
+}
+
+///|
+test "filter_var_resolving_to_filter_function_establishes_abspos_cb" {
+  // The valid var() case must still establish the CB: filter: var(--fx)
+  // where --fx is a real filter function behaves like a literal filter.
+  let html_str =
+    #|<!DOCTYPE html>
+    #|<style>
+    #|#cb { --fx: blur(2px); filter: var(--fx); }
+    #|</style>
+    #|<div><span id="cb">text</span></div>
+  let ctx = @renderer.RenderContext::default()
+  let root = @renderer.render_to_node(html_str, ctx)
+  let cb = root.children[0].children[0]
+  inspect(cb.id, content="span#cb")
+  inspect(cb.style.has_filter, content="true")
+}
+
+///|
 test "wpt_intrinsic_percent_replaced_019_like_abspos_flex_basis_content_uses_definite_cross_chain" {
   let html_str =
     #|<!DOCTYPE html>

--- a/renderer/renderer/style_resolve.mbt
+++ b/renderer/renderer/style_resolve.mbt
@@ -587,6 +587,53 @@ fn normalize_display_contents_for_unusual_html(
 }
 
 ///|
+/// Whether a `filter` / `backdrop-filter` value establishes a containing
+/// block for absolutely positioned descendants. var() is resolved against the
+/// element's custom properties first. A value that resolves to `none`, to an
+/// empty string (unresolved var with no fallback), or — for var()-bearing
+/// declarations — to a token that is not a filter function list computes to
+/// the initial value `none` and therefore does not establish the CB.
+fn filter_value_establishes_effect_cb(
+  raw_value : String,
+  css_vars : Map[String, String],
+) -> Bool {
+  let had_var = raw_value.contains("var(")
+  let resolved = if had_var {
+    let empty_attributes : Map[String, String] = {}
+    resolve_pseudo_content_value(raw_value, css_vars, empty_attributes)
+  } else {
+    raw_value
+  }
+  let normalized = resolved.to_lower().trim().to_owned()
+  if normalized == "" || normalized == "none" {
+    false
+  } else if had_var {
+    // Only a resolved filter function list (or url() reference) establishes
+    // the CB; a custom property holding a non-filter token computes to none.
+    filter_value_has_function(normalized)
+  } else {
+    // Literal (non-var) values keep the prior permissive behaviour.
+    true
+  }
+}
+
+///|
+/// Whether a lowercased value contains a recognised filter function token.
+fn filter_value_has_function(lowered : String) -> Bool {
+  lowered.contains("blur(") ||
+  lowered.contains("brightness(") ||
+  lowered.contains("contrast(") ||
+  lowered.contains("drop-shadow(") ||
+  lowered.contains("grayscale(") ||
+  lowered.contains("hue-rotate(") ||
+  lowered.contains("invert(") ||
+  lowered.contains("opacity(") ||
+  lowered.contains("saturate(") ||
+  lowered.contains("sepia(") ||
+  lowered.contains("url(")
+}
+
+///|
 /// Compute element style using indexed stylesheets for better performance
 fn compute_element_style_indexed(
   selector_elem : @css.Element,
@@ -1012,28 +1059,27 @@ fn compute_element_style_indexed(
   )
 
   // Effects that establish a containing block for positioned descendants:
-  // filter and backdrop-filter (non-none values).
+  // filter and backdrop-filter (non-none values). var() is resolved against
+  // the element's custom properties first so `filter: var(--x)` that computes
+  // to none / invalid does not mis-establish the containing block.
   let mut establishes_effect_cb = false
   match cascaded {
-    Some(cascaded_values) =>
+    Some(cascaded_values) => {
       match cascaded_values.get_value("filter") {
         Some(value) =>
-          if value.to_lower().trim() != "none" {
+          if filter_value_establishes_effect_cb(value, element_css_vars) {
             establishes_effect_cb = true
           }
         None => ()
       }
-    None => ()
-  }
-  match cascaded {
-    Some(cascaded_values) =>
       match cascaded_values.get_value("backdrop-filter") {
         Some(value) =>
-          if value.to_lower().trim() != "none" {
+          if filter_value_establishes_effect_cb(value, element_css_vars) {
             establishes_effect_cb = true
           }
         None => ()
       }
+    }
     None => ()
   }
   match inline_css {
@@ -1043,12 +1089,18 @@ fn compute_element_style_indexed(
       }
     None => ()
   }
-  if establishes_effect_cb {
-    style = {
-      ..style,
-      has_filter: true,
-      contain: { ..style.contain, paint: true },
-    }
+  // @css sets has_filter from the raw declaration text without resolving
+  // var(), so `filter: var(--x)` computing to none / invalid still flips it
+  // true. Set it authoritatively from the var-aware determination above; this
+  // covers every trigger @css uses (cascaded filter, cascaded backdrop-filter,
+  // and the inline path), so it neither under- nor over-establishes the CB.
+  style = {
+    ..style,
+    has_filter: establishes_effect_cb,
+    contain: {
+      ..style.contain,
+      paint: style.contain.paint || establishes_effect_cb,
+    },
   }
 
   // Apply viewport dimensions if root


### PR DESCRIPTION
Addresses item 1 of #236 (the `chatgpt-codex-connector` review point from #226).

## Problem
`filter: var(--x)` / `backdrop-filter: var(--x)` always established an absolute-positioning containing block, because the detection in `renderer/renderer/style_resolve.mbt` compared the **raw cascaded text** (`"var(--x)"`) against `"none"`. `@css` (`computed/compute.mbt`) also sets `has_filter` from the same raw text **without resolving var()** (it resolves var for `background-image` but not `filter`), so the flag stayed `true` even when the custom property resolved to `none` or to an invalid value. Since #226 the layout engine reads `has_filter` on inline elements, so this could mis-establish an inline filter CB.

## Fix
Resolve var() against the element's custom properties first, then classify:
- `none` / empty (unresolved var, no fallback) → **no CB**
- var() resolving to a non-filter token (invalid) → **no CB** (computes to the initial value `none`)
- var() resolving to a filter function list / `url()` → **CB**
- literal (non-var) values keep the prior permissive behaviour

`has_filter` is now set **authoritatively** from this var-aware determination (it covers every trigger `@css` uses — cascaded `filter`, cascaded `backdrop-filter`, and the inline path), correcting the `@css` raw-text value rather than only OR-ing into it.

## Acceptance (#236 item 1)
- ✅ `filter: var(--x)` where `--x: none` does not set `has_filter` / abspos CB
- ✅ `filter: var(--x)` where `--x` is invalid / unresolved does not set them
- ✅ existing `inline_filter_preserves_abspos_descendant_wpt_like` and the inline / backdrop filter CB tests still pass

## Tests
Adds 4 regression tests (var → none, var → unresolved, var → non-filter token, var → real filter function). Full renderer suite: **382 passed, 0 failed**. Surgical 2-file change (`style_resolve.mbt`, `absolute_position_test.mbt`); no public API / `.mbti` change.

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_