### PR TITLE
css 0.4.4 + apply cascaded declarations in source order (fixes #68 border longhand)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,15 +105,15 @@ jobs:
         uses: ./.github/actions/moon-prefetch
         with:
           manifests: |
-            js/moon.mod.json
-            browser/moon.mod.json
-            browser/native/moon.mod.json
-            wasm/moon.mod.json
+            js/moon.mod
+            browser/moon.mod
+            browser/native/moon.mod
+            wasm/moon.mod
 
       - name: Prefetch rusty_v8 source binding
         uses: ./.github/actions/rusty-v8-prefetch
         with:
-          cache-extra-key: ${{ hashFiles('browser/native/moon.mod.json', 'webdriver/moon.mod.json') }}
+          cache-extra-key: ${{ hashFiles('browser/native/moon.mod', 'webdriver/moon.mod') }}
 
       - name: Check code
         run: just check
@@ -179,7 +179,7 @@ jobs:
         uses: ./.github/actions/moon-prefetch
         with:
           manifests: |
-            js/moon.mod.json
+            js/moon.mod
 
       - name: Build js package
         run: pnpm run build
@@ -211,7 +211,7 @@ jobs:
         uses: ./.github/actions/moon-prefetch
         with:
           manifests: |
-            wasm/moon.mod.json
+            wasm/moon.mod
 
       # Tracking issue #227: MoonBit 0.1.20260522 nightly broke the
       # wit-bindgen cabi_realloc -> $moonbit.gc.malloc path, so the
@@ -280,7 +280,7 @@ jobs:
         uses: ./.github/actions/moon-prefetch
         with:
           manifests: |
-            wasm/moon.mod.json
+            wasm/moon.mod
 
       - name: Build WASM
         run: just build-wasm && just transpile-wasm
@@ -340,7 +340,7 @@ jobs:
         uses: ./.github/actions/moon-prefetch
         with:
           manifests: |
-            browser/moon.mod.json
+            browser/moon.mod
 
       - name: Run WPT DOM shard
         run: |
@@ -440,14 +440,14 @@ jobs:
         uses: ./.github/actions/moon-prefetch
         with:
           manifests: |
-            browser/moon.mod.json
-            webdriver/moon.mod.json
-            testing/moon.mod.json
+            browser/moon.mod
+            webdriver/moon.mod
+            testing/moon.mod
 
       - name: Prefetch rusty_v8 source binding
         uses: ./.github/actions/rusty-v8-prefetch
         with:
-          cache-extra-key: ${{ hashFiles('browser/native/moon.mod.json', 'webdriver/moon.mod.json') }}
+          cache-extra-key: ${{ hashFiles('browser/native/moon.mod', 'webdriver/moon.mod') }}
 
       - name: Build BiDi server
         run: |
@@ -528,13 +528,13 @@ jobs:
         uses: ./.github/actions/moon-prefetch
         with:
           manifests: |
-            browser/moon.mod.json
-            webdriver/moon.mod.json
+            browser/moon.mod
+            webdriver/moon.mod
 
       - name: Prefetch rusty_v8 source binding
         uses: ./.github/actions/rusty-v8-prefetch
         with:
-          cache-extra-key: ${{ hashFiles('browser/native/moon.mod.json', 'webdriver/moon.mod.json') }}
+          cache-extra-key: ${{ hashFiles('browser/native/moon.mod', 'webdriver/moon.mod') }}
 
       - name: Build BiDi server
         run: bash scripts/ci/run-moon-step.sh bidi-build moon -C webdriver build bidi_main --target js --release -j 1
@@ -770,13 +770,13 @@ jobs:
         uses: ./.github/actions/moon-prefetch
         with:
           manifests: |
-            browser/moon.mod.json
-            webdriver/moon.mod.json
+            browser/moon.mod
+            webdriver/moon.mod
 
       - name: Prefetch rusty_v8 source binding
         uses: ./.github/actions/rusty-v8-prefetch
         with:
-          cache-extra-key: ${{ hashFiles('browser/native/moon.mod.json', 'webdriver/moon.mod.json') }}
+          cache-extra-key: ${{ hashFiles('browser/native/moon.mod', 'webdriver/moon.mod') }}
 
       - name: Build BiDi server
         run: bash scripts/ci/run-moon-step.sh bidi-build moon -C webdriver build bidi_main --target js --release -j 1
@@ -1024,13 +1024,13 @@ jobs:
         uses: ./.github/actions/moon-prefetch
         with:
           manifests: |
-            browser/moon.mod.json
-            webdriver/moon.mod.json
+            browser/moon.mod
+            webdriver/moon.mod
 
       - name: Prefetch rusty_v8 source binding
         uses: ./.github/actions/rusty-v8-prefetch
         with:
-          cache-extra-key: ${{ hashFiles('browser/native/moon.mod.json', 'webdriver/moon.mod.json') }}
+          cache-extra-key: ${{ hashFiles('browser/native/moon.mod', 'webdriver/moon.mod') }}
 
       - name: Build BiDi server
         run: bash scripts/ci/run-moon-step.sh bidi-build moon -C webdriver build bidi_main --target js --release -j 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,7 @@ jobs:
   wpt-css-tests:
     name: wpt-css (${{ matrix.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [wasm-component, affected]
     if: >-
       always()
@@ -294,7 +295,8 @@ jobs:
       # poisoned cache entry can never skip it.
       - name: Install Chromium (Playwright) for the WPT runner
         continue-on-error: ${{ matrix.soft_fail }}
-        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 25
+        run: bash scripts/ci/install-playwright-chromium.sh
 
       - name: Point Puppeteer at the Playwright Chromium
         continue-on-error: ${{ matrix.soft_fail }}
@@ -498,6 +500,7 @@ jobs:
 
   playwright-bidi-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -522,7 +525,8 @@ jobs:
 
       - name: Install Playwright Chromium browser
         if: steps.playwright_bidi_playwright_cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 25
+        run: bash scripts/ci/install-playwright-chromium.sh
 
       - name: Prefetch MoonBit dependencies
         uses: ./.github/actions/moon-prefetch
@@ -683,6 +687,7 @@ jobs:
   playwright-paint-vrt:
     name: paint-vrt (${{ matrix.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [affected]
     if: >-
       always()
@@ -761,7 +766,8 @@ jobs:
 
       - name: Install Playwright browsers for VRT
         if: steps.paint_vrt_playwright_cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 25
+        run: bash scripts/ci/install-playwright-chromium.sh
 
       - name: Install compatible fonts for VRT
         run: bash scripts/ci/install-compatible-fonts.sh
@@ -982,6 +988,7 @@ jobs:
   playwright-wpt-vrt:
     name: wpt-vrt (${{ matrix.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: wpt-vrt-matrix
     strategy:
       fail-fast: false
@@ -1015,7 +1022,8 @@ jobs:
 
       - name: Install Playwright browsers for VRT
         if: steps.wpt_vrt_playwright_cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 25
+        run: bash scripts/ci/install-playwright-chromium.sh
 
       - name: Install compatible fonts for VRT
         run: bash scripts/ci/install-compatible-fonts.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,9 +291,23 @@ jobs:
       # Chromium with Playwright instead — the VRT jobs already depend on this
       # path, and `--with-deps` brings the system libraries headless Chrome
       # needs to launch — then point puppeteer at that binary via
-      # PUPPETEER_EXECUTABLE_PATH. Runs unconditionally (no cache gate) so a
-      # poisoned cache entry can never skip it.
+      # PUPPETEER_EXECUTABLE_PATH.
+      #
+      # Restore the browser binary from cache and only download on a miss, the
+      # same pattern the playwright-bidi and paint-vrt jobs use. The strict
+      # (soft_fail: false) shards previously ran the download unconditionally on
+      # every run; the bare `playwright install` network path stalled past all
+      # three retry attempts and failed the gate even though nothing in the PR
+      # touched CSS. Caching removes that per-run network dependency.
+      - name: Restore Playwright Chromium browser cache
+        id: wpt_css_playwright_cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
+
       - name: Install Chromium (Playwright) for the WPT runner
+        if: steps.wpt_css_playwright_cache.outputs.cache-hit != 'true'
         continue-on-error: ${{ matrix.soft_fail }}
         timeout-minutes: 25
         run: bash scripts/ci/install-playwright-chromium.sh

--- a/.github/workflows/flaker-daily.yml
+++ b/.github/workflows/flaker-daily.yml
@@ -87,6 +87,7 @@ jobs:
     needs: batch-plan
     if: ${{ fromJson(needs.batch-plan.outputs.matrix).include[0] != null }}
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.batch-plan.outputs.matrix) }}
@@ -152,7 +153,8 @@ jobs:
         working-directory: metric-ci
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 25
+        run: bash scripts/ci/install-playwright-chromium.sh
 
       - name: Update MoonBit dependencies
         run: |

--- a/benchmarks/moon.mod
+++ b/benchmarks/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-browser@0.18.0",
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/benchmarks/moon.mod
+++ b/benchmarks/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-browser@0.18.0",
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/benchmarks/moon.mod
+++ b/benchmarks/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-browser@0.18.0",
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/browser/moon.mod
+++ b/browser/moon.mod
@@ -6,7 +6,7 @@ import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
   "mizchi/crater-dom@0.18.0",
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",
   "mizchi/crater-renderer@0.18.0",

--- a/browser/moon.mod
+++ b/browser/moon.mod
@@ -6,7 +6,7 @@ import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
   "mizchi/crater-dom@0.18.0",
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",
   "mizchi/crater-renderer@0.18.0",

--- a/browser/moon.mod
+++ b/browser/moon.mod
@@ -6,7 +6,7 @@ import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
   "mizchi/crater-dom@0.18.0",
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",
   "mizchi/crater-renderer@0.18.0",

--- a/browser_helpers/moon.mod
+++ b/browser_helpers/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-renderer@0.18.0",
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-aomx@0.18.0",
 }

--- a/browser_helpers/moon.mod
+++ b/browser_helpers/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-renderer@0.18.0",
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-aomx@0.18.0",
 }

--- a/browser_helpers/moon.mod
+++ b/browser_helpers/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-renderer@0.18.0",
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-aomx@0.18.0",
 }

--- a/conformance/moon.mod.json
+++ b/conformance/moon.mod.json
@@ -6,7 +6,7 @@
       "path": "../core",
       "version": "0.18.0"
     },
-    "mizchi/css": "0.4.4",
+    "mizchi/css": "0.4.5",
     "mizchi/crater-layout": {
       "path": "../layout",
       "version": "0.18.0"

--- a/conformance/moon.mod.json
+++ b/conformance/moon.mod.json
@@ -6,7 +6,7 @@
       "path": "../core",
       "version": "0.18.0"
     },
-    "mizchi/css": "0.4.3",
+    "mizchi/css": "0.4.4",
     "mizchi/crater-layout": {
       "path": "../layout",
       "version": "0.18.0"

--- a/conformance/moon.mod.json
+++ b/conformance/moon.mod.json
@@ -6,7 +6,7 @@
       "path": "../core",
       "version": "0.18.0"
     },
-    "mizchi/css": "0.4.2",
+    "mizchi/css": "0.4.3",
     "mizchi/crater-layout": {
       "path": "../layout",
       "version": "0.18.0"

--- a/core/layout_view/pkg.generated.mbti
+++ b/core/layout_view/pkg.generated.mbti
@@ -16,13 +16,13 @@ pub(all) enum ResourceLoadState {
 
 // Traits
 pub(open) trait LayoutView {
-  uid(Self) -> Int
-  computed_x(Self) -> Double
-  computed_y(Self) -> Double
-  computed_width(Self) -> Double
-  computed_height(Self) -> Double
-  children(Self) -> Array[Self]
-  text(Self) -> String?
-  resource_state(Self) -> ResourceLoadState?
+  fn uid(Self) -> Int
+  fn computed_x(Self) -> Double
+  fn computed_y(Self) -> Double
+  fn computed_width(Self) -> Double
+  fn computed_height(Self) -> Double
+  fn children(Self) -> Array[Self]
+  fn text(Self) -> String?
+  fn resource_state(Self) -> ResourceLoadState?
 }
 

--- a/core/moon.mod
+++ b/core/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-core"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/core/moon.mod
+++ b/core/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-core"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/core/moon.mod
+++ b/core/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-core"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/dom/moon.mod
+++ b/dom/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-layout@0.18.0",
 }
 

--- a/dom/moon.mod
+++ b/dom/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-layout@0.18.0",
 }
 

--- a/dom/moon.mod
+++ b/dom/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-layout@0.18.0",
 }
 

--- a/http/cache/pkg.generated.mbti
+++ b/http/cache/pkg.generated.mbti
@@ -60,9 +60,9 @@ pub impl HttpCacheBackend for MemoryCacheBackend
 
 // Traits
 pub(open) trait HttpCacheBackend {
-  lookup(Self, String) -> CacheEntry?
-  store(Self, CacheEntry) -> Unit
-  remove(Self, String) -> Unit
-  clear(Self) -> Unit
+  fn lookup(Self, String) -> CacheEntry?
+  fn store(Self, CacheEntry) -> Unit
+  fn remove(Self, String) -> Unit
+  fn clear(Self) -> Unit
 }
 

--- a/js/moon.mod
+++ b/js/moon.mod
@@ -10,7 +10,6 @@ import {
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",
   "mizchi/crater-renderer@0.18.0",
-  "mizchi/crater-terminal-image-cache@0.18.0",
 }
 
 readme = "README.md"

--- a/js/moon.mod
+++ b/js/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/js/moon.mod
+++ b/js/moon.mod
@@ -10,6 +10,7 @@ import {
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",
   "mizchi/crater-renderer@0.18.0",
+  "mizchi/crater-terminal-image-cache@0.18.0",
 }
 
 readme = "README.md"

--- a/js/moon.mod
+++ b/js/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/js/moon.mod
+++ b/js/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/layout/moon.mod
+++ b/layout/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 description = "Layout kernel for crater CSS layout engine"
 
 import {
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-core@0.18.0",
   "mizchi/layout@0.2.0",
 }

--- a/layout/moon.mod
+++ b/layout/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 description = "Layout kernel for crater CSS layout engine"
 
 import {
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-core@0.18.0",
   "mizchi/layout@0.2.0",
 }

--- a/layout/moon.mod
+++ b/layout/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 description = "Layout kernel for crater CSS layout engine"
 
 import {
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-core@0.18.0",
   "mizchi/layout@0.2.0",
 }

--- a/moon.mod
+++ b/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-webvitals@0.18.0",

--- a/moon.mod
+++ b/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-webvitals@0.18.0",

--- a/moon.mod
+++ b/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-webvitals@0.18.0",

--- a/painter/moon.mod
+++ b/painter/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-painter"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-terminal-protocol@0.18.0",
   "mizchi/font@0.7.3",

--- a/painter/moon.mod
+++ b/painter/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-painter"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-terminal-protocol@0.18.0",
   "mizchi/font@0.7.3",

--- a/painter/moon.mod
+++ b/painter/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-painter"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-terminal-protocol@0.18.0",
   "mizchi/font@0.7.3",

--- a/painter/paint/raster/pkg.generated.mbti
+++ b/painter/paint/raster/pkg.generated.mbti
@@ -69,6 +69,7 @@ pub struct Framebuffer {
   height : Int
   pixels : Array[Int]
 }
+pub fn Framebuffer::crop(Self, Int, Int, Int, Int) -> Self
 pub fn Framebuffer::draw_char(Self, Int, Int, Char, Int, Int) -> Int
 pub fn Framebuffer::draw_text(Self, Int, Int, String, Int, Int, Int) -> Int
 pub fn Framebuffer::fill_rect(Self, Int, Int, Int, Int, Int) -> Unit

--- a/renderer/moon.mod
+++ b/renderer/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/renderer/moon.mod
+++ b/renderer/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/renderer/moon.mod
+++ b/renderer/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/renderer/renderer/style_property_render_test.mbt
+++ b/renderer/renderer/style_property_render_test.mbt
@@ -102,3 +102,26 @@ test "visually hidden element should be skipped" {
   inspect(a_node.style.width, content="Length(1)")
   inspect(a_node.style.height, content="Length(1)")
 }
+
+///|
+/// Regression (#68): stylesheet declarations must be applied in CSS source
+/// order, so a higher-specificity `border-left-width` longhand overrides an
+/// earlier `border` shorthand instead of being clobbered by it. Crater used to
+/// apply cascaded values in hash-map order (CascadedValues::each), which lost
+/// source order for shorthand/longhand interplay.
+test "stylesheet border longhand overrides shorthand in source order" {
+  let html =
+    #|<style>.test { width: 200px; height: 100px; border: solid 10px; } #g { border-left-width: 100px; }</style>
+    #|<div id="g" class="test">x</div>
+  let ctx : @renderer.RenderContext = {
+    viewport_width: 800.0,
+    viewport_height: 600.0,
+    root_font_size: 16.0,
+    color_scheme: @css.ColorScheme::Light,
+  }
+  let d = @renderer.render(html, ctx).children[0]
+  // border-box width = 200 content + 100 left border + 10 right border = 310
+  inspect(d.border.left, content="100")
+  inspect(d.border.right, content="10")
+  inspect(d.width, content="310")
+}

--- a/renderer/renderer/style_resolve.mbt
+++ b/renderer/renderer/style_resolve.mbt
@@ -998,26 +998,39 @@ fn compute_element_style_indexed(
         }
       }
 
-      // Apply remaining cascaded values
+      // Apply remaining cascaded values.
+      // CascadedValues::each iterates in hash-map order, which does not
+      // preserve CSS source order. Shorthand/longhand interplay (e.g.
+      // `border: solid 10px` in one rule and `border-left-width: 100px` in a
+      // higher-specificity rule) requires applying declarations in source
+      // order, otherwise the shorthand can clobber the longhand. Collect and
+      // sort by source_order before applying, matching @css's own
+      // regular_declarations_in_source_order.
+      let remaining_decls : Array[(String, @css.Declaration)] = []
       cascaded_values.each(fn(prop, decl) {
         if prop == "font" || prop == "font-size" || prop == "line-height" {
           ()
         } else {
-          match decl.value {
-            @css.PropertyValue::Value(value) =>
-              style = apply_css_property_with_viewport(
-                style,
-                prop,
-                value,
-                ctx.viewport_width,
-                ctx.viewport_height,
-                element_css_vars,
-                parent_style,
-              )
-            _ => ()
-          }
+          remaining_decls.push((prop, decl))
         }
       })
+      remaining_decls.sort_by(fn(a, b) { a.1.source_order - b.1.source_order })
+      for entry in remaining_decls {
+        let (prop, decl) = entry
+        match decl.value {
+          @css.PropertyValue::Value(value) =>
+            style = apply_css_property_with_viewport(
+              style,
+              prop,
+              value,
+              ctx.viewport_width,
+              ctx.viewport_height,
+              element_css_vars,
+              parent_style,
+            )
+          _ => ()
+        }
+      }
     }
     None => ()
   }

