### PR TITLE
renderer(shadow): ::slotted styling for assigned light nodes (#285, PR 5)

### DIFF
--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -30,6 +30,8 @@ pub fn compute_shadow_element_style(@dom.DomTree, @dom.NodeId, Array[@cascade.CS
 
 pub fn compute_shadow_tree_styles(@dom.DomTree, @dom.NodeId, RenderContext, @style.Style?) -> Map[Int, @style.Style]
 
+pub fn compute_slotted_styles(@dom.DomTree, @dom.NodeId, RenderContext, @style.Style?) -> Map[Int, @style.Style]
+
 pub fn element_to_node(@html.Element, @style.Style?) -> @node.Node
 
 pub fn get_content_height(String, Int, Int) -> Int

--- a/renderer/renderer/shadow_style.mbt
+++ b/renderer/renderer/shadow_style.mbt
@@ -106,3 +106,42 @@ fn style_shadow_subtree(
     style_shadow_subtree(tree, host, rules, child, child_style, ctx, styles)
   }
 }
+
+///|
+/// Compute the shadow-scoped `@style.Style` contribution for the host's slotted
+/// light children, keyed by node id. A light child assigned to a slot in the
+/// host's shadow tree is matched against that shadow's `::slotted(...)` rules
+/// (via `compute_shadow_element_style`, PR 3) and inherits from `host_style`
+/// (its light-DOM parent context).
+///
+/// Only element light children that are actually assigned to a slot are
+/// included; non-slotted children and non-elements are skipped. This is the
+/// shadow-side contribution only — a slotted node's document/light styles come
+/// from the light tree and are merged by the (deferred) composed-tree walk.
+/// Returns an empty map when `host` has no shadow root.
+pub fn compute_slotted_styles(
+  tree : @dom.DomTree,
+  host : @dom.NodeId,
+  ctx : RenderContext,
+  host_style : @style.Style?,
+) -> Map[Int, @style.Style] {
+  let styles : Map[Int, @style.Style] = {}
+  let shadow_root = match tree.get_shadow_root(host) {
+    Ok(Some(root)) => root
+    _ => return styles
+  }
+  let rules = tree.shadow_stylesheet_rules(shadow_root)
+  let light_children = match tree.get_children(host) {
+    Ok(children) => children
+    Err(_) => return styles
+  }
+  for child in light_children {
+    guard tree.node_to_selector_element(child) is Some(_) else { continue }
+    guard tree.assigned_slot(child) is Some(_) else { continue }
+    let child_style = compute_shadow_element_style(
+      tree, host, rules, child, ctx, host_style,
+    )
+    styles[child.to_int()] = child_style
+  }
+  styles
+}

--- a/renderer/renderer/shadow_style_test.mbt
+++ b/renderer/renderer/shadow_style_test.mbt
@@ -92,3 +92,39 @@ test "compute_shadow_tree_styles threads inheritance across the boundary" {
   let host_style = styles.get(host.to_int()).unwrap()
   inspect(host_style.color == leaf_style.color, content="true")
 }
+
+///|
+test "compute_slotted_styles applies ::slotted rules to assigned light nodes" {
+  let tree = @dom.DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("div")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+  let style = tree.create_element("style")
+  let _ = tree.set_text_content(
+    style, "::slotted(.tag) { color: rgb(1, 2, 3) }",
+  )
+  let _ = tree.append_child(shadow, style)
+  let slot = tree.create_element("slot")
+  let _ = tree.append_child(shadow, slot)
+  // Light children of the host are distributed to the default slot.
+  let tagged = tree.create_element("span")
+  let _ = tree.set_attribute(tagged, "class", "tag")
+  let _ = tree.append_child(host, tagged)
+  let plain = tree.create_element("span")
+  let _ = tree.append_child(host, plain)
+  let styles = compute_slotted_styles(
+    tree,
+    host,
+    RenderContext::default(),
+    None,
+  )
+
+  // Both light children are slotted, so both receive an entry.
+  inspect(styles.size(), content="2")
+
+  // Only .tag matches ::slotted(.tag): its color differs from the plain node's.
+  let tagged_style = styles.get(tagged.to_int()).unwrap()
+  let plain_style = styles.get(plain.to_int()).unwrap()
+  inspect(tagged_style.color == plain_style.color, content="false")
+}


### PR DESCRIPTION
## Summary

Fifth slice of #285. Adds `compute_slotted_styles(tree, host, ctx, host_style) -> Map[Int, @style.Style]`.

A light child assigned to a slot in the host's shadow tree is matched against that shadow's `::slotted(...)` rules (via `compute_shadow_element_style`, PR 3) and inherits from `host_style` (its light-DOM parent context). Only slotted element children are included; non-slotted children and non-elements are skipped.

This is the shadow-side contribution for slotted nodes — their document/light styles still come from the light tree and are merged by the (deferred) composed-tree walk.

With this, the three shadow selector forms from #285 each have a style-level path: `:host`/`:host-context` (PR 3–4) and `::slotted` (this PR), all driven by the #286 `matches_shadow_scoped` matcher.

## Testing
- Renderer suite: **3552 pass** (1 new). Two light children are distributed to the default slot (`size()==2`) and `::slotted(.tag)` applies only to the tagged node (its color differs from the plain node's).
- `.mbti`: +1 public fn (`compute_slotted_styles`).

## Roadmap remaining (deferred, needs its own review)
- `render_dom_tree` composed-tree → `Layout` entry: merge document + shadow + slotted styles into actual layout, slot distribution in the box tree, nested shadow ordering, WPT regression → closes #285. Flagged earlier as architecturally significant (core render/layout path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_