### PR TITLE
dom(shadow): shadow-scoped querySelector with :host resolution (#286)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,7 @@ pkf run spec-check                                          # contract が壊れ
 
 | scenario id | 概要 | link | 状態 |
 |---|---|---|---|
-| `compat.web-components-shadow-selectors` | `:host` 複合 / `::slotted` / `:host-context` | #155 (umbrella) → #285 / #286 | 分割済: スタイリング経路 #285 は landed (PR #288–#293, scenario `compat.shadow-static-styling` approved) — shadow-scoped マッチ→cascade→`compute_composed_shadow_styles` まで実装。DOM query 経路 #286 は crater 単独で着手可。slot 割当 API (assignedNodes/Elements/assignedSlot) は landed |
+| `compat.web-components-shadow-selectors` | `:host` 複合 / `::slotted` / `:host-context` | #155 (umbrella) → #285 / #286 | 両経路 landed: スタイリング #285 (PR #288–#293, scenario `compat.shadow-static-styling` approved) — shadow-scoped マッチ→cascade→`compute_composed_shadow_styles`。DOM query #286 (scenario `compat.shadow-query-selector` approved) — `shadow_query_selector` が compound/combinator + `:host()`/`:host-context()` をシャドウスコープで解決。slot 割当 API (assignedNodes/Elements/assignedSlot) も landed |
 | `compat.web-components-element-internals` | closed shadow / declarative SD / form-associated | #156 | crater 内部 |
 | `compat.browser-shell-form-controls` | select popup / blur change / IME / caret | #159 | crater 内部 |
 | `compat.native-form-control-appearance` | select / button native appearance 方針 | #160 | 方針判断含む |

--- a/dom/dom/pkg.generated.mbti
+++ b/dom/dom/pkg.generated.mbti
@@ -110,6 +110,8 @@ pub fn DomTree::set_focus(Self, NodeId?) -> Unit
 pub fn DomTree::set_form_associated_state(Self, NodeId, String?, String?) -> Result[Unit, CoreError]
 pub fn DomTree::set_text_content(Self, NodeId, String) -> Result[Unit, CoreError]
 pub fn DomTree::shadow_cascaded_values(Self, NodeId, Array[@cascade.CSSRule], NodeId) -> @cascade.CascadedValues
+pub fn DomTree::shadow_query_selector(Self, NodeId, String) -> Result[NodeId?, CoreError]
+pub fn DomTree::shadow_query_selector_all(Self, NodeId, String) -> Result[Array[NodeId], CoreError]
 pub fn DomTree::shadow_stylesheet_rules(Self, NodeId) -> Array[@cascade.CSSRule]
 pub fn DomTree::slot_assigned_elements(Self, NodeId, flatten? : Bool) -> Array[NodeId]
 pub fn DomTree::slot_assigned_nodes(Self, NodeId, flatten? : Bool) -> Array[NodeId]

--- a/dom/dom/shadow_query.mbt
+++ b/dom/dom/shadow_query.mbt
@@ -10,8 +10,12 @@
 /// slot assignment) or, for ordinary compounds, delegated back to
 /// `@selector.matches_complex`.
 ///
-/// This is the matching primitive a shadow-tree style cascade will use; it is
-/// not wired into `querySelector` because `:host` does not match there per spec.
+/// This is the matching primitive the shadow-tree style cascade uses (#285) and
+/// the shadow-scoped `query_selector` (`shadow_query.mbt`, #286) uses for
+/// shadow-root queries. A shadow-root query only considers the shadow tree's own
+/// descendants, so a bare `:host` selector still matches nothing (the host is
+/// not a descendant, matching browser `querySelector` semantics), while
+/// `:host(...) x` / `:host-context(...) x` combinators resolve through the host.
 
 ///|
 /// Match `subject` against `selector` as authored inside the shadow tree whose
@@ -34,12 +38,25 @@ pub fn DomTree::matches_shadow_scoped(
     None =>
       return Err(InvalidOperation(message="invalid selector: \{selector}"))
   }
+  Ok(self.matches_shadow_scoped_list(subject, list, host))
+}
+
+///|
+/// Match `subject` against an already-parsed selector `list` in the shadow scope
+/// whose host is `host`. Shared by the string entry point and the shadow-scoped
+/// `query_selector` walk so a query parses the selector once, not per candidate.
+fn DomTree::matches_shadow_scoped_list(
+  self : DomTree,
+  subject : NodeId,
+  list : @selector.SelectorList,
+  host : NodeId,
+) -> Bool {
   for cs in list.selectors {
     if self.complex_matches_scoped(subject, cs, host) {
-      return Ok(true)
+      return true
     }
   }
-  Ok(false)
+  false
 }
 
 ///|

