### PR TITLE
renderer(style): extract apply_cascaded_to_style (#285, PR 2)

### DIFF
--- a/renderer/renderer/style_resolve.mbt
+++ b/renderer/renderer/style_resolve.mbt
@@ -686,6 +686,25 @@ fn compute_element_style_indexed(
   } else {
     None
   }
+  apply_cascaded_to_style(
+    cascaded, selector_elem, inline_css, is_root, ctx, parent_style, css_vars,
+  )
+}
+
+///|
+/// Fold a cascaded value set (document or, later, shadow-scoped) together with
+/// inline styles and inherited context into a concrete `@style.Style`. Split
+/// out of `compute_element_style_indexed` so a DomTree-driven shadow cascade can
+/// reuse the exact same post-cascade pipeline (#285).
+fn apply_cascaded_to_style(
+  cascaded : @css.CascadedValues?,
+  selector_elem : @css.Element,
+  inline_css : String?,
+  is_root : Bool,
+  ctx : RenderContext,
+  parent_style : @style.Style?,
+  css_vars : Map[String, String],
+) -> @style.Style {
   let element_css_vars = clone_string_map(css_vars)
   collect_cascaded_custom_properties(cascaded, element_css_vars)
   collect_inline_custom_properties(inline_css, element_css_vars)


### PR DESCRIPTION
## Summary

Second slice of #285. Pure refactor that splits the post-cascade body of `compute_element_style_indexed` into a new private `apply_cascaded_to_style(cascaded, selector_elem, inline_css, is_root, ctx, parent_style, css_vars) -> @style.Style`.

The original function now only computes the document `cascaded` value set and delegates the fold-into-`@style.Style` pipeline (custom properties, color scheme, inline styles, inheritance, box-sizing, inline-only cache) to the new function. A later slice feeds a **shadow-scoped** `CascadedValues` (from `DomTree::shadow_cascaded_values`, PR 1) through the exact same pipeline.

Enabling fact: `@css.Element` is `@selector.Element` (re-export), so a DomTree node projects into `selector_elem` via the existing `dom_node_to_selector_element` bridge.

## Testing
- Full `mizchi/crater-renderer` module suite: **3548/3549 pass**. The single failure (`browser` sixel PNG compositing test) **pre-exists on main** and is unrelated to this change (verified by stashing the diff).
- `moon check` 0 errors; no `.mbti` change (the new function is private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_