### PR TITLE
Approve BiDi computed-style + CSS-rule-usage diagnostics (#26, #27)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,7 +39,6 @@ pkf run spec-check                                          # contract が壊れ
 | `diagnostic.paint-tree-diff` | paint tree diff API | #23 |
 | `diagnostic.css-property-mutation` | CSS property mutation API | #24 |
 | `diagnostic.selector-scoped-render` | selector-scoped rendering API | #25 |
-| `protocol.bidi-computed-style` | BiDi `getComputedStyle()` | #26 |
 | `diagnostic.vrt-prescanner-tracker` | VRT prescanner benchmark tracker | #29 |
 | `ci.parallel-vrt-bottleneck` | VRT shard 並列化 | #44 |
 | `ci.flaker-effectiveness` | flaker quarantine / fixture tighten | #79 |
@@ -58,7 +57,6 @@ pkf run spec-check                                          # contract が壊れ
 | `bug.bidi.navigate-wait-complete-returns-early` | `browsingContext.navigate` wait=complete が JS target で HTML fetch より先に解決 | PR #132 |
 | `bug.runtime.fetch-no-partition-cookies` | runtime `fetch()` が partition cookie を自動付与しない | PR #132 |
 | `bug.runtime.fetch-no-cors-gate` | runtime `fetch()` が `script_fetch_with_cors` を通らない | PR #132 |
-| `diagnostic.css-rule-usage-tracking` | dead CSS rule tracking | #27 |
 | `tui.raster-image-display` | TUI JPEG / PNG / GIF | #16 |
 | `ci.affected-required-check` | affected pkfire の required 化判断 | — |
 | `ci.flaker-vrt-harness-contract` | vrt-harness consumer payload 接続 | — |

--- a/docs/bidi-cross-frame-realm-model-design.md
+++ b/docs/bidi-cross-frame-realm-model-design.md
@@ -1,0 +1,139 @@
+# Design doc: live cross-frame DOM access / realm model (issue #200)
+
+Status: **design / decision-required**. Issue #200 explicitly asks for a design
+decision on Crater's realm model before implementation. This doc grounds the
+three approaches from the issue in the current architecture, lays out the
+trade-offs and implementation shape of each, and recommends a path. The choice
+is the maintainer's to make.
+
+Related, already-shipped: #197 (generalized synthetic iframe handler), #199
+(read-only nested property/index mirror), #198 (cross-evaluate child
+registration). #200 is the remaining, structurally harder "live" case.
+
+---
+
+## 1. Current state
+
+Cross-frame access today is a **one-shot textual snapshot**, not a live link:
+
+- `try_handle_synthetic_iframe_creation` (`webdriver/webdriver/bidi_protocol.mbt`)
+  is a **text-pattern matcher** over the `script.evaluate` expression. It
+  detects `createElement('iframe')` + a DOM-insertion verb, extracts `src`,
+  and registers a child context (`assign_new_realm`).
+- `bidi_iframe_content_window_mirror.mbt` extracts `<lhs> = <var>.contentWindow.<chain>`
+  and, at evaluate time, reads `window.<chain>` once and writes the value into
+  the parent's LHS. After that, the two sides are disconnected.
+- Realms: Crater assigns a distinct **realm id** per browsing context, but JS
+  executes in a **shared runtime / single `globalThis`** (the headless default).
+  The "child realm" read is an eval against that shared global.
+
+What this misses (from #200):
+
+1. **Parent observes child mutations** — `iframe.contentWindow.addEventListener('foo', cb)`.
+2. **Parent reads child state lazily** — `iframe.contentWindow.getState()` each render.
+3. **Child writes parent state** — `window.parent.appCallback = ...`.
+
+All three need a *standing* relationship between realms, which the snapshot
+model cannot express.
+
+---
+
+## 2. Options
+
+### Option A — Proxy-based live `contentWindow`
+
+`iframe.contentWindow` returns a JS `Proxy` whose `get`/`set`/`apply` traps
+route each access through the target realm at access time.
+
+- **Pros**: shape-conformant; handles all three patterns (lazy reads, method
+  calls, child→parent writes) including ones the text matcher can never parse
+  (computed property names, calls, compound RHS).
+- **Cons**: every cross-frame access pays a realm-switch + eval round-trip;
+  requires a real per-realm global object to proxy *to* (see §3); trap
+  semantics (prototype chain, `this` binding for methods, structured-clone vs
+  live-reference of returned objects) are subtle and easy to get subtly wrong.
+- **Shape**: replace the text matcher's snapshot with a runtime `contentWindow`
+  accessor that returns the proxy; implement traps in the JS runtime bridge
+  (`bidi_runtime_context.mbt` region) keyed by child realm id.
+
+### Option B — Shared-realm alias (test/headless mode)
+
+Since the default runtime is a single `globalThis`, treat
+`iframe.contentWindow` as an **alias for the same global** when parent and child
+are pinned to one realm.
+
+- **Pros**: cheap; no round-trips; immediately makes lazy reads, method calls,
+  and child→parent writes "work" because they are literally the same object.
+- **Cons**: **semantically wrong** for isolation — parent and child share one
+  global, so name collisions leak, `window.parent === window`, and any test that
+  asserts realm isolation (separate `globalThis`, separate `document`) breaks.
+  It is a convenience that models "one realm pretending to be two".
+- **Shape**: when `assign_new_realm` would pin the child to the shared global,
+  make `contentWindow` resolve to that global directly; gate behind an explicit
+  "single-realm test mode" flag so it never masks real isolation expectations.
+
+### Option C — Document the limitation, steer to `postMessage`
+
+Keep the snapshot mirror for the simple `lhs = contentWindow.chain` case; for
+everything else, document that live cross-frame member access is unsupported and
+that apps should use `window.postMessage` (which has a real channel).
+
+- **Pros**: zero new surface; honest; `postMessage` is the portable pattern.
+- **Cons**: real apps and WPT use direct `contentWindow` member access; this
+  closes #200 as "won't fix the general case".
+- **Shape**: a docs note + ensure `postMessage` parent↔child delivery works in
+  the shared runtime (verify/strengthen if needed).
+
+---
+
+## 3. The underlying decision: does Crater have real per-frame realms?
+
+Options A and B diverge on the realm model:
+
+- **A** presupposes (or forces) **distinct global objects per browsing context**
+  so the proxy has a real target and isolation holds. That is the
+  browser-faithful model but a larger runtime change (per-context global, realm
+  switch on the JS side, lifetime/GC of child realms).
+- **B** leans into the **single shared global** that exists today.
+
+So #200 is really: *do we invest in true per-frame realms (A), accept a
+shared-realm convenience (B), or decline the general case (C)?* Everything else
+follows from that.
+
+---
+
+## 4. Recommendation
+
+Phase the work rather than commit to full realm isolation up front:
+
+1. **Now — Option C baseline**: document the snapshot limitation and confirm
+   `postMessage` parent↔child works, so apps have one correct path today. Low
+   risk, immediately honest.
+2. **Next — Option B behind a flag** for the headless/test single-realm path:
+   make `contentWindow` a live alias to the shared global *only* under an
+   explicit single-realm mode, so lazy reads / method calls / child→parent
+   writes work for the common test scenarios **without** claiming isolation.
+   Add wbtests for the three #200 patterns and a test asserting the flag is off
+   by default (isolation preserved).
+3. **Later — Option A** if/when true multi-realm isolation is required (real
+   per-context globals + proxy `contentWindow`). Track as its own scenario; it
+   is the only option that is both live *and* isolation-correct, but it is the
+   largest runtime change.
+
+Acceptance for closing #200 should be tied to whichever phase is chosen (e.g. a
+`protocol.bidi-cross-frame-*` scenario + wbtests for the three patterns), not to
+all three at once.
+
+---
+
+## 5. Wiring points (for whoever implements)
+
+- `webdriver/webdriver/bidi_protocol.mbt` — `try_handle_synthetic_iframe_creation`,
+  `assign_new_realm` (realm/child-context creation).
+- `webdriver/webdriver/bidi_iframe_content_window_mirror.mbt` — the snapshot
+  extractor that A/B would supersede for the live cases.
+- The JS runtime bridge (`bidi_runtime_context.mbt` region) — where a proxy
+  (A) or a shared-global alias (B) for `contentWindow` would live, and where
+  `postMessage` delivery (C) is exercised.
+- `specs/crater.pkl` — add a `protocol.bidi-cross-frame-*` scenario for the
+  chosen phase; link a wbtest in `specs/tasks.Test.pkl`.

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -540,10 +540,10 @@ scenarios {
     id = "protocol.bidi-computed-style"
     name = "BiDi exposes computed CSS styles"
     description =
-      "Add a BiDi command equivalent to getComputedStyle() so VRT tools can use computed-style diffs (single most impactful detection signal, +23% over pixel-only in the CSS challenge benchmark). See GitHub issue #26."
+      "BiDi commands equivalent to getComputedStyle() so VRT tools can use computed-style diffs (single most impactful detection signal, +23% over pixel-only in the CSS challenge benchmark). browsingContext.getComputedStyles / getAllComputedStyles / getComputedStylesWithState are handled in webdriver/webdriver/bidi_browsing_context_computed_styles.mbt, routed in bidi_protocol_dispatch_browsing_context_rendering.mbt, and covered by bidi_protocol_browsing_context_styles_wbtest.mbt (selector / sharedId / elementId targets, selector-keyed batch, hover / focus-visible forced state). See GitHub issue #26."
     tags { "protocol"; "bidi"; "diagnostic"; "issue:26" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.diagnostic-api"; "goal.protocol-compat" }
   }
   new {
@@ -924,10 +924,10 @@ scenarios {
     id = "diagnostic.css-rule-usage-tracking"
     name = "CSS rule usage tracking identifies dead rules"
     description =
-      "Track which CSS rules are matched and applied during rendering, then report unused or overridden rules. See GitHub issue #27."
+      "Track which CSS rules are matched and applied during rendering, then report unused or overridden rules. browsingContext.getCssRuleUsage (handler in webdriver/webdriver/bidi_browsing_context_vrt.mbt, routed in bidi_protocol_dispatch_browsing_context_rendering.mbt) reports matched / overridden-by-specificity / applied-no-op (inherited, initial, same-as-fallback) rules, covered by bidi_protocol_browsing_context_styles_wbtest.mbt. See GitHub issue #27."
     tags { "diagnostic"; "css"; "api"; "issue:27" }
     severity = "minor"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.diagnostic-api" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -665,6 +665,26 @@ tests {
       "bash -lc 'set -e; test -f webdriver/webdriver/bidi_runtime_cookie_parity_wbtest.mbt; grep -Fq -- \"cookie URL filter parity: 10 representative cases\" webdriver/webdriver/bidi_runtime_cookie_parity_wbtest.mbt; grep -Fq -- \"storage_cookie_matches_request_url\" webdriver/webdriver/bidi_runtime_cookie_parity_wbtest.mbt; grep -Fq -- \"__bidiResolveCookies\" webdriver/webdriver/bidi_runtime_cookie_parity_wbtest.mbt; test -f webdriver/webdriver/bidi_storage.mbt; grep -Fq -- \"fn storage_cookie_matches_request_url\" webdriver/webdriver/bidi_storage.mbt; test -f webdriver/webdriver/bidi_runtime_context.mbt; grep -Fq -- \"globalThis.__bidiResolveCookies\" webdriver/webdriver/bidi_runtime_context.mbt'"
   }
   new {
+    name = "bidi_get_computed_styles_exposed"
+    description =
+      "browsingContext.getComputedStyles / getAllComputedStyles / getComputedStylesWithState expose resolved CSS values over BiDi (the +23% computed-style diff signal from the CSS challenge benchmark). Handlers live in bidi_browsing_context_computed_styles.mbt, routed in bidi_protocol_dispatch_browsing_context_rendering.mbt, and exercised by bidi_protocol_browsing_context_styles_wbtest.mbt for selector / sharedId / elementId targets, the selector-keyed batch form, and forced-state (hover / focus-visible) variants."
+    tags { "protocol"; "bidi"; "diagnostic"; "issue:26" }
+    specRef { "protocol.bidi-computed-style" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f webdriver/webdriver/bidi_browsing_context_computed_styles.mbt; grep -Fq -- \"fn BidiProtocol::handle_get_computed_styles\" webdriver/webdriver/bidi_browsing_context_computed_styles.mbt; test -f webdriver/webdriver/bidi_protocol_dispatch_browsing_context_rendering.mbt; grep -Fq -- \"\\\"getComputedStyles\\\" =>\" webdriver/webdriver/bidi_protocol_dispatch_browsing_context_rendering.mbt; grep -Fq -- \"\\\"getAllComputedStyles\\\" =>\" webdriver/webdriver/bidi_protocol_dispatch_browsing_context_rendering.mbt; test -f webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt; grep -Fq -- \"bidi getComputedStyles returns live inline styles for selector\" webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt; grep -Fq -- \"bidi getAllComputedStyles returns selector keyed styles\" webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt'"
+  }
+  new {
+    name = "bidi_get_css_rule_usage_exposed"
+    description =
+      "browsingContext.getCssRuleUsage reports which CSS rules matched, which were overridden by higher specificity, and which were applied no-ops (inherited / initial / same-as-fallback), for dead-CSS detection. Handler in bidi_browsing_context_vrt.mbt, routed in bidi_protocol_dispatch_browsing_context_rendering.mbt, exercised by bidi_protocol_browsing_context_styles_wbtest.mbt."
+    tags { "diagnostic"; "css"; "api"; "issue:27" }
+    specRef { "diagnostic.css-rule-usage-tracking" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f webdriver/webdriver/bidi_browsing_context_vrt.mbt; grep -Fq -- \"fn BidiProtocol::handle_get_css_rule_usage\" webdriver/webdriver/bidi_browsing_context_vrt.mbt; test -f webdriver/webdriver/bidi_protocol_dispatch_browsing_context_rendering.mbt; grep -Fq -- \"\\\"getCssRuleUsage\\\" =>\" webdriver/webdriver/bidi_protocol_dispatch_browsing_context_rendering.mbt; test -f webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt; grep -Fq -- \"bidi getCssRuleUsage reports matched and overridden rules\" webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt'"
+  }
+  new {
     name = "playwright_synthetic_navigation_url"
     description =
       "CraterBidiPage.page.click drains synthetic navigation after input.performActions, and the pointer runtime routes submit buttons through requestSubmit so form GET updates page.url. Covered by tests/playwright-adapter-user-scenarios.test.ts."


### PR DESCRIPTION
Closes #26. Closes #27.

Both diagnostic features were **already implemented and wbtested** in the BiDi surface, but their pkspec scenarios were still `draft` with no `implementingTest` link — so the work was done but unrecognized by the spec contract. This PR reifies them per the pkspec workflow (no code change).

## #26 — computed styles via BiDi (`protocol.bidi-computed-style`)
`browsingContext.getComputedStyles` / `getAllComputedStyles` / `getComputedStylesWithState` — handlers in `bidi_browsing_context_computed_styles.mbt`, routed in `bidi_protocol_dispatch_browsing_context_rendering.mbt`, covered by `bidi_protocol_browsing_context_styles_wbtest.mbt` (selector / sharedId / elementId targets, selector-keyed batch, hover / focus-visible forced state). This is the +23% computed-style-diff detection signal from the CSS challenge benchmark.

## #27 — CSS rule usage tracking (`diagnostic.css-rule-usage-tracking`)
`browsingContext.getCssRuleUsage` — handler in `bidi_browsing_context_vrt.mbt`, same dispatch + wbtest file; reports matched / overridden-by-specificity / applied-no-op (inherited, initial, same-as-fallback) rules for dead-CSS detection.

## Changes (specs/docs only)
- `specs/tasks.Test.pkl`: add `bidi_get_computed_styles_exposed` and `bidi_get_css_rule_usage_exposed` implementingTests (`specRef` + structural grep `cmd`).
- `specs/crater.pkl`: flip both scenarios `draft → approved` with descriptions pointing at the handlers/dispatch/wbtests.
- `TODO.md`: drop the two reified rows.

## Validation
- The full `mizchi/crater-webdriver/webdriver` suite is green locally (433 passed, 0 failed) — the wbtests these scenarios link are included.
- Both `implementingTest` grep commands verified locally.

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_