### PR TITLE
flaker: extend paint-vrt-real-world-ci-latency quarantine to 2026-06-30 (#79)

### DIFF
--- a/flaker-quarantine.json
+++ b/flaker-quarantine.json
@@ -35,10 +35,10 @@
       "mode": "skip",
       "scope": "environment",
       "owner": "mizchi",
-      "reason": "Actual paint export for the largest real-world snapshots currently exceeds CI latency budget.",
+      "reason": "Actual paint export for the largest real-world snapshots currently exceeds CI latency budget. Extended to 2026-06-30 (aligned with the other paint-vrt entries) per GitHub issue #79: the substantive fix (commit playwright-intro / mdn-wasm-text snapshots and split the slow shard, or speed up capturePaintData) plus an expired-quarantine CI gate are tracked there and not yet done.",
       "condition": "Skip only on CI until capturePaintData latency is reduced or the fixture is split.",
       "introducedAt": "2026-04-14",
-      "expiresAt": "2026-05-31"
+      "expiresAt": "2026-06-30"
     }
   ]
 }


### PR DESCRIPTION
Partial action on #79 — the time-sensitive part.

The `paint-vrt-real-world-ci-latency` quarantine entry was set to `expiresAt: "2026-05-31"` (tomorrow), while the other two `paint-vrt` entries already run to `2026-06-30`. None of #79's substantive acceptance items are done:
- `playwright-intro` / `mdn-wasm-text` snapshots are still not committed (so the fixture-split option can't be enabled),
- there is no CI gate that fails on `status==expired`,
- there is no `.flaker/data.duckdb` cache/artifact persistence.

With no enforcement gate, the entry would just silently lapse at expiry. This extends it to the shared `2026-06-30` review date **with a written reason pointing at #79**, so all three paint-vrt entries share one date and the deadline is off the critical path.

The real fix (commit the two snapshots + split the slow shard, or speed up `capturePaintData`) and the expired-quarantine gate remain tracked in #79.

JSON validated; `flaker-quarantine` + `flaker-quarantine-expiry` tests pass (9/9).

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_