### PR TITLE
gfx_text: real-font text rendering via per-pixel coverage

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -97,6 +97,14 @@ export function renderHtmlToImageRgba(html: string, width: number, height: numbe
 export function renderTextToImagePngBase64(text: string, width: number, height: number, scale: number): string;
 
 /**
+ * Install a TrueType/OpenType font (raw bytes as 0..255 ints) as the global
+ * glyph provider, so subsequent renderHtmlToImage* calls render real glyph
+ * shapes for text. Returns false if the font could not be parsed.
+ * @param data - the font file bytes as an array of 0..255 integers
+ */
+export function setFontProviderFromBytes(data: number[]): boolean;
+
+/**
  * Render HTML to Sixel graphics string
  * @param html - HTML string with inline styles
  * @param width - Viewport width in pixels

--- a/js/index.js
+++ b/js/index.js
@@ -6,6 +6,7 @@ export {
   renderHtmlToImagePngBase64,
   renderHtmlToImageRgba,
   renderTextToImagePngBase64,
+  setFontProviderFromBytes,
   renderHtmlToSixel,
   renderHtmlToSixelWithStyles,
   // Incremental API

--- a/js/moon.pkg
+++ b/js/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "mizchi/crater-renderer/renderer",
   "mizchi/crater-renderer/gfx_vrt",
+  "mizchi/crater-painter/paint/glyph",
   "mizchi/crater-renderer/terminal" @renderer_terminal,
   "mizchi/crater-aomx/arc90",
   "mizchi/crater-painter/paint",
@@ -25,6 +26,7 @@ options(
         "renderHtmlToImagePngBase64",
         "renderHtmlToImageRgba",
         "renderTextToImagePngBase64",
+        "setFontProviderFromBytes",
         "renderHtmlToSixel",
         "renderHtmlToSixelWithStyles",
         "createTree",

--- a/js/png_image.mbt
+++ b/js/png_image.mbt
@@ -151,3 +151,18 @@ pub fn renderTextToImagePngBase64(
   let image = @gfx_vrt.render_text_to_image(text, width, height, scale~)
   rgba_to_png_base64_js(image.width, image.height, image.pixels)
 }
+
+///|
+/// Install a TrueType/OpenType font (raw bytes as 0..255 ints) as the
+/// global glyph provider, so HTML text renders real glyph shapes through
+/// the gfx pipeline. Returns false if the font could not be parsed.
+pub fn setFontProviderFromBytes(data : Array[Int]) -> Bool {
+  let bytes = Bytes::from_array(data.map(fn(i) { (i & 0xff).to_byte() }))
+  match @glyph.glyph_provider_from_bytes(bytes) {
+    Some(provider) => {
+      @glyph.set_glyph_provider(provider)
+      true
+    }
+    None => false
+  }
+}

--- a/renderer/gfx_bridge/gfx_bridge.mbt
+++ b/renderer/gfx_bridge/gfx_bridge.mbt
@@ -201,7 +201,7 @@ pub fn append_paint_node_text(
         return
       }
       let p = node.paint
-      let cmds = @gfx_text.text_run_commands(
+      let cmds = @gfx_text.text_run_coverage_commands(
         frame,
         provider,
         text,

--- a/renderer/gfx_text/coverage_test.mbt
+++ b/renderer/gfx_text/coverage_test.mbt
@@ -1,0 +1,87 @@
+///|
+// A synthetic glyph provider returning a filled right-triangle outline for
+// every codepoint. This drives crater's real glyph rasterizer
+// (@glyph.layout_glyph_bitmaps -> rasterize), so coverage/anti-aliasing is
+// produced by the same path real fonts use -- only the outline is
+// substituted.
+fn triangle_provider() -> @glyph.GlyphProvider {
+  {
+    get_glyph: fn(_codepoint, font_size, _is_bold) {
+      let commands : Array[@svg.PathCommand] = [
+        MoveTo(0.0, -font_size),
+        LineTo(font_size, 0.0),
+        LineTo(0.0, 0.0),
+        ClosePath,
+      ]
+      (commands, font_size)
+    },
+    get_kern: fn(_l, _r, _fs, _b) { 0.0 },
+    get_glyph_by_weight: None,
+    get_kern_by_weight: None,
+    ascent_ratio: 1.0,
+    get_glyph_for_family: None,
+    get_kern_for_family: None,
+    get_glyph_for_family_by_weight: None,
+    get_kern_for_family_by_weight: None,
+    get_ascent_for_family: None,
+  }
+}
+
+///|
+test "real glyph rasterization lowers to coverage fills" {
+  let w = 10
+  let h = 10
+  let driver = @gfx_software.SoftwareDriver::new(w, h)
+  @gfx.GraphicsDriver::initialize(driver)
+  let dst = @gfx.GraphicsDriver::new_image(driver, w, h)
+  let shader = @gfx.GraphicsDriver::new_shader(driver, "s")
+  @gfx.GraphicsDriver::begin(
+    driver,
+    @gfx.new_render_pass_desc(@gfx.new_color(1.0, 1.0, 1.0, 1.0), true),
+  )
+  let frame = @gfx_frame.RenderFrame2D::new(
+    dst~,
+    shader~,
+    screen_w=w,
+    screen_h=h,
+  )
+  let commands = text_run_coverage_commands(
+    frame,
+    triangle_provider(),
+    "A",
+    0,
+    0,
+    8.0,
+    @gfx.new_color(0.0, 0.0, 0.0, 1.0),
+  )
+  // a real glyph rasterizes to many coverage pixels, not a single box
+  inspect(commands.length() > 4, content="true")
+  for cmd in commands {
+    @gfx.GraphicsDriver::draw_triangles(driver, cmd)
+  }
+  @gfx.GraphicsDriver::end(driver, false)
+  let buf = StringBuilder::new()
+  for py in 0..<h {
+    for px in 0..<w {
+      let (r, _g, _b, _a) = driver.pixel_at(px, py)
+      buf.write_char(if r < 64 { '#' } else if r < 200 { '+' } else { ' ' })
+    }
+    buf.write_char('\n')
+  }
+  inspect(
+    buf.to_string(),
+    content=(
+      #|+         
+      #|#+        
+      #|##+       
+      #|###+      
+      #|####+     
+      #|#####+    
+      #|######+   
+      #|#######+  
+      #|          
+      #|          
+      #|
+    ),
+  )
+}

--- a/renderer/gfx_text/gfx_text.mbt
+++ b/renderer/gfx_text/gfx_text.mbt
@@ -81,3 +81,97 @@ pub fn text_run_commands(
   )
   glyph_placements_to_commands(frame, placements, color)
 }
+
+///|
+/// Lower positioned glyphs into per-pixel coverage fills, drawing the
+/// actual glyph shapes (not just the ink box). Each "on" coverage pixel
+/// becomes a 1x1 fill quad whose alpha is the text alpha scaled by the
+/// pixel's antialiased coverage. This renders crater's real glyph
+/// rasterization (`@glyph.layout_glyph_bitmaps`) on any solid-quad backend
+/// (e.g. gfx_software), with no texture upload.
+pub fn glyph_placements_to_coverage_commands(
+  frame : @gfx_frame.RenderFrame2D,
+  placements : Array[@glyph.GlyphPlacement],
+  color : @gfx.Color,
+) -> Array[@gfx.DrawTrianglesCommand] {
+  let commands : Array[@gfx.DrawTrianglesCommand] = []
+  for placement in placements {
+    let b = placement.bitmap
+    if b.width <= 0 || b.height <= 0 {
+      continue
+    }
+    let max_cov = if b.ss_factor * b.ss_factor <= 0 {
+      1
+    } else {
+      b.ss_factor * b.ss_factor
+    }
+    let has_cov = b.coverage.length() == b.width * b.height
+    let ox = placement.x + b.offset_x.to_double()
+    let oy = placement.y + b.offset_y.to_double()
+    for by in 0..<b.height {
+      for bx in 0..<b.width {
+        let bi = by * b.width + bx
+        let on = bi < b.pixels.length() && b.pixels[bi]
+        if !on {
+          continue
+        }
+        let cov = if has_cov { b.coverage[bi] } else { max_cov }
+        let alpha = color.a * cov.to_double() / max_cov.to_double()
+        if alpha <= 0.0 {
+          continue
+        }
+        let (vertices, indices) = @gfx_frame.ndc_rect_fill_vertices(
+          ox + bx.to_double(),
+          oy + by.to_double(),
+          1.0,
+          1.0,
+          frame.screen_w.to_double(),
+          frame.screen_h.to_double(),
+        )
+        commands.push(
+          @gfx_frame.new_primitive_command(frame, vertices, indices, {
+            ..color,
+            a: alpha,
+          }),
+        )
+      }
+    }
+  }
+  commands
+}
+
+///|
+/// Lay out `text` with the given glyph provider and lower it into per-pixel
+/// coverage fills (actual glyph shapes) at pixel position `(x, y)`.
+pub fn text_run_coverage_commands(
+  frame : @gfx_frame.RenderFrame2D,
+  provider : @glyph.GlyphProvider,
+  text : String,
+  x : Int,
+  y : Int,
+  font_size : Double,
+  color : @gfx.Color,
+  max_width? : Int = 0,
+  line_height? : Double = 0.0,
+  is_bold? : Bool = false,
+  font_family? : String = "",
+  letter_spacing? : Double = 0.0,
+  word_spacing? : Double = 0.0,
+  font_weight? : Double = 400.0,
+) -> Array[@gfx.DrawTrianglesCommand] {
+  let (placements, _used_height) = @glyph.layout_glyph_bitmaps(
+    provider,
+    x,
+    y,
+    text,
+    max_width,
+    font_size,
+    line_height,
+    is_bold,
+    font_family~,
+    letter_spacing~,
+    word_spacing~,
+    font_weight~,
+  )
+  glyph_placements_to_coverage_commands(frame, placements, color)
+}

--- a/renderer/gfx_text/moon.pkg
+++ b/renderer/gfx_text/moon.pkg
@@ -6,4 +6,5 @@ import {
 
 import {
   "mizchi/crater-renderer/gfx_software",
+  "mizchi/svg",
 } for "test"

--- a/renderer/gfx_text/pkg.generated.mbti
+++ b/renderer/gfx_text/pkg.generated.mbti
@@ -22,7 +22,11 @@ pub fn glyph_placements_to_atlas_commands(@gfx_frame.RenderFrame2D, Array[@glyph
 
 pub fn glyph_placements_to_commands(@gfx_frame.RenderFrame2D, Array[@glyph.GlyphPlacement], @gfx.Color) -> Array[@gfx.DrawTrianglesCommand]
 
+pub fn glyph_placements_to_coverage_commands(@gfx_frame.RenderFrame2D, Array[@glyph.GlyphPlacement], @gfx.Color) -> Array[@gfx.DrawTrianglesCommand]
+
 pub fn text_run_commands(@gfx_frame.RenderFrame2D, @glyph.GlyphProvider, String, Int, Int, Double, @gfx.Color, max_width? : Int, line_height? : Double, is_bold? : Bool, font_family? : String, letter_spacing? : Double, word_spacing? : Double, font_weight? : Double) -> Array[@gfx.DrawTrianglesCommand]
+
+pub fn text_run_coverage_commands(@gfx_frame.RenderFrame2D, @glyph.GlyphProvider, String, Int, Int, Double, @gfx.Color, max_width? : Int, line_height? : Double, is_bold? : Bool, font_family? : String, letter_spacing? : Double, word_spacing? : Double, font_weight? : Double) -> Array[@gfx.DrawTrianglesCommand]
 
 // Errors
 

--- a/renderer/moon.mod
+++ b/renderer/moon.mod
@@ -9,6 +9,7 @@ import {
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",
   "mizchi/gfx@0.1.0",
+  "mizchi/svg@0.2.1",
   "moonbitlang/async@0.19.0",
 }
 


### PR DESCRIPTION
## 概要

crater の**実フォント機構**を gfx パイプラインに通し、HTML テキストを実際の（アンチエイリアス付き）グリフ形状で描画できるようにしました。

ビットマップフォント（#275）はソリッド塗りの自己完結フォントでしたが、本 PR は **crater の実ラスタライザ**（`@glyph.layout_glyph_bitmaps` — 端末バックエンドと同じ経路）を使い、実フォントのアウトラインをラスタライズした coverage をピクセル化します。

## 変更

- **gfx_text** に coverage ベースの lower を追加:
  - `glyph_placements_to_coverage_commands` — 各 lit coverage ピクセルを 1×1 塗り quad 化し、アルファ＝AA coverage（実グリフ形状）
  - `text_run_coverage_commands` — `@glyph.layout_glyph_bitmaps` ＋上記の glue
- **gfx_bridge** のテキスト lower を coverage 経路に切替（HTML テキストが実グリフ・AA 付きで software backend に描画。テクスチャアップロード不要 ＝ gfx 契約の制約に適合）
- **js `setFontProviderFromBytes`** — TTF/OTF バイト列をグローバル glyph provider に設定。以後の `renderHtmlToImage*` が実グリフを描画
- renderer モジュールが `mizchi/svg` に依存（テストでグリフアウトラインを構築）

## 検証

- **コミット済みの決定的テスト**: 合成アウトラインプロバイダで crater の実ラスタライザを駆動し、AA coverage（斜辺の部分被覆）をスナップショット — CI で実行
- **実 TTF を node で end-to-end 確認**: `minimal-kern.ttf` を読み込み、HTML "AV" がフォント実物の AA 字形でレンダリング
- js 全体 3528（新規回帰なし。既存 `crater-browser` の sixel/png 1件は環境依存でベースでも失敗、本PR無関係）
- `moon check` 0 errors / `moon info`・`moon fmt` 済み

## 補足

実フォント PNG ベースラインの CI フィクスチャは、フォントファイルのパス（`.mooncakes` 依存）が脆いため追加していません。実ラスタライズ経路は合成プロバイダの決定的テストで CI 担保し、実 TTF 描画は node で確認しています。リポジトリにフォントを同梱すれば実 TTF の VRT フィクスチャも追加可能です。

https://claude.ai/code/session_013Jvp1N2ZkdLXMvpKmqPz36

---
_Generated by [Claude Code](https://claude.ai/code/session_013Jvp1N2ZkdLXMvpKmqPz36)_