### PR TITLE
runtime(shadow): WPT shadow-dom interface conformance for attachShadow/ShadowRoot

### DIFF
--- a/runtime/js_runtime_quickjs_ffi.mbt
+++ b/runtime/js_runtime_quickjs_ffi.mbt
@@ -6337,12 +6337,17 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|           return this._shadowRoot || null;
   #|         },
   #|         attachShadow(init) {
-  #|           if (this._shadowRoot) throw new Error('Already has shadow root');
+  #|           const mode = init && init.mode;
+  #|           if (mode !== 'open' && mode !== 'closed') {
+  #|             throw new TypeError("Failed to execute 'attachShadow' on 'Element': mode must be 'open' or 'closed'");
+  #|           }
+  #|           if (this._shadowRoot) {
+  #|             throw new DOMException('The element already hosts a shadow tree', 'NotSupportedError');
+  #|           }
   #|           const definition = this.__customElementDefinition || null;
   #|           if (hasDefinitionDisabledFeature(definition, 'shadow')) {
   #|             throw new DOMException('Shadow root creation is disabled for this custom element', 'NotSupportedError');
   #|           }
-  #|           const mode = String((init && init.mode) || 'open');
   #|           const slotAssignment = init && init.slotAssignment === 'manual' ? 'manual' : 'named';
   #|           const shadowId = nodeIdCounter++;
   #|           domOps.push({ op: 'createDocumentFragment', id: shadowId });

--- a/scripts/wpt-dom-runner.ts
+++ b/scripts/wpt-dom-runner.ts
@@ -272,6 +272,26 @@ function createTestHarness() {
     function Element() {}
     Element.prototype = Object.create(Node.prototype);
     Element.prototype.constructor = Element;
+    // Shadow DOM interface surface on Element.prototype. Instances carry their
+    // own shadowRoot/attachShadow from the mock DOM; these make the members
+    // visible on the interface prototype (per the Element interface) and
+    // delegate to the instance implementation when reached via the prototype.
+    if (!('shadowRoot' in Element.prototype)) {
+      Object.defineProperty(Element.prototype, 'shadowRoot', {
+        get() {
+          return this._shadowRootMode === 'closed' ? null : (this._shadowRoot || null);
+        },
+        configurable: true,
+      });
+    }
+    if (typeof Element.prototype.attachShadow !== 'function') {
+      Element.prototype.attachShadow = function attachShadow(init) {
+        if (typeof this.attachShadow === 'function' && this.attachShadow !== Element.prototype.attachShadow) {
+          return this.attachShadow(init);
+        }
+        throw new TypeError("Failed to execute 'attachShadow' on 'Element': unsupported target");
+      };
+    }
 
     // HTMLElement and subclasses are defined in mockDomCode
     // Just ensure prototype chain is correct
@@ -305,6 +325,14 @@ function createTestHarness() {
     } else if (DocumentFragment.prototype && Object.getPrototypeOf(DocumentFragment.prototype) !== Node.prototype) {
       Object.setPrototypeOf(DocumentFragment.prototype, Node.prototype);
     }
+
+    // ShadowRoot interface: inherits DocumentFragment, not constructable.
+    function ShadowRoot() {
+      throw new TypeError('Illegal constructor');
+    }
+    ShadowRoot.prototype = Object.create(DocumentFragment.prototype);
+    ShadowRoot.prototype.constructor = ShadowRoot;
+    if (typeof globalThis !== 'undefined') globalThis.ShadowRoot = ShadowRoot;
 
     function DocumentType() {}
     DocumentType.prototype = Object.create(Node.prototype);
@@ -344,6 +372,18 @@ function createTestHarness() {
       Object.setPrototypeOf(frag, DocumentFragment.prototype);
       return frag;
     };
+
+    // Shadow roots are created via decorateShadowRoot(createMockDocumentFragment(...));
+    // re-parent them onto ShadowRoot.prototype so "shadow instanceof ShadowRoot"
+    // (and inheritance from DocumentFragment) holds.
+    if (typeof decorateShadowRoot === 'function') {
+      const _origDecorateShadowRoot = decorateShadowRoot;
+      decorateShadowRoot = function(frag) {
+        const shadow = _origDecorateShadowRoot(frag);
+        Object.setPrototypeOf(shadow, ShadowRoot.prototype);
+        return shadow;
+      };
+    }
 
     const _origCreateMockProcessingInstruction = createMockProcessingInstruction;
     createMockProcessingInstruction = function(target, data, mockId) {


### PR DESCRIPTION
## Summary

Targeted WPT **shadow-dom** conformance wins, found empirically by running the WPT DOM runner against the shadow-dom suite.

**1. `attachShadow` spec validation** (`runtime/js_runtime_quickjs_ffi.mbt`, real mock-DOM behavior):
- require a valid `mode` (`'open'`/`'closed'`) or throw `TypeError`
- throw a `NotSupportedError` `DOMException` (not a plain `Error`) when the element already hosts a shadow tree

Internal callers always pass a valid `mode` (the serializer emits `{ mode: '…' }`), so this only tightens the public surface to match the spec.

**2. Shadow DOM interface surface** (`scripts/wpt-dom-runner.ts` interface scaffold):
- expose `shadowRoot` / `attachShadow` on `Element.prototype`
- add a non-constructable `ShadowRoot` interface object inheriting `DocumentFragment`
- re-parent shadow roots onto `ShadowRoot.prototype` so `shadow instanceof ShadowRoot` holds

This extends the runner's existing interface-object scaffolding (which already mocks `Node`/`Element` constants and `appendChild` delegators) to cover the shadow DOM surface.

## WPT shadow-dom deltas

| test | before | after |
|---|---|---|
| `Element-interface-shadowRoot-attribute` | 2/3 | **3/3 (green)** |
| `Element-interface-attachShadow` | 1/6 | **5/6** |
| `ShadowRoot-interface` | 7/12 | **10/12** |

**No regressions:** 1728 passed / 0 failed across a 25-file `dom/nodes` sample; `HTMLSlotElement-interface` (18/0) and `slotchange-event` (32/0) unchanged; `moon check runtime` clean.

## Out of scope (residual)

- `ShadowRoot.styleSheets` → needs a CSSOM `StyleSheetList` (parsing `<style>` into sheets)
- one `attachShadow` subtest references `HTML5_SHADOW_DISALLOWED_ELEMENTS`, an undefined constant in the test file itself

The `wpt` submodule isn't in the runner's `TEST_DIRS`, so wiring shadow-dom into the CI suite is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_