### PR TITLE
ci: drive wpt-css shards with Playwright's Chromium (#236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,26 +275,23 @@ jobs:
       - name: Build WASM
         run: just build-wasm && just transpile-wasm
 
-      # scripts/wpt-runner.ts drives Chrome via the `puppeteer` package.
-      # Unlike the VRT jobs (which use Playwright), this job needs the Chrome
-      # build that puppeteer expects in ~/.cache/puppeteer. pnpm's store cache
-      # can short-circuit the puppeteer postinstall that would otherwise fetch
-      # it, so install it explicitly here. The install is idempotent (it skips
-      # the download when the expected build is already present), so it runs
-      # unconditionally — gating it on an actions/cache hit risks a poisoned
-      # empty-cache entry permanently skipping the install and leaving the
-      # browser missing at launch time.
-      - name: Install Puppeteer Chrome browser
+      # scripts/wpt-runner.ts drives Chrome via the `puppeteer` package, but
+      # `puppeteer browsers install` proved unreliable on the runner. Install
+      # Chromium with Playwright instead — the VRT jobs already depend on this
+      # path, and `--with-deps` brings the system libraries headless Chrome
+      # needs to launch — then point puppeteer at that binary via
+      # PUPPETEER_EXECUTABLE_PATH. Runs unconditionally (no cache gate) so a
+      # poisoned cache entry can never skip it.
+      - name: Install Chromium (Playwright) for the WPT runner
         continue-on-error: ${{ matrix.soft_fail }}
-        run: pnpm exec puppeteer browsers install chrome
+        run: pnpm exec playwright install --with-deps chromium
 
-      # `puppeteer browsers install` fetches only the Chrome binary, not the
-      # shared libraries headless Chrome needs to launch. Reuse Playwright's
-      # dependency installer (Chromium and Chrome share the same system libs)
-      # so the browser can actually start on the runner.
-      - name: Install Chrome system dependencies
+      - name: Point Puppeteer at the Playwright Chromium
         continue-on-error: ${{ matrix.soft_fail }}
-        run: pnpm exec playwright install-deps chromium
+        run: |
+          chrome_path="$(pnpm exec node -e 'console.log(require("playwright").chromium.executablePath())')"
+          echo "Resolved Chromium: ${chrome_path}"
+          echo "PUPPETEER_EXECUTABLE_PATH=${chrome_path}" >> "$GITHUB_ENV"
 
       - name: Run WPT CSS shard
         timeout-minutes: 20


### PR DESCRIPTION
Follow-up to #237 / #239; resolves the wpt-css strict-shard residual tracked in #236.

## Story so far
- #237 added a Chrome install to the `wpt-css-tests` job but gated it on an `actions/cache` hit; a failed early install poisoned the cache so the install was **skipped** thereafter.
- #239 removed the cache gate so the install **always runs** — which revealed the next layer: `pnpm exec puppeteer browsers install chrome` **fails on the runner** (`Install Puppeteer Chrome browser` step, exit 1), even though it succeeds locally.

## Fix
Stop fighting puppeteer's browser installer. Install Chromium with **Playwright** (the VRT jobs already use `pnpm exec playwright install --with-deps chromium`, so it's known-good in this CI), then point puppeteer at that binary via `PUPPETEER_EXECUTABLE_PATH` (puppeteer honours that env var as its launch executable). `--with-deps` also pulls the system libraries headless Chrome needs to launch.

```yaml
- name: Install Chromium (Playwright) for the WPT runner
  run: pnpm exec playwright install --with-deps chromium
- name: Point Puppeteer at the Playwright Chromium
  run: |
    chrome_path="$(pnpm exec node -e 'console.log(require("playwright").chromium.executablePath())')"
    echo "PUPPETEER_EXECUTABLE_PATH=${chrome_path}" >> "$GITHUB_ENV"
```

## Validation
Locally, `scripts/wpt-runner.ts css-position` renders **84 passed / 0 failed** with `PUPPETEER_EXECUTABLE_PATH` pointed at Playwright's Chromium — identical to the puppeteer-bundled Chrome. (css-box 30/0, compositing 2/0 confirmed earlier on the same code.) So once the browser launches in CI, the strict shards should pass.

## Merge order
Merge this first; then #238 (rebased onto main) picks it up and its wpt-css shards go green.

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_