### PR TITLE
renderer(shadow): compute styles for a whole shadow subtree (#285, PR 4)

### DIFF
--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -28,6 +28,8 @@ pub fn compute_layout_from_render_root(@node.Node, PreparedRenderDocument, Rende
 
 pub fn compute_shadow_element_style(@dom.DomTree, @dom.NodeId, Array[@cascade.CSSRule], @dom.NodeId, RenderContext, @style.Style?) -> @style.Style
 
+pub fn compute_shadow_tree_styles(@dom.DomTree, @dom.NodeId, RenderContext, @style.Style?) -> Map[Int, @style.Style]
+
 pub fn element_to_node(@html.Element, @style.Style?) -> @node.Node
 
 pub fn get_content_height(String, Int, Int) -> Int

--- a/renderer/renderer/shadow_style.mbt
+++ b/renderer/renderer/shadow_style.mbt
@@ -38,3 +38,71 @@ pub fn compute_shadow_element_style(
     css_vars,
   )
 }
+
+///|
+/// Compute `@style.Style` for the shadow host and every element in its shadow
+/// tree, keyed by node id (`NodeId::to_int`). The host is styled by its `:host`
+/// rules and inherits from `host_parent_style` (its light-DOM context); each
+/// shadow node inherits from its parent's computed style, threading inheritance
+/// across the shadow boundary (host -> top-level shadow nodes -> descendants).
+///
+/// `<style>` elements and non-element nodes are skipped. Returns an empty map
+/// when `host` has no shadow root. Slotted light nodes are styled from the light
+/// tree, not here.
+pub fn compute_shadow_tree_styles(
+  tree : @dom.DomTree,
+  host : @dom.NodeId,
+  ctx : RenderContext,
+  host_parent_style : @style.Style?,
+) -> Map[Int, @style.Style] {
+  let styles : Map[Int, @style.Style] = {}
+  let shadow_root = match tree.get_shadow_root(host) {
+    Ok(Some(root)) => root
+    _ => return styles
+  }
+  let rules = tree.shadow_stylesheet_rules(shadow_root)
+  let host_style = compute_shadow_element_style(
+    tree, host, rules, host, ctx, host_parent_style,
+  )
+  styles[host.to_int()] = host_style
+  style_shadow_subtree(tree, host, rules, shadow_root, host_style, ctx, styles)
+  styles
+}
+
+///|
+/// Recursively style the element children of `parent_node`, each inheriting
+/// from `parent_style`, accumulating into `styles`.
+fn style_shadow_subtree(
+  tree : @dom.DomTree,
+  host : @dom.NodeId,
+  rules : Array[@css.CSSRule],
+  parent_node : @dom.NodeId,
+  parent_style : @style.Style,
+  ctx : RenderContext,
+  styles : Map[Int, @style.Style],
+) -> Unit {
+  let children = match tree.get_children(parent_node) {
+    Ok(children) => children
+    Err(_) => return
+  }
+  for child in children {
+    let tag = match tree.get_tag_name(child) {
+      Ok(tag) => tag.to_lower()
+      Err(_) => ""
+    }
+    if tag == "style" {
+      continue
+    }
+    guard tree.node_to_selector_element(child) is Some(_) else { continue }
+    let child_style = compute_shadow_element_style(
+      tree,
+      host,
+      rules,
+      child,
+      ctx,
+      Some(parent_style),
+    )
+    styles[child.to_int()] = child_style
+    style_shadow_subtree(tree, host, rules, child, child_style, ctx, styles)
+  }
+}

--- a/renderer/renderer/shadow_style_test.mbt
+++ b/renderer/renderer/shadow_style_test.mbt
@@ -52,3 +52,43 @@ test "compute_shadow_element_style applies :host and inner rules to Style" {
     ),
   )
 }
+
+///|
+test "compute_shadow_tree_styles threads inheritance across the boundary" {
+  let tree = @dom.DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("div")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+  let style = tree.create_element("style")
+  // color on :host should inherit into shadow descendants; font-size set on the
+  // wrapper inherits into its child.
+  let _ = tree.set_text_content(
+    style, ":host { color: rgb(10, 20, 30) } .wrap { font-size: 20px }",
+  )
+  let _ = tree.append_child(shadow, style)
+  let wrap = tree.create_element("div")
+  let _ = tree.set_attribute(wrap, "class", "wrap")
+  let _ = tree.append_child(shadow, wrap)
+  let leaf = tree.create_element("span")
+  let _ = tree.append_child(wrap, leaf)
+  let styles = compute_shadow_tree_styles(
+    tree,
+    host,
+    RenderContext::default(),
+    None,
+  )
+
+  // Host, wrapper, and leaf are all styled.
+  inspect(styles.size(), content="3")
+
+  // font-size: 20px on .wrap inherits into its leaf child.
+  let wrap_style = styles.get(wrap.to_int()).unwrap()
+  let leaf_style = styles.get(leaf.to_int()).unwrap()
+  inspect(wrap_style.font_size, content="20")
+  inspect(leaf_style.font_size, content="20")
+
+  // :host color inherits across the boundary down to the leaf.
+  let host_style = styles.get(host.to_int()).unwrap()
+  inspect(host_style.color == leaf_style.color, content="true")
+}


### PR DESCRIPTION
## Summary

Fourth slice of #285. Adds `compute_shadow_tree_styles(tree, host, ctx, host_parent_style) -> Map[Int, @style.Style]`, extending PR 3 from a single node to the host plus every element in its shadow tree.

- The host is styled by its `:host` rules and inherits from its light-DOM context (`host_parent_style`).
- Each shadow node inherits from its parent's computed style, so inheritance threads **across the shadow boundary** (host → top-level shadow nodes → descendants) and within the tree.
- `<style>` and non-element nodes are skipped.

Still style-only (no layout). The composed-tree render entry that turns these styles into a `Layout` is intentionally **deferred** — it touches the core render/layout path and slot distribution, which warrants its own review.

## Testing
- Renderer suite: **3551 pass** (1 new). The test asserts host/wrap/leaf are all styled (`size()==3`), `.wrap { font-size: 20px }` inherits into the leaf (20 → 20), and `:host` color inherits across the boundary so `host.color == leaf.color`.
- `.mbti`: +1 public fn (`compute_shadow_tree_styles`).

## Roadmap remaining
- PR 5 (deferred, needs review): `render_dom_tree` composed-tree → `Layout` entry, slot distribution, `::slotted` light-node styling from the host, nested shadow ordering, WPT regression → closes #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_