### PR TITLE
Reify inline abspos Ahem width scenario (#17)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -44,7 +44,6 @@ pkf run spec-check                                          # contract が壊れ
 
 | scenario id | 概要 | link |
 |---|---|---|
-| `bug.inline-abspos-width-ahem` | inline abspos width Ahem | #17 |
 | `bug.border-radius-paint` | border-radius pixel diff | #19 |
 | `bug.samesite.psl-required` | SameSite eTLD+1 は PSL が必要 (security review I3) | — |
 | `bug.dom.html-form-element-submit-missing` | `HTMLFormElement.submit` / `requestSubmit` 未公開 | PR #132 |

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -738,10 +738,10 @@ scenarios {
     id = "bug.inline-abspos-width-ahem"
     name = "inline abspos text width matches Ahem"
     description =
-      "Fix inline abspos text width estimation mismatch with Ahem font (position-absolute-in-inline-003/004). See GitHub issue #17."
+      "Inline abspos text width estimation with the Ahem font now matches the browser: css-position WPT tests position-absolute-in-inline-003/004 pass, css-position is a gated wpt.json module, and the tests are no longer in knownFailures. See GitHub issue #17."
     tags { "css"; "inline"; "bug"; "issue:17" }
     severity = "minor"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.css-compat" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -735,6 +735,16 @@ tests {
       "bash -lc 'set -e; test -f layout/flex/flex_test.mbt; grep -Fq -- \"flexbox_min_width_justify_and_padding\" layout/flex/flex_test.mbt'"
   }
   new {
+    name = "inline_abspos_width_ahem_passes"
+    description =
+      "css-position WPT tests position-absolute-in-inline-003/004 (inline abspos text width with the Ahem font) pass: css-position is a gated wpt.json module and these tests are no longer quarantined in knownFailures, so the inline text-width estimation matches the browser (#17)."
+    tags { "css"; "inline"; "bug"; "issue:17" }
+    specRef { "bug.inline-abspos-width-ahem" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; test -f wpt/css/css-position/position-absolute-in-inline-003.html; test -f wpt/css/css-position/position-absolute-in-inline-004.html; grep -Fq -- \"\\\"css-position\\\"\" wpt.json; ! grep -q -- \"position-absolute-in-inline\" wpt.json'"
+  }
+  new {
     name = "playwright_synthetic_navigation_url"
     description =
       "CraterBidiPage.page.click drains synthetic navigation after input.performActions, and the pointer runtime routes submit buttons through requestSubmit so form GET updates page.url. Covered by tests/playwright-adapter-user-scenarios.test.ts."


### PR DESCRIPTION
Closes #17.

The two css-position WPT tests `position-absolute-in-inline-003/004` (inline abspos text width with the Ahem font) **now pass** — I confirmed both render-match Chromium via the runner. The inline text-width estimation fix has landed and the entries were removed from `knownFailures`:
- `css-position` is a gated module in `wpt.json` (line 10), and
- `knownFailures` is empty — these tests are no longer quarantined, so they're enforced-passing under the `css-position` gate.

So this is a verify-and-reify (no code change):
- `specs/crater.pkl`: `bug.inline-abspos-width-ahem` flipped `draft → approved`.
- `specs/tasks.Test.pkl`: implementingTest `inline_abspos_width_ahem_passes` (asserts the tests exist, css-position is gated, and they're not in knownFailures).
- `TODO.md`: backlog row dropped.

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_