--- a/dom/dom/shadow_query_selector.mbt
+++ b/dom/dom/shadow_query_selector.mbt
@@ -1,0 +1,99 @@
+///|
+/// Shadow-scoped `querySelector` / `querySelectorAll` (#286).
+///
+/// `query_selector` (`query.mbt`) scopes to a node's descendants using the plain
+/// `mizchi/css` matcher, which cannot resolve the shadow-scoping pseudo-classes.
+/// These entries query *inside a shadow root* and route matching through
+/// `matches_shadow_scoped` (#285) so `:host(...)` and `:host-context(...)`
+/// resolve against the live shadow relationships. (`::slotted()` targets light
+/// nodes, which are not shadow-tree descendants, and is a styling pseudo-element
+/// not matched by `querySelector` — see #286 — so it never selects here.)
+///
+/// Candidates are the shadow root's element descendants in document order;
+/// nested shadow trees are not crossed (a shadow host inside the tree contributes
+/// only its light children, never its own shadow root). The scope root itself is
+/// never returned, matching `querySelectorAll` semantics.
+
+///|
+/// Shadow-scoped `querySelectorAll`: every shadow-tree element selected by
+/// `selector`, in document order. `shadow_root` must be a shadow root node; its
+/// host (resolved from the shadow root) anchors `:host` / `:host-context` /
+/// `::slotted` resolution. An invalid selector yields `InvalidOperation`.
+pub fn DomTree::shadow_query_selector_all(
+  self : DomTree,
+  shadow_root : NodeId,
+  selector : String,
+) -> Result[Array[NodeId], CoreError] {
+  let root_node = match self.nodes.get(shadow_root.to_int()) {
+    Some(node) => node
+    None => return Err(NodeNotFound(node_id=shadow_root))
+  }
+  guard root_node.node_type == ShadowRoot else {
+    return Err(
+      InvalidOperation(message="node is not a shadow root: \{shadow_root}"),
+    )
+  }
+  let host = match root_node.host_id {
+    Some(id) => NodeId(id)
+    None =>
+      return Err(
+        InvalidOperation(message="shadow root has no host: \{shadow_root}"),
+      )
+  }
+  let list = match @selector.parse_selector_list_text(selector) {
+    Some(list) => list
+    None =>
+      return Err(InvalidOperation(message="invalid selector: \{selector}"))
+  }
+  let results : Array[NodeId] = []
+  self.shadow_query_collect(shadow_root, host, list, results)
+  Ok(results)
+}
+
+///|
+/// Shadow-scoped `querySelector`: the first shadow-tree element selected by
+/// `selector` in document order, or `None`.
+pub fn DomTree::shadow_query_selector(
+  self : DomTree,
+  shadow_root : NodeId,
+  selector : String,
+) -> Result[NodeId?, CoreError] {
+  match self.shadow_query_selector_all(shadow_root, selector) {
+    Ok(results) =>
+      if results.length() > 0 {
+        Ok(Some(results[0]))
+      } else {
+        Ok(None)
+      }
+    Err(e) => Err(e)
+  }
+}
+
+///|
+/// Walk the element descendants of `node` in document order, testing each with
+/// the shadow-aware matcher and recursing through light children only (nested
+/// shadow roots are not entered).
+fn DomTree::shadow_query_collect(
+  self : DomTree,
+  node : NodeId,
+  host : NodeId,
+  list : @selector.SelectorList,
+  results : Array[NodeId],
+) -> Unit {
+  let n = match self.nodes.get(node.to_int()) {
+    Some(n) => n
+    None => return
+  }
+  for child_id in n.children {
+    match self.nodes.get(child_id) {
+      Some(child) if child.node_type == Element => {
+        let child_node = NodeId(child_id)
+        if self.matches_shadow_scoped_list(child_node, list, host) {
+          results.push(child_node)
+        }
+        self.shadow_query_collect(child_node, host, list, results)
+      }
+      _ => ()
+    }
+  }
+}

--- a/dom/dom/shadow_query_selector_test.mbt
+++ b/dom/dom/shadow_query_selector_test.mbt
@@ -1,0 +1,100 @@
+///|
+/// Shadow-scoped querySelector (#286): querying inside a shadow root supports
+/// compound selectors and combinators, resolves `:host(...)` / `:host-context`
+/// through the host, scopes to the shadow tree (never crossing nested shadow
+/// roots), and reports invalid input as errors.
+test "shadow_query_selector handles compounds, combinators, and :host scoping" {
+  let tree = DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("section")
+  let _ = tree.set_attribute(host, "class", "theme")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+  let box = tree.create_element("div")
+  let _ = tree.set_attribute(box, "class", "box")
+  let _ = tree.append_child(shadow, box)
+  let leaf = tree.create_element("span")
+  let _ = tree.set_attribute(leaf, "class", "leaf")
+  let _ = tree.append_child(box, leaf)
+  let other = tree.create_element("span")
+  let _ = tree.append_child(shadow, other)
+
+  // Compound + child combinator resolves the nested leaf.
+  match tree.shadow_query_selector(shadow, "div.box > span.leaf") {
+    Ok(Some(n)) => inspect(n.to_int() == leaf.to_int(), content="true")
+    _ => fail("expected leaf")
+  }
+
+  // :host(.theme) anchors a descendant query at the host: both shadow spans match.
+  let scoped = tree
+    .shadow_query_selector_all(shadow, ":host(.theme) span")
+    .unwrap()
+  inspect(scoped.length(), content="2")
+  inspect(scoped[0].to_int() == leaf.to_int(), content="true")
+  inspect(scoped[1].to_int() == other.to_int(), content="true")
+
+  // A non-matching :host argument selects nothing.
+  inspect(
+    tree
+    .shadow_query_selector_all(shadow, ":host(.nope) span")
+    .unwrap()
+    .length(),
+    content="0",
+  )
+
+  // A bare :host matches nothing: the host is not a shadow-tree descendant.
+  match tree.shadow_query_selector(shadow, ":host") {
+    Ok(None) => inspect(true, content="true")
+    _ => fail("expected None")
+  }
+}
+
+///|
+/// A shadow-root query stays within its own shadow tree: a nested shadow host's
+/// shadow content is never visited.
+test "shadow_query_selector does not cross into nested shadow roots" {
+  let tree = DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("div")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+  let inner_host = tree.create_element("div")
+  let _ = tree.append_child(shadow, inner_host)
+  let inner_shadow = tree.attach_shadow(inner_host, "open").unwrap()
+  let deep = tree.create_element("span")
+  let _ = tree.set_attribute(deep, "class", "deep")
+  let _ = tree.append_child(inner_shadow, deep)
+
+  // .deep lives in the nested shadow tree, so the outer query cannot reach it.
+  inspect(
+    tree.shadow_query_selector_all(shadow, ".deep").unwrap().length(),
+    content="0",
+  )
+  // Querying the nested shadow root directly finds it.
+  match tree.shadow_query_selector(inner_shadow, ".deep") {
+    Ok(Some(n)) => inspect(n.to_int() == deep.to_int(), content="true")
+    _ => fail("expected deep")
+  }
+}
+
+///|
+/// Invalid input is reported, not silently empty: a non-shadow-root scope and an
+/// unparseable selector both error.
+test "shadow_query_selector rejects non-shadow-root scope and invalid selector" {
+  let tree = DomTree::new()
+  let doc = tree.get_document()
+  let host = tree.create_element("div")
+  let _ = tree.append_child(doc, host)
+  let shadow = tree.attach_shadow(host, "open").unwrap()
+
+  // Scope must be a shadow root, not an ordinary element.
+  match tree.shadow_query_selector_all(host, "div") {
+    Err(InvalidOperation(..)) => inspect(true, content="true")
+    _ => fail("expected InvalidOperation")
+  }
+  // Unparseable selector errors rather than matching nothing.
+  match tree.shadow_query_selector_all(shadow, "div >") {
+    Err(InvalidOperation(..)) => inspect(true, content="true")
+    _ => fail("expected InvalidOperation")
+  }
+}

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -461,6 +461,16 @@ scenarios {
     contributes { "goal.dom-compat" }
   }
   new {
+    id = "compat.shadow-query-selector"
+    name = "Shadow-root querySelector resolves compounds and combinators with host scoping"
+    description =
+      "DomTree::shadow_query_selector / shadow_query_selector_all query inside a shadow root with the full mizchi/css compound + combinator matcher and route shadow-scoping pseudos through DomTree::matches_shadow_scoped so :host() and :host-context() resolve against the host. Candidates are the shadow tree's element descendants in document order; nested shadow roots are not crossed and a bare :host matches nothing, matching querySelector semantics. ::slotted is a styling pseudo-element and is out of scope. Source: GitHub issue #286."
+    tags { "dom"; "shadow"; "selectors"; "query"; "issue:286" }
+    severity = "major"
+    reviewStatus = "approved"
+    contributes { "goal.dom-compat" }
+  }
+  new {
     id = "compat.web-components-element-internals"
     name = "Web Components advanced surface is covered"
     description =

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -844,4 +844,14 @@ tests {
     cmd =
       "bash -lc 'set -e; grep -Fq -- \"pub fn compute_shadow_element_style\" renderer/renderer/shadow_style.mbt; grep -Fq -- \"pub fn compute_shadow_tree_styles\" renderer/renderer/shadow_style.mbt; grep -Fq -- \"pub fn compute_slotted_styles\" renderer/renderer/shadow_style.mbt; grep -Fq -- \"pub fn compute_composed_shadow_styles\" renderer/renderer/composed_shadow_style.mbt; grep -Fq -- \"compute_shadow_element_style applies :host and inner rules to Style\" renderer/renderer/shadow_style_test.mbt; grep -Fq -- \"compute_slotted_styles applies ::slotted rules to assigned light nodes\" renderer/renderer/shadow_style_test.mbt; grep -Fq -- \"compute_composed_shadow_styles composes nested shadow and slotted nodes\" renderer/renderer/composed_shadow_style_test.mbt'"
   }
+  new {
+    name = "shadow_query_selector_resolves_compounds_and_host_scoping"
+    description =
+      "DomTree::shadow_query_selector / shadow_query_selector_all query inside a shadow root with the mizchi/css compound + combinator matcher and resolve :host() / :host-context() through matches_shadow_scoped, scoping to the shadow tree's descendants without crossing nested shadow roots (#286)."
+    tags { "dom"; "shadow"; "selectors"; "query"; "issue:286" }
+    specRef { "compat.shadow-query-selector" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"pub fn DomTree::shadow_query_selector_all\" dom/dom/shadow_query_selector.mbt; grep -Fq -- \"pub fn DomTree::shadow_query_selector(\" dom/dom/shadow_query_selector.mbt; grep -Fq -- \"shadow_query_selector handles compounds, combinators, and :host scoping\" dom/dom/shadow_query_selector_test.mbt; grep -Fq -- \"shadow_query_selector does not cross into nested shadow roots\" dom/dom/shadow_query_selector_test.mbt; grep -Fq -- \"shadow_query_selector rejects non-shadow-root scope and invalid selector\" dom/dom/shadow_query_selector_test.mbt'"
+  }
 }


### PR DESCRIPTION
Closes #286.

## Summary

Adds shadow-scoped `querySelector` / `querySelectorAll` to `DomTree`, completing the **DOM query** half of the shadow-selector surface (#155).

- **`DomTree::shadow_query_selector_all(shadow_root, selector)`** / **`shadow_query_selector(...)`** — query inside a shadow root, routing matching through `matches_shadow_scoped` (#285) so `:host(...)` and `:host-context(...)` resolve against the host, with the full `mizchi/css` compound + combinator matcher for ordinary selectors.
- **Scoping:** candidates are the shadow tree's element descendants in document order; nested shadow roots are **not** crossed; a bare `:host` matches nothing (the host is not a descendant), matching browser `querySelector` semantics.
- **`::slotted`** is a styling pseudo-element targeting light nodes and is out of scope per the issue.
- Shared a parsed-list helper (`matches_shadow_scoped_list`) so a query parses the selector **once**, not per candidate, and refreshed the stale "not wired into querySelector" note in `shadow_query.mbt`.

The light-tree matcher in `query.mbt` already handles compounds/combinators, so this fills the remaining shadow-aware gap rather than rebuilding the matcher.

## Tests (`dom/dom`, 3 new, 49/49 pass)

- compounds + child combinator, `:host(.theme) span` resolving through the host, non-matching `:host(...)`, and bare `:host` → none
- nested shadow root is not crossed (outer query can't reach inner shadow content; querying the inner shadow root directly does)
- invalid input errors: non-shadow-root scope and unparseable selector

## Spec / docs

- New pkspec scenario `compat.shadow-query-selector` (`reviewStatus = "approved"`) wired to its implementing tests in `specs/tasks.Test.pkl` (gate greps verified locally).
- `TODO.md`: both shadow-selector paths (#285 styling, #286 query) now marked landed.

`moon check`/`moon test` clean; `moon info && moon fmt` applied — `.mbti` delta is the two new public functions. (`pkf`/`pkspec` aren't installed in this environment, so those gates run in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_