### PR TITLE
ci: reuse prior Chromium cache via restore-keys so dep changes don't flake strict WPT gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,12 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
+          # Fall back to the most recent Chromium cache when only unrelated deps
+          # change (e.g. a new devDependency). A partial restore reuses the
+          # existing browser so `playwright install` is a fast verify instead of
+          # a fresh multi-hundred-MB download that stalls the strict gates.
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
 
       - name: Install Chromium (Playwright) for the WPT runner
         if: steps.wpt_css_playwright_cache.outputs.cache-hit != 'true'
@@ -536,6 +542,9 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
+          # Reuse the most recent Chromium cache when unrelated deps change.
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
 
       - name: Install Playwright Chromium browser
         if: steps.playwright_bidi_playwright_cache.outputs.cache-hit != 'true'
@@ -751,6 +760,9 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
+          # Reuse the most recent Chromium cache when unrelated deps change.
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
 
       - name: Validate installed metric-ci CLI package
         id: metric_ci_package
@@ -1033,6 +1045,9 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
+          # Reuse the most recent Chromium cache when unrelated deps change.
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
 
       - name: Install Playwright browsers for VRT
         if: steps.wpt_vrt_playwright_cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Problem

The four Playwright-using CI jobs — `wpt-css`, `playwright-bidi`, `paint-vrt`, `wpt-vrt` — key their `~/.cache/ms-playwright` cache on `hashFiles('package.json', 'pnpm-lock.yaml')`.

Any dependency change — even an unrelated devDependency like the `opentype.js` add in #267 — invalidates that key for **every** job at once, forcing a fresh `playwright install --with-deps chromium` download. That download is documented in-repo to stall, and the **strict** wpt-css shards (`soft_fail: false`) hard-fail the gate on it even when the PR doesn't touch the tested CSS.

This reproduced **identically on #266 and #267**: `compositing-strict` / `css-position-strict` / `css-box-strict` failed in ~1 minute (before any test comparison ran), while the aggregate `wpt-compat-summary` stayed green. The failures are environmental, not layout regressions — confirmed locally where `css-position` (84/84), `css-box` (30/30), and `compositing` (2/2) all pass with the #267 measurement change.

## Fix

Add `restore-keys: playwright-chromium-${{ runner.os }}-` to all four cache blocks. On an exact-key miss the cache now **partially restores the most recent Chromium build**, so `playwright install` becomes a fast verify instead of a full re-download — and the post-job step still saves a fresh cache under the new exact key.

When Playwright *itself* is upgraded, the required browser revision is absent from the restored cache and is correctly downloaded. No change to install gating or test logic.

## Validation

`ci.yml` passes `yaml.safe_load`; all four blocks now carry the prefix `restore-keys`. This is the standard actions/cache fallback pattern.

https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD

---
_Generated by [Claude Code](https://claude.ai/code/session_013PUMLcBPfuE5hRtRf3HBpD)_