--- a/runtime/pkg.generated.mbti
+++ b/runtime/pkg.generated.mbti
@@ -82,8 +82,8 @@ pub fn ScriptExecutor::tick(Self) -> Bool raise JsError
 
 // Traits
 pub(open) trait JsRuntime {
-  init(Self) -> Unit
-  execute(Self, Int, @dom.DomTree, String, AsyncExecutionMode) -> JsResult raise JsError
-  tick(Self, Int, @dom.DomTree) -> JsResult raise JsError
+  fn init(Self) -> Unit
+  fn execute(Self, Int, @dom.DomTree, String, AsyncExecutionMode) -> JsResult raise JsError
+  fn tick(Self, Int, @dom.DomTree) -> JsResult raise JsError
 }
 

--- a/scripts/ci/install-playwright-chromium.sh
+++ b/scripts/ci/install-playwright-chromium.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Install Playwright's Chromium (plus the system libraries pulled in by
+# `--with-deps`), bounded by a per-attempt timeout and retried.
+#
+# `pnpm exec playwright install --with-deps chromium` has been observed to
+# stall indefinitely after the browser download reaches 100% (extraction /
+# post-install hang). The CI jobs that call it have no step or job timeout, so
+# a single stall pins the job to GitHub's 6-hour default and the whole run has
+# to be cancelled by hand. Bound each attempt with `timeout` and retry a few
+# times so a transient stall fails fast and self-recovers instead of hanging
+# the workflow.
+set -euo pipefail
+
+attempts="${PLAYWRIGHT_INSTALL_ATTEMPTS:-3}"
+per_attempt_timeout="${PLAYWRIGHT_INSTALL_TIMEOUT:-420}"
+
+for attempt in $(seq 1 "$attempts"); do
+  echo "::group::playwright install --with-deps chromium (attempt ${attempt}/${attempts})"
+  status=0
+  timeout "${per_attempt_timeout}" pnpm exec playwright install --with-deps chromium || status=$?
+  echo "::endgroup::"
+
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+  if [ "$status" -eq 124 ]; then
+    echo "attempt ${attempt} timed out after ${per_attempt_timeout}s" >&2
+  else
+    echo "attempt ${attempt} failed with exit ${status}" >&2
+  fi
+  sleep $((attempt * 5))
+done
+
+echo "playwright install --with-deps chromium failed after ${attempts} attempts" >&2
+exit 1

--- a/testing/moon.mod
+++ b/testing/moon.mod
@@ -7,7 +7,7 @@ import {
   "mizchi/crater-browser@0.18.0",
   "mizchi/crater-browser-native@0.18.0",
   "mizchi/crater-browser-runtime@0.18.0",
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
 }

--- a/testing/moon.mod
+++ b/testing/moon.mod
@@ -7,7 +7,7 @@ import {
   "mizchi/crater-browser@0.18.0",
   "mizchi/crater-browser-native@0.18.0",
   "mizchi/crater-browser-runtime@0.18.0",
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
 }

--- a/testing/moon.mod
+++ b/testing/moon.mod
@@ -7,7 +7,7 @@ import {
   "mizchi/crater-browser@0.18.0",
   "mizchi/crater-browser-native@0.18.0",
   "mizchi/crater-browser-runtime@0.18.0",
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
 }

--- a/webdriver/moon.mod
+++ b/webdriver/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webdriver-bidi"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-network@0.18.0",
   "mizchi/font@0.7.3",

--- a/webdriver/moon.mod
+++ b/webdriver/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webdriver-bidi"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-network@0.18.0",
   "mizchi/font@0.7.3",

--- a/webdriver/moon.mod
+++ b/webdriver/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webdriver-bidi"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-network@0.18.0",
   "mizchi/font@0.7.3",

--- a/webvitals/moon.mod
+++ b/webvitals/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webvitals"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.2",
+  "mizchi/css@0.4.3",
   "mizchi/crater-core@0.18.0",
 }
 

--- a/webvitals/moon.mod
+++ b/webvitals/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webvitals"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.3",
+  "mizchi/css@0.4.4",
   "mizchi/crater-core@0.18.0",
 }
 

--- a/webvitals/moon.mod
+++ b/webvitals/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webvitals"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.4.4",
+  "mizchi/css@0.4.5",
   "mizchi/crater-core@0.18.0",
 }
 


### PR DESCRIPTION
Three things in this PR:

## 1. css 0.3.2 → 0.4.5
0.4.x adds `Dimension::Calc(px, percent)` generated from mixed `calc()`; Crater's layout already had the `Calc` arms wired, so block mixed-calc tests pass (`calc-max-width-block-intrinsic-1` etc.).

## 2. Cascade source-order fix (the real #68 border bug)
`compute_element_style_indexed` applied cascaded values via `CascadedValues::each` (hash-map order), losing CSS source order. A higher-specificity `border-left-width` longhand in a separate rule was clobbered by an earlier `border` shorthand → `border.left=10` instead of 100. Now sorts by `source_order` before applying. **`css-images/gradients-with-border` passes** (border-box 310, was 220). Inline styles were already correct; only the stylesheet path was affected.

## 3. CI fix (main was broken, independent of this change)
Commit `d3d54fd6` migrated every workspace manifest `moon.mod.json` → pkl `moon.mod` (conformance stays `.json` for its local-path deps), but `ci.yml` still referenced the old `.json` paths. The `moon-prefetch` action ran `moon update --manifest-path js/moon.mod.json` and died with "No such file or directory", failing every build job ~50s in. Repointed the prefetch manifest lists and rusty-v8 `hashFiles` cache keys to `moon.mod`; also regenerated four `.mbti` files to the new MoonBit trait `fn` format that the current toolchain emits. Verified prefetch works against the pkl manifest locally.

## Validation
- `gradients-with-border` pass; css-images module 383/408.
- No regression: css-box 30/0, css-position 84/0, compositing 2/0 strict green; css-flexbox 260/29, css-overflow 229/14 unchanged; layout 3481/3482 (pre-existing sixel); webdriver 438/438; js-package + wasm build green.
- Renderer regression test added.

## Still open in #68
`linear-gradient-body-sibling-index` — the `sibling-index()` value function is unimplemented (separate from the selector-side `sibling_index`).

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD