### PR TITLE
Lock in flexbox align-items cross-axis behavior (#22)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,6 @@ pkf run spec-check                                          # contract が壊れ
 | `bug.flexbox-min-width-justify` | flexbox min_width + justify-content | #2 |
 | `bug.inline-abspos-width-ahem` | inline abspos width Ahem | #17 |
 | `bug.border-radius-paint` | border-radius pixel diff | #19 |
-| `bug.flexbox-align-items` | align-items 反映 | #22 |
 | `bug.samesite.psl-required` | SameSite eTLD+1 は PSL が必要 (security review I3) | — |
 | `bug.dom.html-form-element-submit-missing` | `HTMLFormElement.submit` / `requestSubmit` 未公開 | PR #132 |
 | `bug.dom.document-forms-missing` | `document.forms` HTMLCollection 未公開 | PR #132 |

--- a/layout/flex/flex_test.mbt
+++ b/layout/flex/flex_test.mbt
@@ -5256,3 +5256,53 @@ test "row_flex_scroll_list_item_keeps_expected_track_sizes" {
   inspect(layout.children[2].width, content="56")
   inspect(layout.children[2].height, content="24")
 }
+
+///|
+/// Regression (#22): align-items must be reflected in cross-axis layout, so
+/// removing `align-items: center` (reverting to the default `stretch`) changes
+/// where/how flex items are laid out. A pixel diff that found "no change" when
+/// align-items: center was removed indicated this was not applied.
+test "flex_align_items_center_differs_from_default_stretch" {
+  let ds = @style.Style::default()
+  let m = fn(h : Double) -> @layout_types.MeasureFunc {
+    {
+      func: fn(_w, _h) {
+        { min_width: 20.0, max_width: 20.0, min_height: h, max_height: h }
+      },
+    }
+  }
+  let ctx : @layout_types.LayoutContext = {
+    available_width: 800.0,
+    available_height: Some(600.0),
+    sizing_mode: @layout_types.Definite,
+    viewport_width: 800.0,
+    viewport_height: 600.0,
+    stretch_width: false,
+    stretch_height: false,
+  }
+  let mk = fn(align : @types.Alignment?) -> @layout_types.Layout {
+    let c1 = @node.Node::with_measure("c1", ds, m(20.0))
+    let c2 = @node.Node::with_measure("c2", ds, m(40.0))
+    let base = {
+      ..ds,
+      display: @types.Flex,
+      flex_direction: @types.Row,
+      width: @types.Length(100.0),
+    }
+    let style = match align {
+      Some(a) => { ..base, align_items: a }
+      None => base
+    }
+    compute(@node.Node::new("root", style, [c1, c2]), ctx, default_dispatch())
+  }
+  // align-items: center -> the shorter item keeps its content height and is
+  // centered within the 40px line (y = (40-20)/2 = 10).
+  let centered = mk(Some(@types.Center))
+  inspect(centered.children[0].height, content="20")
+  inspect(centered.children[0].y, content="10")
+  // default (align-items: stretch) -> the shorter item stretches to the line
+  // height (40) at the top (y = 0). This is the visible change #22 asks for.
+  let default_stretch = mk(None)
+  inspect(default_stretch.children[0].height, content="40")
+  inspect(default_stretch.children[0].y, content="0")
+}

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -758,10 +758,10 @@ scenarios {
     id = "bug.flexbox-align-items"
     name = "align-items on flex containers is reflected"
     description =
-      "Removing align-items: center from a flex container must produce a pixel diff. See GitHub issue #22."
+      "Removing align-items: center from a flex container must produce a pixel diff. Verified: with align-items: center a shorter flex item keeps its content height and centers in the line (cross-axis), while the default stretch sizes it to the line height at the top, so the two layouts differ. Covered by flex_align_items_center_differs_from_default_stretch in layout/flex/flex_test.mbt. See GitHub issue #22."
     tags { "css"; "flexbox"; "bug"; "issue:22" }
     severity = "minor"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.css-compat"; "goal.paint-accuracy" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -715,6 +715,16 @@ tests {
       "bash -lc 'set -e; test -f webdriver/webdriver/bidi_browsing_context_vrt.mbt; grep -Fq -- \"fn BidiProtocol::handle_get_css_rule_usage\" webdriver/webdriver/bidi_browsing_context_vrt.mbt; test -f webdriver/webdriver/bidi_protocol_dispatch_browsing_context_rendering.mbt; grep -Fq -- \"\\\"getCssRuleUsage\\\" =>\" webdriver/webdriver/bidi_protocol_dispatch_browsing_context_rendering.mbt; test -f webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt; grep -Fq -- \"bidi getCssRuleUsage reports matched and overridden rules\" webdriver/webdriver/bidi_protocol_browsing_context_styles_wbtest.mbt'"
   }
   new {
+    name = "flexbox_align_items_reflected"
+    description =
+      "align-items on a flex container changes cross-axis layout: with align-items: center a shorter item keeps its content height and is centered in the line, while the default (stretch) sizes it to the line height at the top. layout/flex/flex_test.mbt asserts the two differ, so removing align-items: center produces a real layout change (the pixel-diff gap in #22)."
+    tags { "css"; "flexbox"; "bug"; "issue:22" }
+    specRef { "bug.flexbox-align-items" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f layout/flex/flex_test.mbt; grep -Fq -- \"flex_align_items_center_differs_from_default_stretch\" layout/flex/flex_test.mbt'"
+  }
+  new {
     name = "playwright_synthetic_navigation_url"
     description =
       "CraterBidiPage.page.click drains synthetic navigation after input.performActions, and the pointer runtime routes submit buttons through requestSubmit so form GET updates page.url. Covered by tests/playwright-adapter-user-scenarios.test.ts."


### PR DESCRIPTION
Closes #22.

#22 reported that removing `align-items: center` from a flex container produced no pixel diff. I reproduced the cross-axis cases directly against the layout engine and the behavior is **now correct** — so this PR verifies it and **locks it in with a regression test** (no engine change needed).

## Verified behavior
| case | result |
|---|---|
| definite-height container, default align | item stretches to fill (h=50, y=0) |
| auto-height container, `align-items: center` | shorter item keeps content height (h=20) and centers (y=10) |
| auto-height container, default (stretch) | shorter item stretches to line height (h=40, y=0) |

So removing `align-items: center` **does** change the layout (shorter item goes from h=20/y=10 → h=40/y=0). The default `align_items` is `Stretch` (per spec).

## Changes
- `layout/flex/flex_test.mbt`: regression test `flex_align_items_center_differs_from_default_stretch` asserting center ≠ default-stretch for a shorter item (flex suite 112 passed).
- `specs/crater.pkl`: `bug.flexbox-align-items` flipped `draft → approved`.
- `specs/tasks.Test.pkl`: implementingTest `flexbox_align_items_reflected`.
- `TODO.md`: backlog row dropped.

(The original VRT "no change" was likely a case where the flex items were equal-height, so center and stretch coincide visually — correct behavior. The general mechanism is sound, now guarded.)

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_