### PR TITLE
deps: bump mizchi/css to 0.4.2 (mixed calc unblocks #67 block cases)

### DIFF
--- a/benchmarks/moon.mod
+++ b/benchmarks/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-browser@0.18.0",
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/benchmarks/moon.mod
+++ b/benchmarks/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-browser@0.18.0",
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/browser/moon.mod
+++ b/browser/moon.mod
@@ -6,7 +6,7 @@ import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
   "mizchi/crater-dom@0.18.0",
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",
   "mizchi/crater-renderer@0.18.0",

--- a/browser/moon.mod
+++ b/browser/moon.mod
@@ -6,7 +6,7 @@ import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
   "mizchi/crater-dom@0.18.0",
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",
   "mizchi/crater-renderer@0.18.0",

--- a/browser_helpers/moon.mod
+++ b/browser_helpers/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-renderer@0.18.0",
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-aomx@0.18.0",
 }

--- a/browser_helpers/moon.mod
+++ b/browser_helpers/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-renderer@0.18.0",
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-aomx@0.18.0",
 }

--- a/conformance/moon.mod.json
+++ b/conformance/moon.mod.json
@@ -6,7 +6,7 @@
       "path": "../core",
       "version": "0.18.0"
     },
-    "mizchi/css": "0.2.0",
+    "mizchi/css": "0.4.1",
     "mizchi/crater-layout": {
       "path": "../layout",
       "version": "0.18.0"

--- a/conformance/moon.mod.json
+++ b/conformance/moon.mod.json
@@ -6,7 +6,7 @@
       "path": "../core",
       "version": "0.18.0"
     },
-    "mizchi/css": "0.4.1",
+    "mizchi/css": "0.4.2",
     "mizchi/crater-layout": {
       "path": "../layout",
       "version": "0.18.0"

--- a/core/moon.mod
+++ b/core/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-core"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/core/moon.mod
+++ b/core/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-core"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/dom/moon.mod
+++ b/dom/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-layout@0.18.0",
 }
 

--- a/dom/moon.mod
+++ b/dom/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-layout@0.18.0",
 }
 

--- a/js/moon.mod
+++ b/js/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/js/moon.mod
+++ b/js/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/layout/moon.mod
+++ b/layout/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 description = "Layout kernel for crater CSS layout engine"
 
 import {
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-core@0.18.0",
   "mizchi/layout@0.2.0",
 }

--- a/layout/moon.mod
+++ b/layout/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 description = "Layout kernel for crater CSS layout engine"
 
 import {
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-core@0.18.0",
   "mizchi/layout@0.2.0",
 }

--- a/moon.mod
+++ b/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-webvitals@0.18.0",

--- a/moon.mod
+++ b/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-webvitals@0.18.0",

--- a/painter/moon.mod
+++ b/painter/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-painter"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-terminal-protocol@0.18.0",
   "mizchi/font@0.7.3",

--- a/painter/moon.mod
+++ b/painter/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-painter"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-terminal-protocol@0.18.0",
   "mizchi/font@0.7.3",

--- a/renderer/moon.mod
+++ b/renderer/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/renderer/moon.mod
+++ b/renderer/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/testing/moon.mod
+++ b/testing/moon.mod
@@ -7,7 +7,7 @@ import {
   "mizchi/crater-browser@0.18.0",
   "mizchi/crater-browser-native@0.18.0",
   "mizchi/crater-browser-runtime@0.18.0",
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
 }

--- a/testing/moon.mod
+++ b/testing/moon.mod
@@ -7,7 +7,7 @@ import {
   "mizchi/crater-browser@0.18.0",
   "mizchi/crater-browser-native@0.18.0",
   "mizchi/crater-browser-runtime@0.18.0",
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
 }

--- a/webdriver/moon.mod
+++ b/webdriver/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webdriver-bidi"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-network@0.18.0",
   "mizchi/font@0.7.3",

--- a/webdriver/moon.mod
+++ b/webdriver/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webdriver-bidi"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-network@0.18.0",
   "mizchi/font@0.7.3",

--- a/webvitals/moon.mod
+++ b/webvitals/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webvitals"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.1",
+  "mizchi/css@0.4.2",
   "mizchi/crater-core@0.18.0",
 }
 

--- a/webvitals/moon.mod
+++ b/webvitals/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webvitals"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.3.2",
+  "mizchi/css@0.4.1",
   "mizchi/crater-core@0.18.0",
 }
 


### PR DESCRIPTION
Bumps `mizchi/css` **0.3.2 → 0.4.2** across the workspace (and `conformance/moon.mod.json` 0.2.0 → 0.4.2), unblocking the mixed-`calc()` half of #67.

## What the bump brings (measured)
0.4.x adds `Dimension::Calc(px, percent)` and **generates it from mixed `calc()`** in the computed-value path (`compute.mbt`), instead of 0.3.2's "mixed → `Auto`" collapse. Crater's layout already had the `Calc` match arms wired (`layout/table/table.mbt:435`, `layout/absolute/absolute.mbt`, …), so the bump alone recovers the **block** mixed-calc tests:

| test | 0.3.2 | 0.4.x |
|---|---|---|
| `calc-max-width-block-intrinsic-1` | ✗ (Auto) | ✓ |
| `calc-min-width-block-intrinsic-1` | — | ✓ |
| `calc-max-width-block-1` | — | ✓ |
| `calc-width-block-1` | — | ✓ |

0.4.2 is a compatible follow-up to 0.4.1 (no css-values WPT change — 254/350 on both; its fixes land elsewhere, e.g. web-animations).

## Build / regression
Full build green across layout / renderer / dom / conformance (0 errors — `Calc` doesn't break any Crater `Dimension` match). Layout suite 3480/3481 (the one failure is the pre-existing unrelated sixel test); renderer 383/383.

## Still open (follow-ups, not in this PR)
- **#67 table calc** (`calc-width-table-{auto,fixed}-1`, `calc-height-table-1`): the mixed calc resolves, but crater's table-layout (fixed/auto column widths + `<table border>` width) doesn't yet thread the `calc()` % basis correctly. Crater-side table wiring — separate PR.
- **#68 border longhand cascade** (`gradients-with-border`): still fails (border-box 220 vs 310) — the `border-*-width`-longhand-over-`border`-shorthand fix is not in 0.4.x; that part of #68 remains upstream.
- **Web Animations**: 0.4.x adds a `mizchi/css/src/animation/` module (`EffectTiming`, `NumericKeyframeEffect`, sampling). Crater does not import it yet — a foundation for a future `element.animate` API, not wired here.

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD