### PR TITLE
deps: hoist pngjs to root so the PNG decoder resolves under any cwd (fixes #262)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:website": "playwright test tests/website-loading.test.ts tests/browser-user-scenarios.test.ts"
   },
   "dependencies": {
+    "pngjs": "^7.0.0",
     "puppeteer": "^24.40.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       puppeteer:
         specifier: ^24.40.0
         version: 24.40.0(typescript@6.0.3)


### PR DESCRIPTION
## Summary

The sixel raster decoder FFI in `terminal_image_cache/entry.mbt` loads pngjs via `require('pngjs')`, falling back to cwd-relative candidates (`cwd/node_modules/pngjs`, `cwd/browser/node_modules/pngjs`). pngjs was declared **only** in `browser/package.json`, so resolution succeeded from the repo root and from `browser/`, but failed under `moon -C js test --target js` (cwd = `js/`), where neither candidate path exists. The cached `data:` PNG then decoded to nothing and the sixel test (`browser_js_render_wbtest.mbt`: *"sixel render composites cached data png image for img src"*) failed — **3481/3482**.

## Fix

Declare `pngjs ^7.0.0` in the root `package.json` so it hoists to the top-level `node_modules`, letting the primary `require('pngjs')` upward-walk resolve from any workspace cwd. `pngjs@7.0.0` was already in the lockfile via the browser importer, so only the root-importer reference is added — a 4-line lockfile diff with no unrelated churn.

## Verification

- `moon -C js test --target js` → **3482/3482** (was 3481/3482)
- whole-workspace `moon test --target js` → 3482/3482 (no regression)
- `pnpm install --frozen-lockfile` (CI parity) → passes

Fixes #262.

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_