### PR TITLE
renderer(shadow): composed shadow-style capstone for DomTree (#285, PR 6)

### DIFF
--- a/renderer/renderer/composed_shadow_style.mbt
+++ b/renderer/renderer/composed_shadow_style.mbt
@@ -1,0 +1,89 @@
+///|
+/// Composed shadow-scoped styling for a whole DomTree (#285, PR 6).
+///
+/// Walks the light DOM from the document root and folds together every shadow
+/// host's contribution into one `NodeId::to_int`-keyed style map:
+///
+/// - each host plus its shadow-subtree elements via `compute_shadow_tree_styles`
+///   (PR 3), threading inheritance across the boundary;
+/// - the host's slotted light children's `::slotted(...)` contribution via
+///   `compute_slotted_styles` (PR 5);
+/// - nested shadow roots: a host living inside another host's shadow tree (or
+///   slotted into one) is composed too, inheriting from its own computed style.
+///
+/// The returned map covers shadow hosts, shadow-subtree elements, and slotted
+/// light nodes. Plain light nodes that are neither hosts nor slotted are absent:
+/// the DomTree has no document-scope cascade, so this is the shadow-scoped
+/// composition only. It is the capstone over the PR 1-5 building blocks.
+pub fn compute_composed_shadow_styles(
+  tree : @dom.DomTree,
+  ctx : RenderContext,
+) -> Map[Int, @style.Style] {
+  let styles : Map[Int, @style.Style] = {}
+  compose_node(tree, tree.get_document(), ctx, styles)
+  styles
+}
+
+///|
+/// Visit `node` in the light tree: if it is a shadow host, compose it; then
+/// recurse into its light children (slotted or not) to reach hosts nested
+/// deeper. A host already styled by an ancestor's slotted pass inherits from
+/// that style when composing its own shadow tree.
+fn compose_node(
+  tree : @dom.DomTree,
+  node : @dom.NodeId,
+  ctx : RenderContext,
+  styles : Map[Int, @style.Style],
+) -> Unit {
+  if tree.get_shadow_root(node) is Ok(Some(_)) {
+    compose_host(tree, node, styles.get(node.to_int()), ctx, styles)
+  }
+  let children = match tree.get_children(node) {
+    Ok(children) => children
+    Err(_) => return
+  }
+  for child in children {
+    compose_node(tree, child, ctx, styles)
+  }
+}
+
+///|
+/// Compose a single shadow `host`: establish the host's authoritative style,
+/// style its shadow-subtree descendants and slotted light children, then descend
+/// through its shadow tree to compose any nested hosts.
+///
+/// A host element belongs to its *outer* scope, so when an outer pass has
+/// already styled it (`styles` holds an entry — e.g. a nested host matched by an
+/// enclosing shadow tree, or a slotted node) that style stays authoritative and
+/// the shadow subtree inherits from it. Only a top-level host with no prior
+/// entry is styled here from its own `:host` rules, inheriting from
+/// `host_parent_style`. (A nested host's own-shadow `:host` rules are not layered
+/// on top of its outer style yet — a known gap for this composition pass.)
+fn compose_host(
+  tree : @dom.DomTree,
+  host : @dom.NodeId,
+  host_parent_style : @style.Style?,
+  ctx : RenderContext,
+  styles : Map[Int, @style.Style],
+) -> Unit {
+  let shadow_root = match tree.get_shadow_root(host) {
+    Ok(Some(root)) => root
+    _ => return
+  }
+  let rules = tree.shadow_stylesheet_rules(shadow_root)
+  let host_style = match styles.get(host.to_int()) {
+    Some(existing) => existing
+    None => {
+      let computed = compute_shadow_element_style(
+        tree, host, rules, host, ctx, host_parent_style,
+      )
+      styles[host.to_int()] = computed
+      computed
+    }
+  }
+  style_shadow_subtree(tree, host, rules, shadow_root, host_style, ctx, styles)
+  for id, style in compute_slotted_styles(tree, host, ctx, Some(host_style)) {
+    styles[id] = style
+  }
+  compose_node(tree, shadow_root, ctx, styles)
+}

--- a/renderer/renderer/composed_shadow_style_test.mbt
+++ b/renderer/renderer/composed_shadow_style_test.mbt
@@ -1,0 +1,68 @@
+///|
+/// Composed shadow styling (#285, PR 6): one walk over a DomTree folds together
+/// host styles, slotted contributions, and nested shadow roots into a single
+/// style map. This is the composition the per-host building blocks cannot do
+/// alone: `compute_shadow_tree_styles` styles one shadow tree but does not
+/// descend into nested shadow roots within it.
+test "compute_composed_shadow_styles composes nested shadow and slotted nodes" {
+  let tree = @dom.DomTree::new()
+  let doc = tree.get_document()
+
+  // Top-level host with an open shadow root.
+  let host = tree.create_element("div")
+  let _ = tree.append_child(doc, host)
+  let shadow_a = tree.attach_shadow(host, "open").unwrap()
+  let style_a = tree.create_element("style")
+  let _ = tree.set_text_content(
+    style_a, ":host { display: flex } ::slotted(.tag) { width: 3px } .mid { width: 10px }",
+  )
+  let _ = tree.append_child(shadow_a, style_a)
+  let slot = tree.create_element("slot")
+  let _ = tree.append_child(shadow_a, slot)
+
+  // A nested host lives inside the top host's shadow tree.
+  let inner = tree.create_element("div")
+  let _ = tree.set_attribute(inner, "class", "mid")
+  let _ = tree.append_child(shadow_a, inner)
+  let shadow_b = tree.attach_shadow(inner, "open").unwrap()
+  let style_b = tree.create_element("style")
+  let _ = tree.set_text_content(style_b, ".deep { width: 7px }")
+  let _ = tree.append_child(shadow_b, style_b)
+  let deep = tree.create_element("span")
+  let _ = tree.set_attribute(deep, "class", "deep")
+  let _ = tree.append_child(shadow_b, deep)
+
+  // A light child of the top host, distributed to the default slot.
+  let tagged = tree.create_element("span")
+  let _ = tree.set_attribute(tagged, "class", "tag")
+  let _ = tree.append_child(host, tagged)
+  let styles = compute_composed_shadow_styles(tree, RenderContext::default())
+
+  // Host's :host rule reaches its computed style.
+  inspect(styles.get(host.to_int()).unwrap().display, content="Flex")
+
+  // .mid in shadow A reaches the nested host element.
+  inspect(
+    styles.get(inner.to_int()).unwrap().width,
+    content=(
+      #|Length(10)
+    ),
+  )
+
+  // The nested shadow root (B) is composed: .deep reaches the deep node, which
+  // the per-host building block alone would never visit.
+  inspect(
+    styles.get(deep.to_int()).unwrap().width,
+    content=(
+      #|Length(7)
+    ),
+  )
+
+  // The slotted light child receives its ::slotted(.tag) contribution.
+  inspect(
+    styles.get(tagged.to_int()).unwrap().width,
+    content=(
+      #|Length(3)
+    ),
+  )
+}

--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -24,6 +24,8 @@ pub fn clear_image_intrinsic_size_provider() -> Unit
 
 pub fn clear_text_metrics_provider() -> Unit
 
+pub fn compute_composed_shadow_styles(@dom.DomTree, RenderContext) -> Map[Int, @style.Style]
+
 pub fn compute_layout_from_render_root(@node.Node, PreparedRenderDocument, RenderContext) -> @crater-core.Layout
 
 pub fn compute_shadow_element_style(@dom.DomTree, @dom.NodeId, Array[@cascade.CSSRule], @dom.NodeId, RenderContext, @style.Style?) -> @style.Style


### PR DESCRIPTION
## Summary

Capstone over the PR 1–5 shadow-styling building blocks: `compute_composed_shadow_styles(tree, ctx)` walks a whole `DomTree` once and folds every shadow host's contribution into a single `NodeId`-keyed `@style.Style` map.

For each host it composes:
- the host plus its shadow-subtree elements (threading inheritance across the boundary),
- the host's slotted light children's `::slotted(...)` contribution,
- **nested shadow roots** — a host living inside another host's shadow tree (or slotted into one) is composed too, inheriting from its own computed style.

A host element belongs to its **outer** scope, so when an enclosing pass has already styled it, that style stays authoritative and the shadow subtree inherits from it. This is the composition the per-host blocks cannot do alone: `compute_shadow_tree_styles` styles one shadow tree but never descends into nested shadow roots within it.

## Scope

The `DomTree` has no document-scope cascade, so plain light nodes (neither hosts nor slotted) are intentionally absent — this is the **shadow-scoped composition** only. Producing full document `Layout` from a `DomTree` is deferred until a document-scope cascade exists for that representation. Known minor gap: a nested host's own-shadow `:host` rules are not yet layered on top of its outer-scope style.

## Test

`compute_composed_shadow_styles composes nested shadow and slotted nodes` builds a host whose shadow tree contains a nested host (shadow B) plus a slotted light child, and asserts: `:host` reaches the top host, the outer `.mid` rule reaches the nested host, the **nested** shadow's `.deep` rule reaches the deep node (unreachable by the per-host block), and `::slotted(.tag)` reaches the slotted child. Full package suite: 392 passed. `moon info && moon fmt` applied; `.mbti` delta is the single new public function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_