### PR TITLE
renderer(shadow): compute @style.Style for shadow-tree nodes (#285, PR 3)

### DIFF
--- a/dom/dom/pkg.generated.mbti
+++ b/dom/dom/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "mizchi/crater-dom/dom"
 
 import {
   "mizchi/css/cascade",
+  "mizchi/css/selector",
   "moonbitlang/core/debug",
 }
 
@@ -96,6 +97,7 @@ pub fn DomTree::insert_before(Self, NodeId, NodeId, NodeId?) -> Result[Unit, Cor
 pub fn DomTree::is_slot_element(Self, NodeId) -> Bool
 pub fn DomTree::matches_shadow_scoped(Self, NodeId, String, NodeId) -> Result[Bool, CoreError]
 pub fn DomTree::new() -> Self
+pub fn DomTree::node_to_selector_element(Self, NodeId) -> @selector.Element?
 pub fn DomTree::pending_mutation_count(Self) -> Int
 pub fn DomTree::query_selector(Self, NodeId, String) -> Result[NodeId?, CoreError]
 pub fn DomTree::query_selector_all(Self, NodeId, String) -> Result[Array[NodeId], CoreError]

--- a/dom/dom/shadow_cascade.mbt
+++ b/dom/dom/shadow_cascade.mbt
@@ -127,6 +127,25 @@ fn DomTree::best_shadow_match_specificity(
 }
 
 ///|
+/// Project an element node into a standalone `@selector.Element` (carrying its
+/// own tag / id / classes / attributes and element-sibling index/count, with no
+/// ancestor chain). `None` for non-element nodes. This is the same type the
+/// renderer's cascade consumes (`@css.Element` re-exports `@selector.Element`),
+/// so a shadow-tree node can be styled through the renderer pipeline.
+pub fn DomTree::node_to_selector_element(
+  self : DomTree,
+  id : NodeId,
+) -> @selector.Element? {
+  match self.nodes.get(id.to_int()) {
+    Some(node) if node.node_type == Element => {
+      let (index, count) = self.element_sibling_position(id.to_int())
+      Some(dom_node_to_selector_element(node, None, None, index, count))
+    }
+    _ => None
+  }
+}
+
+///|
 /// Cascade the shadow rules that apply to `target` (host is `host`) into the
 /// winning `@cascade.CascadedValues`, resolving specificity / source order via
 /// the shared `@css.cascade_declarations`.

--- a/renderer/renderer/moon.pkg
+++ b/renderer/renderer/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/core/string",
   "mizchi/crater-dom/html",
+  "mizchi/crater-dom/dom",
   "mizchi/css",
   "mizchi/crater-layout" @node,
   "mizchi/crater-renderer/inline_style_cache",

--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "mizchi/crater-renderer/renderer"
 import {
   "mizchi/crater-core",
   "mizchi/crater-core/node",
+  "mizchi/crater-dom/dom",
   "mizchi/crater-dom/html",
   "mizchi/css/cascade",
   "mizchi/css/media",
@@ -24,6 +25,8 @@ pub fn clear_image_intrinsic_size_provider() -> Unit
 pub fn clear_text_metrics_provider() -> Unit
 
 pub fn compute_layout_from_render_root(@node.Node, PreparedRenderDocument, RenderContext) -> @crater-core.Layout
+
+pub fn compute_shadow_element_style(@dom.DomTree, @dom.NodeId, Array[@cascade.CSSRule], @dom.NodeId, RenderContext, @style.Style?) -> @style.Style
 
 pub fn element_to_node(@html.Element, @style.Style?) -> @node.Node
 

--- a/renderer/renderer/shadow_style.mbt
+++ b/renderer/renderer/shadow_style.mbt
@@ -1,0 +1,40 @@
+///|
+/// Shadow-tree static styling (#285, PR 3).
+///
+/// Compute a concrete `@style.Style` for a node that lives inside a shadow tree
+/// (the host, a slotted light node, or an inner shadow node) by running that
+/// shadow root's `<style>` rules through `DomTree::shadow_cascaded_values`
+/// (PR 1, shadow-scoped matching) and folding the result through the renderer's
+/// shared post-cascade pipeline `apply_cascaded_to_style` (PR 2).
+///
+/// `rules` is the shadow root's parsed stylesheet, obtained once via
+/// `DomTree::shadow_stylesheet_rules`, so a caller styling many nodes does not
+/// re-parse `<style>` per node. `parent_style` carries inherited context across
+/// the shadow boundary (the host's style for top-level shadow nodes).
+///
+/// This is a building block; the composed-tree render entry (PR 4) walks the
+/// DomTree and calls it for shadow-scoped nodes.
+pub fn compute_shadow_element_style(
+  tree : @dom.DomTree,
+  host : @dom.NodeId,
+  rules : Array[@css.CSSRule],
+  target : @dom.NodeId,
+  ctx : RenderContext,
+  parent_style : @style.Style?,
+) -> @style.Style {
+  let selector_elem = match tree.node_to_selector_element(target) {
+    Some(elem) => elem
+    None => @css.Element::new("span")
+  }
+  let cascaded = Some(tree.shadow_cascaded_values(host, rules, target))
+  let css_vars : Map[String, String] = {}
+  apply_cascaded_to_style(
+    cascaded,
+    selector_elem,
+    None,
+    false,
+    ctx,
+    parent_style,
+    css_vars,
+  )
+}

--- a/renderer/renderer/shadow_style_test.mbt
+++ b/renderer/renderer/shadow_style_test.mbt
@@ -1,0 +1,54 @@
+///|
+/// Shadow-tree static styling (#285, PR 3): a shadow root's <style> rules
+/// produce a concrete @style.Style for shadow-tree nodes through the same
+/// post-cascade pipeline the document path uses.
+test "compute_shadow_element_style applies :host and inner rules to Style" {
+  let tree = @dom.DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("div")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+  let style = tree.create_element("style")
+  let _ = tree.set_text_content(
+    style, ":host { display: flex } .inner { width: 50px }",
+  )
+  let _ = tree.append_child(shadow, style)
+  let inner = tree.create_element("span")
+  let _ = tree.set_attribute(inner, "class", "inner")
+  let _ = tree.append_child(shadow, inner)
+  let rules = tree.shadow_stylesheet_rules(shadow)
+  let ctx = RenderContext::default()
+
+  // :host { display: flex } reaches the host's computed Style.
+  let host_style = compute_shadow_element_style(
+    tree,
+    host,
+    rules,
+    host,
+    ctx,
+    None,
+  )
+  inspect(host_style.display, content="Flex")
+
+  // .inner { width: 50px } reaches the inner node; :host does not.
+  let inner_style = compute_shadow_element_style(
+    tree,
+    host,
+    rules,
+    inner,
+    ctx,
+    None,
+  )
+  inspect(
+    inner_style.width,
+    content=(
+      #|Length(50)
+    ),
+  )
+  inspect(
+    inner_style.display,
+    content=(
+      #|Inline
+    ),
+  )
+}


### PR DESCRIPTION
## Summary

Third slice of #285. Wires the shadow cascade (PR 1) into the renderer's post-cascade pipeline (PR 2). The renderer now depends on `mizchi/crater-dom/dom`.

- **dom**: add public `DomTree::node_to_selector_element(id) -> @selector.Element?`, projecting an element node (tag / id / classes / attrs + element sibling index/count, no ancestor chain) into the type `@css.Element` re-exports.
- **renderer**: add `compute_shadow_element_style(tree, host, rules, target, ctx, parent_style) -> @style.Style`. It projects `target`, cascades the shadow root's rules via `shadow_cascaded_values`, and folds the result through `apply_cascaded_to_style`.

So a shadow root's `<style>` now produces a concrete computed style for its host / slotted / inner nodes. PR 4 adds the composed-tree render entry that walks a DomTree and calls this for shadow-scoped nodes.

## Testing
- dom: **992 pass**; renderer full suite: **3550 pass** (1 new).
- The new test asserts `:host { display: flex }` reaches the host (`display=Flex`), `.inner { width: 50px }` reaches the inner span (`width=Length(50)`) without `:host` leaking (`display=Inline`).
- `.mbti`: +1 public fn each in dom and renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_