### PR TITLE
Give visible empty inline boxes a line-height strut (#66)

### DIFF
--- a/layout/block/block_test.mbt
+++ b/layout/block/block_test.mbt
@@ -3224,3 +3224,39 @@ test "empty_inline_with_border_gets_line_height_strut" {
   // line-height (19.2) + 1px border top + 1px border bottom; previously 2.0
   inspect(span.height, content="21.2")
 }
+
+///|
+/// Regression (#66): a margin-only empty inline box is also a visible line box.
+/// item.layout carries a zero margin (the real margin is applied to the
+/// fragment after line layout), so the strut decision must read the margin
+/// from the node style; otherwise a margin-only empty inline advances
+/// horizontally but collapses the line to zero height.
+test "empty_inline_with_margin_gets_line_height_strut" {
+  @dispatch.setup()
+  let default_style = @style.Style::default()
+  let margin_left : @types.Rect[@types.Dimension] = {
+    top: @types.Length(0.0),
+    right: @types.Length(0.0),
+    bottom: @types.Length(0.0),
+    left: @types.Length(10.0),
+  }
+  let empty_span = @node.Node::leaf("span#empty", {
+    ..default_style,
+    display: @types.Inline,
+    margin: margin_left,
+  })
+  let root_style = { ..default_style, width: @types.Length(200.0) }
+  let root = @node.Node::new("root", root_style, [empty_span])
+  let ctx : @layout_types.LayoutContext = {
+    available_width: 800.0,
+    available_height: Some(600.0),
+    sizing_mode: @layout_types.Definite,
+    viewport_width: 800.0,
+    viewport_height: 600.0,
+    stretch_width: false,
+    stretch_height: false,
+  }
+  let layout = compute(root, ctx, default_dispatch())
+  // No border/padding, so the border-box height is exactly the line-height.
+  inspect(layout.children[0].height, content="19.2")
+}

--- a/layout/block/block_test.mbt
+++ b/layout/block/block_test.mbt
@@ -3188,3 +3188,39 @@ test "multicol_single_display_contents_child_uses_descendant_flow_items" {
   inspect(layout.children[0].children[2].x, content="408")
   inspect(layout.children[0].children[2].y, content="0")
 }
+
+///|
+/// Regression (#66): a visible empty inline box (non-zero border, no content)
+/// is not an invisible line box (css-inline-3 §invisible-line-boxes). It
+/// generates a line box, so its own border-box height is the line-height plus
+/// its border (previously it collapsed to just the 2px border).
+test "empty_inline_with_border_gets_line_height_strut" {
+  @dispatch.setup()
+  let default_style = @style.Style::default()
+  let border_1px : @types.Rect[@types.Dimension] = {
+    top: @types.Length(1.0),
+    right: @types.Length(1.0),
+    bottom: @types.Length(1.0),
+    left: @types.Length(1.0),
+  }
+  let empty_span = @node.Node::leaf("span#empty", {
+    ..default_style,
+    display: @types.Inline,
+    border: border_1px,
+  })
+  let root_style = { ..default_style, width: @types.Length(200.0) }
+  let root = @node.Node::new("root", root_style, [empty_span])
+  let ctx : @layout_types.LayoutContext = {
+    available_width: 800.0,
+    available_height: Some(600.0),
+    sizing_mode: @layout_types.Definite,
+    viewport_width: 800.0,
+    viewport_height: 600.0,
+    stretch_width: false,
+    stretch_height: false,
+  }
+  let layout = compute(root, ctx, default_dispatch())
+  let span = layout.children[0]
+  // line-height (19.2) + 1px border top + 1px border bottom; previously 2.0
+  inspect(span.height, content="21.2")
+}

--- a/layout/inline/inline.mbt
+++ b/layout/inline/inline.mbt
@@ -1032,6 +1032,7 @@ fn LineBox::ensure_line_strut(
   let mut replaced_like_count = 0
   let mut has_text_item = false
   let mut has_br_item = false
+  let mut has_inline_box_item = false
   for item in self.items {
     let child = children[item.index]
     if child.text is Some(_) {
@@ -1043,8 +1044,37 @@ fn LineBox::ensure_line_strut(
     if is_replaced_strut_candidate(child) {
       replaced_like_count = replaced_like_count + 1
     }
+    // A non-replaced, content-less inline box with non-zero border / padding /
+    // margin (e.g. an empty `<span style="border:1px">`) is not an invisible
+    // line box (css-inline-3 §invisible-line-boxes), so it still generates the
+    // inline formatting context strut and its line takes the line-height of the
+    // containing block. A bare empty inline (no box decoration) stays invisible
+    // and contributes no height; inline-block / replaced size themselves.
+    let deco = item.layout
+    let has_box_decoration = deco.border.top +
+      deco.border.bottom +
+      deco.border.left +
+      deco.border.right +
+      deco.padding.top +
+      deco.padding.bottom +
+      deco.padding.left +
+      deco.padding.right +
+      deco.margin.top +
+      deco.margin.bottom +
+      deco.margin.left +
+      deco.margin.right >
+      0.0
+    if child.text is None &&
+      child.measure is None &&
+      child.id != "br" &&
+      child.style.display == @types.Inline &&
+      !is_replaced_strut_candidate(child) &&
+      has_box_decoration {
+      has_inline_box_item = true
+    }
   }
-  if has_text_item || (replaced_like_count == 0 && !has_br_item) {
+  if has_text_item ||
+    (replaced_like_count == 0 && !has_br_item && !has_inline_box_item) {
     return ()
   }
   if replaced_like_count > 0 && !has_br_item {
@@ -2128,6 +2158,19 @@ fn compute_inline_child(
       _ =>
         if id_matches_tag(node.id, "source") {
           text_glyph_height_from_style(style) +
+          padding.vertical_sum() +
+          border.vertical_sum()
+        } else if style.display == @types.Inline &&
+          padding.vertical_sum() +
+          padding.horizontal_sum() +
+          border.vertical_sum() +
+          border.horizontal_sum() >
+          0.0 {
+          // Visible empty inline box (non-zero border / padding, no content):
+          // not an invisible line box (css-inline-3 §invisible-line-boxes), so
+          // it generates a line box and its border-box height is the
+          // line-height plus its block-axis decorations.
+          line_height_from_style(style) +
           padding.vertical_sum() +
           border.vertical_sum()
         } else {

--- a/layout/inline/inline.mbt
+++ b/layout/inline/inline.mbt
@@ -1020,6 +1020,25 @@ fn resolve_abs_static_position_in_inline(
 }
 
 ///|
+fn dimension_is_nonzero(d : @types.Dimension) -> Bool {
+  match d {
+    @types.Length(v) => v != 0.0
+    @types.Percent(p) => p != 0.0
+    _ => false
+  }
+}
+
+///|
+/// Whether any margin edge resolves to a non-zero used value. Auto margins on
+/// inline boxes compute to zero, so only explicit lengths / percentages count.
+fn style_has_nonzero_margin(style : @style.Style) -> Bool {
+  dimension_is_nonzero(style.margin.top) ||
+  dimension_is_nonzero(style.margin.bottom) ||
+  dimension_is_nonzero(style.margin.left) ||
+  dimension_is_nonzero(style.margin.right)
+}
+
+///|
 /// Ensure each line box includes the inline formatting strut from parent font metrics.
 /// The strut defines the line box minimum ascent/descent from line-height.
 fn LineBox::ensure_line_strut(
@@ -1050,6 +1069,9 @@ fn LineBox::ensure_line_strut(
     // inline formatting context strut and its line takes the line-height of the
     // containing block. A bare empty inline (no box decoration) stays invisible
     // and contributes no height; inline-block / replaced size themselves.
+    // NB: item.layout carries the resolved border / padding but a zero margin
+    // (the real margin is applied to the fragment after line layout), so the
+    // margin contribution is read from the node's own style instead.
     let deco = item.layout
     let has_box_decoration = deco.border.top +
       deco.border.bottom +
@@ -1058,12 +1080,9 @@ fn LineBox::ensure_line_strut(
       deco.padding.top +
       deco.padding.bottom +
       deco.padding.left +
-      deco.padding.right +
-      deco.margin.top +
-      deco.margin.bottom +
-      deco.margin.left +
-      deco.margin.right >
-      0.0
+      deco.padding.right >
+      0.0 ||
+      style_has_nonzero_margin(child.style)
     if child.text is None &&
       child.measure is None &&
       child.id != "br" &&
@@ -2161,15 +2180,20 @@ fn compute_inline_child(
           padding.vertical_sum() +
           border.vertical_sum()
         } else if style.display == @types.Inline &&
-          padding.vertical_sum() +
-          padding.horizontal_sum() +
-          border.vertical_sum() +
-          border.horizontal_sum() >
-          0.0 {
-          // Visible empty inline box (non-zero border / padding, no content):
-          // not an invisible line box (css-inline-3 §invisible-line-boxes), so
-          // it generates a line box and its border-box height is the
-          // line-height plus its block-axis decorations.
+          (
+            padding.vertical_sum() +
+            padding.horizontal_sum() +
+            border.vertical_sum() +
+            border.horizontal_sum() >
+            0.0 ||
+            style_has_nonzero_margin(style)
+          ) {
+          // Visible empty inline box (non-zero border / padding / margin, no
+          // content): not an invisible line box (css-inline-3
+          // §invisible-line-boxes), so it generates a line box and its
+          // border-box height is the line-height plus its block-axis
+          // decorations (margin is outside the border box, so it adds no
+          // height itself).
           line_height_from_style(style) +
           padding.vertical_sum() +
           border.vertical_sum()


### PR DESCRIPTION
Closes #66.

## Problem
`wpt/css/css-inline/empty-span-height.html` measured `height=2.0` on Crater vs `19.2` on Chromium. An empty inline box with a border (`<span style="border:1px"></span>`) collapsed to just its border and contributed no line box.

Per CSS Inline Layout (css-inline-3 §invisible-line-boxes), an empty inline box with **non-zero border / padding / margin** is *not* an invisible line box: it generates a line box and takes the line-height of the containing block. Only a *bare* empty inline (no box decoration) stays invisible.

## Fix (`layout/inline/inline.mbt`)
1. **`compute_inline_child`** — the childless-node branch sized an auto-height box to `padding + border`. A childless `display:inline` box with non-zero border/padding now sizes its own border-box to `line-height + block-axis decorations` (→ span height 21.2).
2. **`LineBox::ensure_line_strut`** — previously early-returned (no strut) for any line with no text, no replaced element and no `<br>`. A line whose content includes such a *visible* empty inline box now gets the inline-formatting-context strut, so the containing block takes the line-height (→ container 19.2).

Both paths are gated on non-zero border/padding and on `display:inline`, so:
- bare empty inlines (outline only) stay invisible — **empty-span-size-001/002** keep passing;
- text lines (`has_text_item`), `inline-block`, and replaced elements are untouched — **empty-span-scroll** and the measure-based inline unit tests keep passing.

## Validation
- ✅ **empty-span-height.html** now passes; **empty-span-size-001 / -002 / -scroll** still pass.
- ✅ Full layout suite green (3466/3467 — the one failure is a pre-existing, unrelated sixel PNG test, confirmed failing on `main`).
- ✅ **css-box** strict WPT module still 30/0; `inline-crash.html` failure confirmed pre-existing.
- ✅ Added a layout regression test (`empty_inline_with_border_gets_line_height_strut`).

All WPT runs done against Chromium via the runner (`PUPPETEER_EXECUTABLE_PATH` → Playwright Chromium, per #240).

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_