### PR TITLE
wpt: render full document (skeleton-disabled) in the WPT runner

### DIFF
--- a/conformance/wpt/wpt_runtime.mbt
+++ b/conformance/wpt/wpt_runtime.mbt
@@ -13,6 +13,14 @@ pub fn renderHtmlToJsonForWpt(
     root_font_size: 16.0,
     color_scheme: @css.ColorScheme::Light,
   }
-  let layout = @renderer.render(html, ctx)
+  // Render the full document with viewport-skeleton culling disabled. The
+  // skeleton optimization replaces below-the-fold content with lightweight
+  // placeholder nodes once the node count or estimated Y exceeds a threshold —
+  // valid for live viewport rendering, but the WPT runner compares the whole
+  // layout tree against a browser that lays out the entire document, so
+  // skeletonized nodes (collapsed to height 0) produce spurious mismatches on
+  // large fixtures (e.g. css-overflow/overflow-alignment-* has 126 scroll cells
+  // × a 9-box float grid, well over the 2000-node cutoff).
+  let (_, layout) = @renderer.render_to_node_and_layout_full_document(html, ctx)
   @renderer.layout_to_json(layout)
 }

--- a/conformance/wpt/wpt_runtime_wbtest.mbt
+++ b/conformance/wpt/wpt_runtime_wbtest.mbt
@@ -1,0 +1,24 @@
+///|
+/// Regression (#64 review / css-overflow): renderHtmlToJsonForWpt must render
+/// the full document with viewport-skeleton culling disabled. The skeleton
+/// optimization collapses below-the-fold content to height 0 once the node
+/// count exceeds ~2000, which produced spurious WPT mismatches on large
+/// fixtures (the whole layout tree is compared against a browser that lays out
+/// the entire document). This builds a >2000-node document and asserts the
+/// last element keeps its real height rather than being skeletonized to 0.
+test "renderHtmlToJsonForWpt renders full document without skeleton culling" {
+  let buf = StringBuilder::new()
+  buf.write_string(
+    "<style>.row{height:10px;width:100px}#last{height:33px;width:55px}</style><body>",
+  )
+  // Emit well over the 2000-node skeleton cutoff.
+  for i = 0; i < 2600; i = i + 1 {
+    buf.write_string("<div class=\"row\"></div>")
+  }
+  buf.write_string("<div id=\"last\"></div></body>")
+  let json = renderHtmlToJsonForWpt(buf.to_string(), 800, 600)
+  // The trailing #last div must survive with its explicit 33px height — if the
+  // skeleton path were active it would collapse to "height":0.
+  inspect(json.contains("\"height\":33"), content="true")
+  inspect(json.contains("\"width\":55"), content="true")
+}


### PR DESCRIPTION
Found while drilling into the `css-overflow` WPT failures (overflow-alignment cluster). This is a **WPT-runner accuracy fix that improves every module**, not specific to one issue — `css-overflow` gains **+20 passing tests** with no regression anywhere.

## Root cause
`renderHtmlToJsonForWpt` (the entry point the WPT runner calls) used `@renderer.render`, which leaves **viewport-skeleton culling enabled**. That optimization replaces below-the-fold content with lightweight placeholder nodes — collapsed to height 0 — once the node count exceeds ~2000 (or estimated Y exceeds the cutoff). It's correct for live viewport rendering, but **wrong for the WPT runner**, which compares the *entire* layout tree against a browser that lays out the whole document.

I confirmed it by elimination: `css-overflow/overflow-alignment-block-001` reported `div.test[105]/.../div.tl.width = 72, height = 0` while the renderer in isolation produces the correct `24×24` for every variant I could build (bare float grid, vertical writing modes, inside scroll cell, all `place-content` values, empty divs, table cells). The only difference was scale: the real fixture has **126 scroll cells × a 9-box float grid (~1100+ nodes plus table chrome)**, pushing past the 2000-node cutoff, so the tail of the document was skeletonized.

## Fix
Switch the WPT entry point to `render_to_node_and_layout_full_document` (skeleton disabled). One line.

## Measured effect
- **css-overflow: 209 → 229 passed (+20)** — the entire `overflow-alignment-*` cluster (17 tests) plus 3 related.
- **No regression**: `css-box` (30/0) and `css-position` (84/0) strict modules stay green; `css-flexbox` (267/22) and `css-grid` (31/2) are identical before/after.

## Test
Adds a conformance regression test: a >2600-node document keeps its trailing element's explicit `height:33px` instead of collapsing to 0. Verified it **fails** if the skeleton path is restored (1031→1030).

Note: this renders the full tree for WPT, so very large fixtures take longer — acceptable since the WPT runner's purpose is layout-accuracy comparison, and the browser side already lays out the whole document.

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_