### PR TITLE
Split css-display VRT into three shards (#44)

### DIFF
--- a/scripts/wpt-vrt-shards.mjs
+++ b/scripts/wpt-vrt-shards.mjs
@@ -9,15 +9,19 @@
 //
 // CI #345 showed that moving early flexbox cases around changed VRT outcomes.
 // Keep the first 21 flexbox cases fixed, then split the tail where the current
-// runtime skew lives. Display stays split in half; css-box is split into three
+// runtime skew lives. Display is split into three contiguous shards (#44: it
+// was the ~22m single-shard bottleneck, then ~11m as two halves — three even
+// thirds keep each display shard under the ~10m target enforced by the
+// ci-timing-summary --max-shard-duration-sec gate). css-box is split into three
 // contiguous shards to dilute the heavy leading margin-trim cases.
 
 export const CI_WPT_VRT_SHARDS = Object.freeze([
   { name: "flexbox-1", modules: ["css-flexbox"], offset: 0, limit: 21 },
   { name: "flexbox-2", modules: ["css-flexbox"], offset: 21, limit: 9 },
   { name: "flexbox-3", modules: ["css-flexbox"], offset: 30, limit: 11 },
-  { name: "display-1", modules: ["css-display"], offset: 0, limit: 20 },
-  { name: "display-2", modules: ["css-display"], offset: 20, limit: 19 },
+  { name: "display-1", modules: ["css-display"], offset: 0, limit: 13 },
+  { name: "display-2", modules: ["css-display"], offset: 13, limit: 13 },
+  { name: "display-3", modules: ["css-display"], offset: 26, limit: 13 },
   { name: "box-1", modules: ["css-box"], offset: 0, limit: 10 },
   { name: "box-2", modules: ["css-box"], offset: 10, limit: 10 },
   { name: "box-3", modules: ["css-box"], offset: 20, limit: 8 },

--- a/scripts/wpt-vrt-shards.test.ts
+++ b/scripts/wpt-vrt-shards.test.ts
@@ -56,7 +56,7 @@ describe("CI_WPT_VRT_SHARDS", () => {
     );
   });
 
-  it("splits css-display into two balanced shards", () => {
+  it("splits css-display into three balanced shards", () => {
     const entries = collectWptVrtTests(loadWptVrtConfig()).filter((entry) =>
       entry.moduleName === "css-display"
     );
@@ -67,14 +67,22 @@ describe("CI_WPT_VRT_SHARDS", () => {
     expect(displayShards.map((shard) => shard.name)).toEqual([
       "display-1",
       "display-2",
+      "display-3",
     ]);
 
     const selectedPathsByShard = displayShards.map((shard) =>
       selectEntriesForShard(entries, shard).map((entry) => entry.relativePath)
     );
-    expect(selectedPathsByShard.map((paths) => paths.length)).toEqual([20, 19]);
+    // 39 css-display fixtures split into even thirds (#44).
+    expect(selectedPathsByShard.map((paths) => paths.length)).toEqual([13, 13, 13]);
     expect(selectedPathsByShard[0]).toContain(
-      "css-display/display-contents-details-001.html",
+      "css-display/display-change-iframe.html",
+    );
+    expect(selectedPathsByShard[1]).toContain(
+      "css-display/display-contents-dynamic-before-after-001.html",
+    );
+    expect(selectedPathsByShard[2]).toContain(
+      "css-display/display-contents-dynamic-multicol-001-inline.html",
     );
   });
 
@@ -112,6 +120,7 @@ describe("CI_WPT_VRT_SHARDS", () => {
       "flexbox-3",
       "display-1",
       "display-2",
+      "display-3",
       "box-1",
       "box-2",
       "box-3",


### PR DESCRIPTION
Partial progress on #44 (VRT shards dominating CI wall time).

## Change
Split **css-display** VRT from 2 shards into 3. It was the ~22m single-shard bottleneck in #44's referenced run; the existing 2-way split left each half ~11m — still over the 10m target the `ci-timing-summary --max-shard-duration-sec 600` gate already warns on. The 39 css-display fixtures now split into even contiguous thirds (13/13/13), so each display shard should land around ~7m.

- `scripts/wpt-vrt-shards.mjs`: `display-1/2/3` at offsets 0/13/26 (limit 13 each).
- `scripts/wpt-vrt-shards.test.ts`: updated to assert three balanced display shards + the new matrix names; all 5 shard tests pass.

The split is **contiguous** (alphabetical order preserved) — it only regroups fixtures across more parallel jobs without reordering, which avoids the #345 reorder-sensitivity class of issue. The CI matrix is generated from `CI_WPT_VRT_SHARDS`, so `display-3` flows into the `playwright-wpt-vrt` matrix automatically (verified locally).

## Context / what this does *not* do
- This is **incremental** — it does not close #44. The other ~21m job, `playwright-paint-vrt`, is **already sharded five ways** (fixtures-a1/a2/b, realworld, url); rebalancing it needs per-shard timing data, which the existing `ci-timing-summary` artifact now captures for a future data-driven pass.
- The timing target + drift warning + artifact the issue asks for are **already implemented** (`scripts/ci-timing-summary.ts`, `--max-shard-duration-sec 600`).

Validation note: needs a `vrt`-labeled CI run to confirm the new shard timings land under target and display outcomes are unchanged.

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_