### PR TITLE
ci: make Format check tolerate the moon.mod migration (#236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,16 @@ jobs:
       - name: Format check
         run: |
           just fmt
+          # `moon fmt` on the current MoonBit also migrates moon.mod.json ->
+          # moon.mod across every workspace. Adopting that migration would
+          # break the ~43 moon.mod.json references across CI / scripts, so it
+          # is tracked separately (#236) rather than performed here. Undo the
+          # migration artifacts and gate only on real source-format drift.
+          deleted_manifests="$(git ls-files --deleted -- '*moon.mod.json')"
+          if [ -n "$deleted_manifests" ]; then
+            echo "$deleted_manifests" | xargs git checkout --
+          fi
+          git clean -fq -- '*moon.mod' || true
           git diff --exit-code || (echo "Code is not formatted. Run 'just fmt' to fix." && exit 1)
         continue-on-error: true
 


### PR DESCRIPTION
Addresses item 3 of #236 (the noisy-red `Format check` step).

## Problem
`moon fmt` on the current MoonBit migrates `moon.mod.json` → `moon.mod` across every workspace package (deleting the `.json` files). The `test` job's Format check runs:

```yaml
just fmt
git diff --exit-code
```

so the migration always dirties the tree and the step exits red (255) on every PR — noise on the dashboard even though it's `continue-on-error`.

## Why not just adopt the migration
A real `moon.mod.json` → `moon.mod` conversion would break **~43 references** to `moon.mod.json` across CI workflows and scripts — `moon-prefetch` manifests, `hashFiles(...)` cache keys, `moon-publish-workspace.mjs`, `find-dead-mbt-packages`, the module-boundary tests, the rusty-v8 prefetch, etc. That's its own scoped change, not a formatting fix.

## Fix
Undo only the migration artifacts after `just fmt` (restore the deleted `moon.mod.json`, remove the generated `moon.mod`), then `git diff --exit-code` — so the check now gates purely on real source-format drift:

```yaml
deleted_manifests="$(git ls-files --deleted -- '*moon.mod.json')"
if [ -n "$deleted_manifests" ]; then
  echo "$deleted_manifests" | xargs git checkout --
fi
git clean -fq -- '*moon.mod' || true
git diff --exit-code || (echo "Code is not formatted. Run 'just fmt' to fix." && exit 1)
```

## Validation
Locally reproduced: `moon fmt` migrates 23 `moon.mod.json` → `moon.mod`; the undo sequence restores all 23 and removes all 23 generated files, leaving **no `moon.mod*` entries** in the tree. The remaining `git diff` then reflects only genuine source formatting (zero in CI, where the formatter matches the committed tree).

`continue-on-error: true` is retained as a safety net.

With this, #236 is fully addressed: item 1 → #238, item 2 → #240, item 3 → this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_