### PR TITLE
ci: stop the browser E2E / accuracy steps from hanging js-package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,9 @@ jobs:
     # part gated on `affected`, so keep the job running even when the
     # `affected` job is skipped (e.g. on schedule).
     if: ${{ !cancelled() }}
+    # Bound the whole job: the browser gates below must never wedge it for the
+    # 6h GitHub default (a bare `playwright install` once hung it indefinitely).
+    timeout-minutes: 25
 
     steps:
       - name: Checkout code
@@ -200,20 +203,44 @@ jobs:
         run: node scripts/image-vrt.mjs
         working-directory: js
 
+      # The browser gates below need Playwright's Chromium. A bare
+      # `playwright install chromium` wedges in its post-download extract phase
+      # on these runners (see scripts/ci/install-playwright-chromium.sh), so
+      # restore the browser from cache and install only on a miss via the
+      # curl/unzip bypass -- the same pattern the WPT / paint-vrt jobs use.
+      - name: Restore Playwright Chromium browser cache
+        if: ${{ github.event_name == 'schedule' || needs.affected.outputs.gfx_vrt == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      - name: Detect cached Chromium browser
+        if: ${{ github.event_name == 'schedule' || needs.affected.outputs.gfx_vrt == 'true' }}
+        id: js_chromium_present
+        run: echo "present=$(bash scripts/ci/chromium-cache-present.sh)" >> "$GITHUB_OUTPUT"
+
+      - name: Install Chromium (Playwright) for the browser gates
+        if: ${{ (github.event_name == 'schedule' || needs.affected.outputs.gfx_vrt == 'true') && steps.js_chromium_present.outputs.present != 'true' }}
+        timeout-minutes: 25
+        run: bash scripts/ci/install-playwright-chromium.sh
+
       # Real-browser E2E for the gfx web backend. Renders in Chromium and,
       # when WebGPU is available, asserts GPU output matches the CPU runtime.
-      # The script skips gracefully if a browser can't be launched.
+      # The script skips gracefully (and self-times-out) if the browser wedges.
       - name: Run gfx web backend E2E (browser)
         if: ${{ github.event_name == 'schedule' || needs.affected.outputs.gfx_vrt == 'true' }}
-        run: |
-          pnpm exec playwright install chromium || true
-          node scripts/webgpu-e2e.mjs
+        timeout-minutes: 10
+        run: node scripts/webgpu-e2e.mjs
         working-directory: js
 
       # Accuracy gate: crater's rendered pixels vs real Chromium. Catches
       # rendering-fidelity regressions; skips if no browser is available.
       - name: Check Chromium rendering accuracy
         if: ${{ github.event_name == 'schedule' || needs.affected.outputs.gfx_vrt == 'true' }}
+        timeout-minutes: 10
         run: node scripts/accuracy.mjs
         working-directory: js
 

--- a/js/scripts/accuracy.mjs
+++ b/js/scripts/accuracy.mjs
@@ -108,15 +108,22 @@ function textHtml(fontB64, text, size) {
 }
 
 async function main() {
+  // Hard wall-clock watchdog so a wedged browser can't hang the CI job.
+  const watchdog = setTimeout(() => {
+    console.error("skip: Chromium accuracy check timed out");
+    process.exit(0);
+  }, 90000);
+  watchdog.unref?.();
   const chromium = await loadChromium();
-  if (!chromium) { console.error("skip: playwright unavailable"); return; }
+  if (!chromium) { console.error("skip: playwright unavailable"); clearTimeout(watchdog); return; }
   const m = await import("../dist/index.js");
   let browser;
   try { browser = await chromium.launch({ args: ["--no-sandbox", "--force-device-scale-factor=1", "--hide-scrollbars"] }); }
-  catch (e) { console.error("skip: could not launch chromium —", e.message); return; }
+  catch (e) { console.error("skip: could not launch chromium —", e.message); clearTimeout(watchdog); return; }
   let failures = 0;
   try {
     const page = await browser.newPage({ deviceScaleFactor: 1 });
+    page.setDefaultTimeout(30000);
     for (const fx of FIXTURES) {
       let html = fx.html;
       if (fx.font) {
@@ -139,6 +146,7 @@ async function main() {
     }
   } finally {
     await browser.close();
+    clearTimeout(watchdog);
   }
   if (failures > 0) { console.error(`\n${failures} fixture(s) exceeded the Chromium accuracy tolerance.`); process.exit(1); }
   console.error("crater matches Chromium within tolerance.");

--- a/js/scripts/webgpu-e2e.mjs
+++ b/js/scripts/webgpu-e2e.mjs
@@ -44,8 +44,16 @@ import { CpuBackend, WebGPUBackend } from "/dist/gfx-web-runtime.mjs";
 
 async function getDevice() {
   if (!navigator.gpu) return null;
-  try { const a = await navigator.gpu.requestAdapter(); if (!a) return null; return await a.requestDevice(); }
-  catch { return null; }
+  // requestAdapter / requestDevice can hang (rather than reject) on a broken
+  // or partially-initialized WebGPU stack -- e.g. SwiftShader in headless CI.
+  // Race each against a timeout so __ready always resolves and the page falls
+  // back to the CPU backend instead of blocking the test forever.
+  const withTimeout = (p, ms) => Promise.race([p, new Promise((r) => setTimeout(() => r(null), ms))]);
+  try {
+    const a = await withTimeout(navigator.gpu.requestAdapter(), 5000);
+    if (!a) return null;
+    return await withTimeout(a.requestDevice(), 5000);
+  } catch { return null; }
 }
 
 window.__mode = "cpu";
@@ -115,11 +123,20 @@ const FIXTURES = [
 ];
 
 async function main() {
+  // Hard wall-clock watchdog: a browser/GPU step that wedges should not hang
+  // the CI job. If we blow the deadline, treat it as a skip (this is a
+  // best-effort browser E2E that already skips when no browser is available).
+  const watchdog = setTimeout(() => {
+    console.error("skip: gfx web backend E2E timed out");
+    process.exit(0);
+  }, 90000);
+  watchdog.unref?.();
   let chromium;
   try {
     chromium = await loadChromium();
   } catch (e) {
     console.error("skip: playwright/chromium unavailable —", e.message);
+    clearTimeout(watchdog);
     return;
   }
   const server = await startServer();
@@ -132,13 +149,15 @@ async function main() {
   } catch (e) {
     server.close();
     console.error("skip: could not launch chromium —", e.message);
+    clearTimeout(watchdog);
     return;
   }
   let failures = 0;
   try {
     const page = await browser.newPage();
+    page.setDefaultTimeout(30000);
     page.on("pageerror", (e) => { console.error("pageerror:", e.message); failures++; });
-    await page.goto(`http://127.0.0.1:${port}/`);
+    await page.goto(`http://127.0.0.1:${port}/`, { timeout: 30000, waitUntil: "load" });
     await page.evaluate(() => window.__ready);
     const mode = await page.evaluate(() => window.__mode);
     console.error(`browser backend mode: ${mode}`);
@@ -167,6 +186,7 @@ async function main() {
   } finally {
     await browser.close();
     server.close();
+    clearTimeout(watchdog);
   }
   if (failures > 0) { console.error(`\n${failures} E2E check(s) failed.`); process.exit(1); }
   console.error("gfx web backend E2E passed.");


### PR DESCRIPTION
## 問題

`js-package` ジョブが **step「Run gfx web backend E2E (browser)」でハング**していました(#279 のマージ時も無限実行）。

`webgpu-e2e.mjs` は SwiftShader WebGPU フラグ付きで `navigator.gpu.requestAdapter()` / `requestDevice()` を呼びますが、GPU の無い CI ランナーではこれらが **reject せず無限に待機**します。すると `page.evaluate(() => window.__ready)` が永久に解決しない Promise を待ち続けます(Playwright の `evaluate` は返り Promise にタイムアウトを持たない)。結果としてステップが終わりません。ローカルは SwiftShader が動くため再現せず、CI 専有の問題でした。

## 修正

ブラウザ系2ステップをフェイルセーフ化:
- **WebGPU device 取得を 5s タイムアウトでレース** — `__ready` が必ず解決し、壊れた GPU スタックでも CPU バックエンドにフォールバック(無限待機しない)。
- **90s ウォールクロック・ウォッチドッグ**を `webgpu-e2e.mjs` と `accuracy.mjs` に追加 — ブラウザがハングしたら exit 0(skip)。どちらもブラウザ不在時に既に skip する best-effort ゲートなので挙動として一貫。
- `page.goto` / `setDefaultTimeout` に明示タイムアウト。

ハッピーパスは不変(WebGPU が動く環境では両方とも従来どおり end-to-end でパス、exit 0)。ローカル検証済み:
```
gfx web backend E2E passed.            (webgpu==cpu maxDiff=0/1)  exit 0
crater matches Chromium within tolerance.                        exit 0
```

https://claude.ai/code/session_013Jvp1N2ZkdLXMvpKmqPz36

---
_Generated by [Claude Code](https://claude.ai/code/session_013Jvp1N2ZkdLXMvpKmqPz36)_