### PR TITLE
dom(shadow): shadow-tree static styling cascade (#285, PR 1)

### DIFF
--- a/dom/dom/moon.pkg
+++ b/dom/dom/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "moonbitlang/core/math",
   "mizchi/css/selector",
+  "mizchi/css",
+  "mizchi/css/cascade",
 }
 
 warnings = "-6"

--- a/dom/dom/pkg.generated.mbti
+++ b/dom/dom/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "mizchi/crater-dom/dom"
 
 import {
+  "mizchi/css/cascade",
   "moonbitlang/core/debug",
 }
 
@@ -57,6 +58,7 @@ pub fn DomTree::attach_existing_shadow_root_with_init(Self, NodeId, NodeId, Shad
 pub fn DomTree::attach_shadow(Self, NodeId, String) -> Result[NodeId, CoreError]
 pub fn DomTree::attach_shadow_with_init(Self, NodeId, ShadowRootInit) -> Result[NodeId, CoreError]
 pub fn DomTree::clear_mutations(Self) -> Unit
+pub fn DomTree::collect_shadow_matched_declarations(Self, NodeId, Array[@cascade.CSSRule], NodeId) -> Array[@cascade.Declaration]
 pub fn DomTree::create_comment(Self, String) -> NodeId
 pub fn DomTree::create_document_fragment(Self) -> NodeId
 pub fn DomTree::create_element(Self, String) -> NodeId
@@ -105,6 +107,8 @@ pub fn DomTree::set_custom_states(Self, NodeId, Array[String]) -> Result[Unit, C
 pub fn DomTree::set_focus(Self, NodeId?) -> Unit
 pub fn DomTree::set_form_associated_state(Self, NodeId, String?, String?) -> Result[Unit, CoreError]
 pub fn DomTree::set_text_content(Self, NodeId, String) -> Result[Unit, CoreError]
+pub fn DomTree::shadow_cascaded_values(Self, NodeId, Array[@cascade.CSSRule], NodeId) -> @cascade.CascadedValues
+pub fn DomTree::shadow_stylesheet_rules(Self, NodeId) -> Array[@cascade.CSSRule]
 pub fn DomTree::slot_assigned_elements(Self, NodeId, flatten? : Bool) -> Array[NodeId]
 pub fn DomTree::slot_assigned_nodes(Self, NodeId, flatten? : Bool) -> Array[NodeId]
 

--- a/dom/dom/shadow_cascade.mbt
+++ b/dom/dom/shadow_cascade.mbt
@@ -1,0 +1,142 @@
+///|
+/// Shadow-tree static styling (#285, PR 1).
+///
+/// A parallel cascade that applies a shadow root's own `<style>` rules to
+/// shadow-tree content using `DomTree::matches_shadow_scoped` (the matcher
+/// added in #286 for `:host` / `:host()` / `:host-context()` / `::slotted()`).
+///
+/// This bypasses `@css.cascade_element_indexed` — which cannot resolve the
+/// shadow-scoping pseudos — and instead routes each rule's selector through the
+/// DOM-aware matcher, then feeds the matched declarations into the shared
+/// `@css.cascade_declarations`. The resulting `@cascade.CascadedValues` is the
+/// same type the renderer's document path already consumes, so a later slice
+/// can merge it into `@style.Style` with no new layout plumbing.
+///
+/// These functions are pure over the `DomTree`; the renderer is not yet wired
+/// to call them.
+
+///|
+/// Parse every `<style>` element in the shadow tree rooted at `shadow_root`
+/// into a flat list of rules, in document order. Nested elements are descended,
+/// but nested shadow roots are not (their styles belong to their own tree).
+pub fn DomTree::shadow_stylesheet_rules(
+  self : DomTree,
+  shadow_root : NodeId,
+) -> Array[@cascade.CSSRule] {
+  let rules : Array[@cascade.CSSRule] = []
+  self.collect_style_rules_into(shadow_root, rules)
+  rules
+}
+
+///|
+fn DomTree::collect_style_rules_into(
+  self : DomTree,
+  node : NodeId,
+  out : Array[@cascade.CSSRule],
+) -> Unit {
+  let children = match self.get_children(node) {
+    Ok(children) => children
+    Err(_) => return
+  }
+  for child in children {
+    let tag = match self.get_tag_name(child) {
+      Ok(tag) => tag.to_lower()
+      Err(_) => ""
+    }
+    if tag == "style" {
+      let css = match self.get_text_content(child) {
+        Ok(text) => text
+        Err(_) => ""
+      }
+      for rule in @css.parse_stylesheet(css).rules {
+        out.push(rule)
+      }
+    } else {
+      self.collect_style_rules_into(child, out)
+    }
+  }
+}
+
+///|
+/// Declarations from `rules` that apply to `target` when the rules are authored
+/// inside the shadow tree whose host is `host`, stamped with the matched
+/// selector's specificity and document source order so `@css.cascade_declarations`
+/// resolves the winner exactly like the document cascade
+/// (`@cascade.cascade_rule_into`). A rule whose selector fails to parse or does
+/// not match is skipped, so one malformed selector cannot abort styling.
+pub fn DomTree::collect_shadow_matched_declarations(
+  self : DomTree,
+  host : NodeId,
+  rules : Array[@cascade.CSSRule],
+  target : NodeId,
+) -> Array[@cascade.Declaration] {
+  let declarations : Array[@cascade.Declaration] = []
+  let mut order = 0
+  for rule in rules {
+    match self.best_shadow_match_specificity(rule.selector_text, target, host) {
+      Some(specificity) =>
+        for decl in rule.declarations {
+          declarations.push(
+            @cascade.Declaration::with_metadata(
+              decl.property,
+              decl.value,
+              decl.origin,
+              decl.importance,
+              specificity,
+              order,
+            ),
+          )
+          order = order + 1
+        }
+      None => ()
+    }
+  }
+  declarations
+}
+
+///|
+/// The highest specificity among the complex selectors in `selector_text` that
+/// match `target` in the shadow tree hosted by `host`, or `None` when none
+/// match (or the selector text does not parse).
+fn DomTree::best_shadow_match_specificity(
+  self : DomTree,
+  selector_text : String,
+  target : NodeId,
+  host : NodeId,
+) -> @selector.Specificity? {
+  let list = match @selector.parse_selector_list_text(selector_text) {
+    Some(list) => list
+    None => return None
+  }
+  let mut best : @selector.Specificity? = None
+  for cs in list.selectors {
+    if self.complex_matches_scoped(target, cs, host) {
+      let specificity = @selector.complex_specificity(cs)
+      best = match best {
+        Some(current) =>
+          if specificity.compare_to(current) > 0 {
+            Some(specificity)
+          } else {
+            Some(current)
+          }
+        None => Some(specificity)
+      }
+    }
+  }
+  best
+}
+
+///|
+/// Cascade the shadow rules that apply to `target` (host is `host`) into the
+/// winning `@cascade.CascadedValues`, resolving specificity / source order via
+/// the shared `@css.cascade_declarations`.
+pub fn DomTree::shadow_cascaded_values(
+  self : DomTree,
+  host : NodeId,
+  rules : Array[@cascade.CSSRule],
+  target : NodeId,
+) -> @cascade.CascadedValues {
+  @css.cascade_declarations(
+    self.collect_shadow_matched_declarations(host, rules, target),
+  )
+}

--- a/dom/dom/shadow_cascade_test.mbt
+++ b/dom/dom/shadow_cascade_test.mbt
@@ -1,0 +1,119 @@
+///|
+/// Read a cascaded property as a plain string for snapshotting (`<none>` when
+/// absent), keeping assertions single-line and Option-free.
+fn cascaded(values : @cascade.CascadedValues, property : String) -> String {
+  match values.get_value(property) {
+    Some(value) => value
+    None => "<none>"
+  }
+}
+
+///|
+/// Shadow-tree static styling (#285, PR 1): a shadow root's <style> rules are
+/// matched against shadow-tree content via matches_shadow_scoped and cascaded
+/// through @css.cascade_declarations.
+test "shadow_cascaded_values applies :host and inner rules" {
+  let tree = DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("div")
+  let _ = tree.set_attribute(host, "class", "theme")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+  let style = tree.create_element("style")
+  let _ = tree.set_text_content(
+    style, ":host { color: red } :host(.theme) { background: blue } .inner { color: green }",
+  )
+  let _ = tree.append_child(shadow, style)
+  let inner = tree.create_element("span")
+  let _ = tree.set_attribute(inner, "class", "inner")
+  let _ = tree.append_child(shadow, inner)
+  let rules = tree.shadow_stylesheet_rules(shadow)
+
+  // Three rules parsed from the single <style>.
+  inspect(rules.length(), content="3")
+
+  // The host gets :host and the matching :host(.theme) declarations.
+  let host_values = tree.shadow_cascaded_values(host, rules, host)
+  inspect(cascaded(host_values, "color"), content="red")
+  inspect(cascaded(host_values, "background"), content="blue")
+
+  // The inner node gets .inner but not the :host rules.
+  let inner_values = tree.shadow_cascaded_values(host, rules, inner)
+  inspect(cascaded(inner_values, "color"), content="green")
+  inspect(cascaded(inner_values, "background"), content="<none>")
+}
+
+///|
+test "shadow_cascaded_values gates :host() on the host and skips bad selectors" {
+  let tree = DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("div")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+  let style = tree.create_element("style")
+  // The first selector is malformed and must be skipped, not fatal.
+  let _ = tree.set_text_content(
+    style, ":::: { color: black } :host(.active) { color: red }",
+  )
+  let _ = tree.append_child(shadow, style)
+
+  // Host without the gating class: :host(.active) does not apply.
+  let rules = tree.shadow_stylesheet_rules(shadow)
+  let plain = tree.shadow_cascaded_values(host, rules, host)
+  inspect(cascaded(plain, "color"), content="<none>")
+
+  // Host with the class: the rule now applies (bad selector still skipped).
+  let _ = tree.set_attribute(host, "class", "active")
+  let active = tree.shadow_cascaded_values(host, rules, host)
+  inspect(cascaded(active, "color"), content="red")
+}
+
+///|
+test "shadow_cascaded_values resolves ::slotted against assigned light nodes" {
+  let tree = DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("div")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+  let style = tree.create_element("style")
+  let _ = tree.set_text_content(style, "::slotted(.tag) { color: purple }")
+  let _ = tree.append_child(shadow, style)
+  let slot = tree.create_element("slot")
+  let _ = tree.append_child(shadow, slot)
+
+  // A light child assigned to the default slot matches ::slotted(.tag).
+  let slotted = tree.create_element("span")
+  let _ = tree.set_attribute(slotted, "class", "tag")
+  let _ = tree.append_child(host, slotted)
+  let rules = tree.shadow_stylesheet_rules(shadow)
+  let slotted_values = tree.shadow_cascaded_values(host, rules, slotted)
+  inspect(cascaded(slotted_values, "color"), content="purple")
+
+  // A light child without the class is slotted but does not match the compound.
+  let other = tree.create_element("section")
+  let _ = tree.append_child(host, other)
+  let other_values = tree.shadow_cascaded_values(host, rules, other)
+  inspect(cascaded(other_values, "color"), content="<none>")
+}
+
+///|
+test "shadow_cascaded_values resolves specificity and source order" {
+  let tree = DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("div")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+  let style = tree.create_element("style")
+  // Same specificity, later wins; higher specificity (#id) always wins.
+  let _ = tree.set_text_content(
+    style, ".box { color: red } .box { color: blue } #b { color: green }",
+  )
+  let _ = tree.append_child(shadow, style)
+  let box = tree.create_element("p")
+  let _ = tree.set_attribute(box, "class", "box")
+  let _ = tree.set_attribute(box, "id", "b")
+  let _ = tree.append_child(shadow, box)
+  let rules = tree.shadow_stylesheet_rules(shadow)
+  let values = tree.shadow_cascaded_values(host, rules, box)
+  inspect(cascaded(values, "color"), content="green")
+}

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -451,6 +451,16 @@ scenarios {
     contributes { "goal.dom-compat" }
   }
   new {
+    id = "compat.shadow-static-styling"
+    name = "Shadow-tree style rules apply via shadow-scoped matching in static styling"
+    description =
+      "Apply a shadow root's <style> rules to shadow-tree content (host, slotted, and inner nodes) using DomTree::matches_shadow_scoped for :host / :host() / :host-context() / ::slotted(), feeding matched declarations through @css.cascade_declarations into cascaded values without changing upstream @css.cascade. Builds on the matcher in dom/dom/shadow_query.mbt. Source: GitHub issue #285."
+    tags { "dom"; "shadow"; "selectors"; "styling"; "render"; "issue:285" }
+    severity = "major"
+    reviewStatus = "draft"
+    contributes { "goal.dom-compat" }
+  }
+  new {
     id = "compat.web-components-element-internals"
     name = "Web Components advanced surface is covered"
     description =


### PR DESCRIPTION
## Summary

First slice of the #285 workstream (shadow selectors in static styling). A pure, DomTree-level **parallel cascade** that applies a shadow root's own `<style>` rules to shadow-tree content using `matches_shadow_scoped` (from #286), without touching the renderer or upstream `@css.cascade`:

- `shadow_stylesheet_rules(shadow_root)` — parse every `<style>` in the shadow tree into an `@cascade.CSSRule` list (document order).
- `collect_shadow_matched_declarations(host, rules, target)` — keep declarations of rules whose selector matches `target`, stamped with the matched complex selector's specificity (`@selector.complex_specificity`) and source order so the winner resolves exactly like the document cascade. Unparseable / non-matching selectors are skipped, never fatal.
- `shadow_cascaded_values(host, rules, target)` — feed those into `@css.cascade_declarations`, yielding the same `@cascade.CascadedValues` the renderer's document path already consumes.

This is the consumer hook the #286 matcher anticipated. Adds a draft pkspec scenario `compat.shadow-static-styling`.

## Roadmap (subsequent slices)
- PR 2: extract the renderer's cascade→`@style.Style` body (`apply_cascaded_to_style`).
- PR 3: computed style for a shadow host + children.
- PR 4: `render_dom_tree` entry + composed-tree walk.
- PR 5: inherited-property boundary flow, `:host-context` ancestors, nested shadow ordering, WPT regression → closes #285.

## Testing
- `moon test -p dom --target js` — **992 passed, 0 failed** (4 new: `:host` / `:host()` gating / `::slotted` assignment / specificity + source order / malformed-skip).
- `moon check` — 0 new warnings; `moon fmt` / `moon info` clean. `.mbti` adds 3 public functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_