### PR TITLE
Lock in flexbox min_width + justify-content + padding behavior (#2)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -44,7 +44,6 @@ pkf run spec-check                                          # contract が壊れ
 
 | scenario id | 概要 | link |
 |---|---|---|
-| `bug.flexbox-min-width-justify` | flexbox min_width + justify-content | #2 |
 | `bug.inline-abspos-width-ahem` | inline abspos width Ahem | #17 |
 | `bug.border-radius-paint` | border-radius pixel diff | #19 |
 | `bug.samesite.psl-required` | SameSite eTLD+1 は PSL が必要 (security review I3) | — |

--- a/layout/flex/flex_test.mbt
+++ b/layout/flex/flex_test.mbt
@@ -5306,3 +5306,66 @@ test "flex_align_items_center_differs_from_default_stretch" {
   inspect(default_stretch.children[0].height, content="40")
   inspect(default_stretch.children[0].y, content="0")
 }
+
+///|
+/// Regression (#2): three flexbox issues reported at v0.2.0, now correct.
+test "flexbox_min_width_justify_and_padding" {
+  let ds = @style.Style::default()
+  let tm : @layout_types.MeasureFunc = {
+    func: fn(_w, _h) {
+      { min_width: 20.0, max_width: 20.0, min_height: 10.0, max_height: 10.0 }
+    },
+  }
+  let ctx : @layout_types.LayoutContext = {
+    available_width: 50.0,
+    available_height: Some(600.0),
+    sizing_mode: @layout_types.Definite,
+    viewport_width: 50.0,
+    viewport_height: 600.0,
+    stretch_width: false,
+    stretch_height: false,
+  }
+  // Issue 1: min_width (not width) + justify-content: center still centers.
+  // Container takes min_width (200); the 20-wide child centers at (200-20)/2.
+  let c1 = @node.Node::with_measure("c1", ds, tm)
+  let r1 = @node.Node::new(
+    "r1",
+    {
+      ..ds,
+      display: @types.Flex,
+      flex_direction: @types.Row,
+      min_width: @types.Length(200.0),
+      justify_content: @types.Center,
+    },
+    [c1],
+  )
+  let l1 = compute(r1, ctx, default_dispatch())
+  inspect(l1.width, content="200")
+  inspect(l1.children[0].x, content="90")
+  // Issue 2: symmetric horizontal padding stays symmetric on the layout.
+  let pad2 : @types.Rect[@types.Dimension] = {
+    top: @types.Length(0.0),
+    right: @types.Length(2.0),
+    bottom: @types.Length(0.0),
+    left: @types.Length(2.0),
+  }
+  let c2 = @node.Node::with_measure("c2", ds, tm)
+  let r2 = @node.Node::new(
+    "r2",
+    { ..ds, display: @types.Flex, flex_direction: @types.Row, padding: pad2 },
+    [c2],
+  )
+  let l2 = compute(r2, ctx, default_dispatch())
+  inspect(l2.padding.left, content="2")
+  inspect(l2.padding.right, content="2")
+  // Issue 3: horizontal padding does not inflate height.
+  let c3 = @node.Node::with_measure("c3", ds, tm)
+  let r3 = @node.Node::new(
+    "r3",
+    { ..ds, display: @types.Flex, flex_direction: @types.Row },
+    [c3],
+  )
+  let l3 = compute(r3, ctx, default_dispatch())
+  inspect(l2.height, content="10")
+  inspect(l3.height, content="10")
+}

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -728,10 +728,10 @@ scenarios {
     id = "bug.flexbox-min-width-justify"
     name = "flexbox min_width with justify-content centers correctly"
     description =
-      "Fix justify-content: center being a no-op when min_width is used instead of width on flex containers. See GitHub issue #2."
+      "justify-content: center is no longer a no-op when min_width sizes a flex container instead of width: a min_width container takes that size and centers its child. Verified together with the other #2 flexbox issues — symmetric horizontal padding stays symmetric on the layout, and horizontal padding does not inflate height. Covered by flexbox_min_width_justify_and_padding in layout/flex/flex_test.mbt. See GitHub issue #2."
     tags { "css"; "flexbox"; "bug"; "issue:2" }
     severity = "minor"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.css-compat" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -725,6 +725,16 @@ tests {
       "bash -lc 'set -e; test -f layout/flex/flex_test.mbt; grep -Fq -- \"flex_align_items_center_differs_from_default_stretch\" layout/flex/flex_test.mbt'"
   }
   new {
+    name = "flexbox_min_width_justify_centers"
+    description =
+      "Flexbox issues from #2 are correct: justify-content: center centers a child when min_width (not width) sizes the container; symmetric horizontal padding stays symmetric on the layout; and horizontal padding does not inflate height. Covered by flexbox_min_width_justify_and_padding in layout/flex/flex_test.mbt."
+    tags { "css"; "flexbox"; "bug"; "issue:2" }
+    specRef { "bug.flexbox-min-width-justify" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f layout/flex/flex_test.mbt; grep -Fq -- \"flexbox_min_width_justify_and_padding\" layout/flex/flex_test.mbt'"
+  }
+  new {
     name = "playwright_synthetic_navigation_url"
     description =
       "CraterBidiPage.page.click drains synthetic navigation after input.performActions, and the pointer runtime routes submit buttons through requestSubmit so form GET updates page.url. Covered by tests/playwright-adapter-user-scenarios.test.ts."


### PR DESCRIPTION
Closes #2.

The three flexbox issues reported in #2 (at v0.2.0) are **now correct** — I reproduced each directly against the layout engine and added a regression test. No engine change was needed; this verifies and locks in the behavior.

| # | issue (v0.2.0) | now |
|---|---|---|
| 1 | `min_width` + `justify-content: center` was a no-op | container takes `min_width` (200) and the child centers (x=90) ✅ |
| 2 | symmetric `padding_x` → asymmetric `Layout.padding` | `padding.left == padding.right == 2` ✅ |
| 3 | `padding_x` inflated computed height | height stays 10 (== no-padding) ✅ |

## Changes
- `layout/flex/flex_test.mbt`: `flexbox_min_width_justify_and_padding` asserts all three (flex suite 113 passed).
- `specs/crater.pkl`: `bug.flexbox-min-width-justify` flipped `draft → approved`.
- `specs/tasks.Test.pkl`: implementingTest `flexbox_min_width_justify_centers`.
- `TODO.md`: backlog row dropped.

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_