### PR TITLE
Enable css-inline WPT module baseline (#65, #66)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,6 @@ pkf run spec-check                                          # contract が壊れ
 |---|---|---|
 | `compat.css-images-baseline` | css-images WPT baseline 有効化 | #65, #68 |
 | `compat.css-values-baseline` | css-values WPT baseline 有効化 | #65, #67 |
-| `compat.css-inline-baseline` | css-inline WPT baseline 有効化 | #65, #66 |
 | `compat.css-filter-effects` | filter-effects 残 failure 潰し | #64 |
 | `paint.text-glyph-metrics` | glyph metrics / AA Chromium parity | #47 |
 

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -380,10 +380,10 @@ scenarios {
     id = "compat.css-inline-baseline"
     name = "css-inline WPT module baseline is enabled"
     description =
-      "Promote css-inline from manual baseline measurement into wpt-config. See GitHub issue #65 (measurement) and #66 (empty inline span height outlier)."
+      "css-inline is promoted into wpt-config: enabled in wpt.json modules with a modulePrefixes [\"\"] entry exposing the top-level suite, baselined at 10/11 passing in tests/wpt-baselines/css-inline.env (including the #66 empty-span strut tests), with the inline-crash.html crashtest quarantined in knownFailures. Subdirectories (model / parsing / initial-letter / ...) are follow-up. See GitHub issue #65 (measurement) and #66 (empty inline span height outlier)."
     tags { "wpt"; "css"; "baseline"; "issue:65"; "issue:66" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.css-compat" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -465,6 +465,16 @@ tests {
       "bash -lc 'set -e; grep -Fq -- \"\\\"css-ruby\\\"\" wpt.json; test -f tests/wpt-baselines/css-ruby.env; grep -Fq -- \"MODULE=css-ruby\" tests/wpt-baselines/css-ruby.env; grep -Fq -- \"BASELINE_PASSED=26\" tests/wpt-baselines/css-ruby.env; grep -Fq -- \"BASELINE_FAILED=74\" tests/wpt-baselines/css-ruby.env'"
   }
   new {
+    name = "wpt_css_inline_baseline_is_pinned"
+    description =
+      "css-inline is enabled in wpt.json with a modulePrefixes [\"\"] entry exposing the top-level suite; the per-module baseline file pins 10/11 passing (including the #66 empty-span strut tests) with inline-crash.html quarantined in knownFailures."
+    tags { "wpt"; "css"; "baseline"; "issue:65"; "issue:66" }
+    specRef { "compat.css-inline-baseline" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"\\\"css-inline\\\"\" wpt.json; grep -Fq -- \"inline-crash.html\" wpt.json; test -f tests/wpt-baselines/css-inline.env; grep -Fq -- \"MODULE=css-inline\" tests/wpt-baselines/css-inline.env; grep -Fq -- \"BASELINE_PASSED=10\" tests/wpt-baselines/css-inline.env; grep -Fq -- \"BASELINE_FAILED=1\" tests/wpt-baselines/css-inline.env'"
+  }
+  new {
     name = "ci_wires_pkfire_affected_with_cache"
     description =
       "The GitHub Actions CI should restore the Pkl cache and compute heavy-gate booleans from pkfire affected output without duplicating core test execution."

--- a/tests/wpt-baselines/css-inline.env
+++ b/tests/wpt-baselines/css-inline.env
@@ -1,0 +1,6 @@
+MODULE=css-inline
+BASELINE_TOTAL=11
+BASELINE_PASSED=10
+BASELINE_FAILED=1
+BASELINE_UPDATED_AT=2026-05-30T00:00:00Z
+NOTE="Top-level css-inline suite exposed via the modulePrefixes [\"\"] entry in wpt.json (subdirectories model / parsing / initial-letter / baseline-source / text-box-trim / animation are follow-up). 10 of 11 layout-gradeable fixtures pass, including the empty-span strut tests fixed in #66 (empty-span-height / -size-001 / -002 / -scroll) and inheritance. The single failure inline-crash.html is a crashtest that browsers pass as 'no crash' but the layout-tree compare runner reports as a mismatch; it is quarantined in wpt.json knownFailures. Pins 10/11 as a no-regression gate; widening to the css-inline subdirectories is follow-up work."

--- a/wpt.json
+++ b/wpt.json
@@ -55,7 +55,14 @@
     // via the recursive modulePrefixes entry below. Widening to further
     // css-text properties is follow-up work.
     // See pkspec compat.css-text-baseline.
-    "css-text"
+    "css-text",
+
+    // Inline module. The global includePrefixes filter matches no inline
+    // fixtures, so the modulePrefixes entry below exposes the top-level
+    // css-inline suite (empty-span struts, inheritance, crashtests) to the
+    // layout-tree compare runner. Subdirectories (model, parsing,
+    // initial-letter, ...) are follow-up. See pkspec compat.css-inline-baseline.
+    "css-inline"
   ],
   "recursiveModules": [
     "css-align",
@@ -63,6 +70,9 @@
     "css-text"
   ],
   "modulePrefixes": {
+    "css-inline": [
+      ""
+    ],
     "css-ruby": [
       ""
     ],
@@ -116,7 +126,11 @@
       // "break-at-end-"
     ]
   },
-  "knownFailures": [],
+  "knownFailures": [
+    // css-inline crashtest: passes "no crash" in browsers but the layout-tree
+    // compare runner reports a mismatch; tracked as a css-inline residual.
+    "inline-crash.html"
+  ],
   "includePrefixes": [
     "align-", "place-",
     "align-content", "align-items", "align-self",


### PR DESCRIPTION
Enables the **css-inline** WPT module as a gated baseline, now that the empty-span strut work (#66) has landed. Relates to #65 (per-module baseline measurement umbrella); reifies `compat.css-inline-baseline`.

## Measured
Ran the full top-level css-inline suite against Chromium: **10 / 11 pass (91%)**, including the #66 strut fixtures (`empty-span-height` / `-size-001` / `-002` / `-scroll`) and `inheritance`. The lone failure is `inline-crash.html` — a crashtest browsers pass as "no crash" but the layout-tree compare runner flags as a mismatch.

## Changes
- **`wpt.json`**: add `"css-inline"` to `modules` + a `modulePrefixes: [""]` entry (the global `includePrefixes` match no inline filenames), exposing the top-level suite. Subdirectories (`model` / `parsing` / `initial-letter` / `baseline-source` / `text-box-trim` / `animation`) are follow-up. Quarantine `inline-crash.html` in `knownFailures`.
- **`tests/wpt-baselines/css-inline.env`**: pin `BASELINE_PASSED=10` / `BASELINE_FAILED=1` as a no-regression gate.
- **`specs/crater.pkl`**: `compat.css-inline-baseline` flipped `draft → approved`.
- **`specs/tasks.Test.pkl`**: implementingTest `wpt_css_inline_baseline_is_pinned`.
- **`TODO.md`**: drop the P0 row.

## Verified locally
`npx tsx scripts/wpt-runner.ts css-inline` → `Summary: 10 passed, 1 failed (1 known)`, **exit 0** (the quarantined crashtest doesn't fail the gate). Pattern `inline-crash.html` is precise (doesn't match `inline-crash-chrome-001.html`).

The CI `wpt-css` shard will now run css-inline (on the Chromium-provisioned workflow from #240).

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_