### PR TITLE
ci: always install Puppeteer Chrome for wpt-css shards (fix poisoned cache) (#236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,28 +276,22 @@ jobs:
         run: just build-wasm && just transpile-wasm
 
       # scripts/wpt-runner.ts drives Chrome via the `puppeteer` package.
-      # Unlike the VRT jobs (which use Playwright), this job needs the
-      # Chrome build that puppeteer expects in ~/.cache/puppeteer. pnpm's
-      # store cache can short-circuit the puppeteer postinstall that would
-      # otherwise fetch it, so install it explicitly.
-      - name: Restore Puppeteer Chrome browser cache
-        id: puppeteer_cache
-        uses: actions/cache@v4
-        continue-on-error: ${{ matrix.soft_fail }}
-        with:
-          path: ~/.cache/puppeteer
-          key: puppeteer-chrome-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
-
+      # Unlike the VRT jobs (which use Playwright), this job needs the Chrome
+      # build that puppeteer expects in ~/.cache/puppeteer. pnpm's store cache
+      # can short-circuit the puppeteer postinstall that would otherwise fetch
+      # it, so install it explicitly here. The install is idempotent (it skips
+      # the download when the expected build is already present), so it runs
+      # unconditionally — gating it on an actions/cache hit risks a poisoned
+      # empty-cache entry permanently skipping the install and leaving the
+      # browser missing at launch time.
       - name: Install Puppeteer Chrome browser
-        if: steps.puppeteer_cache.outputs.cache-hit != 'true'
         continue-on-error: ${{ matrix.soft_fail }}
         run: pnpm exec puppeteer browsers install chrome
 
       # `puppeteer browsers install` fetches only the Chrome binary, not the
       # shared libraries headless Chrome needs to launch. Reuse Playwright's
       # dependency installer (Chromium and Chrome share the same system libs)
-      # so the browser can actually start on the runner. Must run every time
-      # (apt packages are not part of the puppeteer browser cache).
+      # so the browser can actually start on the runner.
       - name: Install Chrome system dependencies
         continue-on-error: ${{ matrix.soft_fail }}
         run: pnpm exec playwright install-deps chromium


### PR DESCRIPTION
Follow-up to #237; resolves the strict-shard residual tracked in #236.

## Root cause
#237 added a Chrome install step to the `wpt-css-tests` job, gated on an `actions/cache` hit:

```yaml
- name: Restore Puppeteer Chrome browser cache
  id: puppeteer_cache
  uses: actions/cache@v4
  with:
    path: ~/.cache/puppeteer
    key: puppeteer-chrome-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
- name: Install Puppeteer Chrome browser
  if: steps.puppeteer_cache.outputs.cache-hit != 'true'   # <-- the bug
  run: pnpm exec puppeteer browsers install chrome
```

An earlier run (before the install command was corrected) **failed the install and left `~/.cache/puppeteer` empty**, but `actions/cache` then **saved that empty directory** under the stable key. Every later run restored the empty cache, reported `cache-hit=true`, and **skipped the install entirely** — so the browser was absent and `scripts/wpt-runner.ts` failed at launch with:

```
Error: Could not find Chrome (ver. 146.0.7680.153). ... cache path: /home/runner/.cache/puppeteer
```

This is why the strict shards (`css-box-strict`, `css-position-strict`, `compositing-strict`) kept failing in CI even though the same modules pass locally with 0 failures (css-position 84/0, css-box 30/0, compositing 2/0).

## Fix
Drop the `actions/cache` step and run `pnpm exec puppeteer browsers install chrome` **unconditionally**. The install is idempotent (it skips the download when the expected build is already present), so it's cheap on warm runners and cannot be defeated by a poisoned cache entry. The `playwright install-deps chromium` step (system libraries) is retained.

YAML validated; the playwright caches in the VRT jobs are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_