### PR TITLE
filter on inline elements establishes an abs containing block in placement (#64)

### DIFF
--- a/renderer/renderer/absolute_position_test.mbt
+++ b/renderer/renderer/absolute_position_test.mbt
@@ -948,3 +948,37 @@ test "position relative with negative offset" {
   inspect(inner.x, content="-40")
   inspect(inner.y, content="-20")
 }
+
+///|
+/// Regression (#64): `filter` on an inline element establishes a containing
+/// block for its absolutely-positioned descendants. Previously the renderer's
+/// establishes_absolute_containing_block ignored filter (it only checked
+/// position / containment / transform), so an abspos child with top:0/left:0
+/// was placed relative to an ancestor instead of the filtered inline box.
+test "filter_on_inline_establishes_abs_containing_block" {
+  let html_filter =
+    #|<p>Filler text.</p>
+    #|<div><span id="cb" style="filter: brightness(100%)">corner text<span id="abspos" style="position:absolute; top:0; left:0; width:10px; height:10px"></span></span></div>
+  let html_rel =
+    #|<p>Filler text.</p>
+    #|<div><span id="cb" style="position:relative; filter: brightness(100%)">corner text<span id="abspos" style="position:absolute; top:0; left:0; width:10px; height:10px"></span></span></div>
+  let ctx : @renderer.RenderContext = {
+    viewport_width: 800.0,
+    viewport_height: 600.0,
+    root_font_size: 16.0,
+    color_scheme: @css.ColorScheme::Light,
+  }
+  let lf = @renderer.render(html_filter, ctx)
+  let lr = @renderer.render(html_rel, ctx)
+  let cb_f = lf.children[1].children[0]
+  let cb_r = lr.children[1].children[0]
+  let abspos_f = cb_f.children[cb_f.children.length() - 1]
+  let abspos_r = cb_r.children[cb_r.children.length() - 1]
+  // top:0/left:0 relative to #cb -> child lands at the CB origin (0,0), not
+  // pushed up to an ancestor baseline.
+  inspect(abspos_f.x, content="0")
+  inspect(abspos_f.y, content="0")
+  // The filtered CB places the child identically to the relative CB.
+  assert_eq(abspos_f.x, abspos_r.x)
+  assert_eq(abspos_f.y, abspos_r.y)
+}

--- a/renderer/renderer/absolute_positioning.mbt
+++ b/renderer/renderer/absolute_positioning.mbt
@@ -122,6 +122,7 @@ fn establishes_absolute_containing_block(node : @node.Node) -> Bool {
   positioned ||
   containment_establishes_cb ||
   !style.transform.is_none() ||
+  style.has_filter ||
   is_svg_container_id(node.id)
 }
 


### PR DESCRIPTION
Partial fix for #64 — resolves the **cb-abspos containing-block geometry** (the x/y mismatch), one line + a regression test.

## Root cause
`Style.has_filter` already feeds the **layout-side** CB checks (`establishes_abs_containing_block` in `layout/block`, `inline_establishes_abs_containing_block` in `layout/inline`). But the **renderer's** `establishes_absolute_containing_block` (`renderer/renderer/absolute_positioning.mbt:111`) — which decides which ancestor an abspos descendant's `top`/`left` resolve against — only checked `position` / containment / `transform`, **not** filter.

So an abspos child of a filtered inline element resolved its `top:0/left:0` against an ancestor instead of the filtered box. Diagnosed value: in `filter-cb-abspos-inline-001` the child's local `y` was `-43.2` (offset by a line-height) instead of `0`.

## Fix
Add `|| style.has_filter` to the renderer's CB predicate, mirroring the layout side.

Result on the three WPT tests: the `span#abspos.y` (and `.x` in `-003`) mismatches are **resolved** — the abspos child now lands at the filtered inline box origin, identical to the `position:relative` reference.

## Honest scope note
The three tests still don't fully pass, and the `filter-effects` module count is unchanged (94/106 before and after). The remaining diff is `span#cb.width` (`440` vs `529.8`) — **text measurement, filter-independent**: the `position:relative` `-ref.html` shows the *same* width delta, so it's a glyph-metrics issue (#47-class), not a containing-block one. This PR fixes the CB geometry that #64's "minimal fix scope" was about; the width residual is separate.

## Validation
- Renderer regression test: a filtered inline box places its `top:0/left:0` abspos child at `(0,0)`, identical to the relative-CB case. Renderer suite **383 passed**.
- Layout suite: only the pre-existing unrelated sixel failure.
- `filter-effects` module: no regression (94/106 unchanged).

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_