### PR TITLE
runtime(shadow): ShadowRoot.styleSheets + curated shadow-dom WPT CI shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,6 +442,7 @@ jobs:
           status=0
           npx tsx scripts/wpt-dom-runner.ts --dom --json "wpt-reports/wpt-dom-dom.json" || status=1
           npx tsx scripts/wpt-dom-runner.ts --svg --json "wpt-reports/wpt-dom-svg.json" || status=1
+          npx tsx scripts/wpt-dom-runner.ts --shadow --json "wpt-reports/wpt-dom-shadow.json" || status=1
           exit $status
         continue-on-error: true
 

--- a/justfile
+++ b/justfile
@@ -242,6 +242,10 @@ wpt-dom-report target report *args:
 wpt-svg:
     npx tsx scripts/wpt-dom-runner.ts --svg
 
+# Run curated WPT shadow-dom tests
+wpt-dom-shadow:
+    npx tsx scripts/wpt-dom-runner.ts --shadow
+
 # List available WPT DOM tests
 wpt-dom-list:
     npx tsx scripts/wpt-dom-runner.ts --list

--- a/runtime/js_runtime_quickjs_ffi.mbt
+++ b/runtime/js_runtime_quickjs_ffi.mbt
@@ -4271,6 +4271,21 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|       shadowRoot.setHTMLUnsafe = function(value) {
   #|         setUnsafeHtmlForNode(this, value);
   #|       };
+  #|       Object.defineProperty(shadowRoot, 'styleSheets', {
+  #|         get() {
+  #|           const sheets = [];
+  #|           traverseTree(this, (node) => {
+  #|             if (node && node._nodeType === 1 &&
+  #|                 String(node._tagName || '').toLowerCase() === 'style') {
+  #|               const s = node.sheet;
+  #|               if (s) sheets.push(s);
+  #|             }
+  #|           });
+  #|           sheets.item = function(i) { return this[i] || null; };
+  #|           return sheets;
+  #|         },
+  #|         configurable: true
+  #|       });
   #|       return shadowRoot;
   #|     }
   #|     function ElementInternals(host) {
@@ -4820,6 +4835,33 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|     function HTMLStyleElement() {}
   #|     HTMLStyleElement.prototype = Object.create(HTMLElement.prototype);
   #|     HTMLStyleElement.prototype.constructor = HTMLStyleElement;
+  #|     Object.defineProperty(HTMLStyleElement.prototype, 'sheet', {
+  #|       get() {
+  #|         const root = getRootNodePublic(this, { composed: true });
+  #|         if (!root || __craterGetNodeType(root) !== 9) return null;
+  #|         if (!this._cssomSheet) {
+  #|           const owner = this;
+  #|           this._cssomSheet = {
+  #|             type: 'text/css',
+  #|             ownerNode: owner,
+  #|             ownerRule: null,
+  #|             parentStyleSheet: null,
+  #|             href: null,
+  #|             title: null,
+  #|             disabled: false,
+  #|             media: { length: 0, mediaText: '', item() { return null; } },
+  #|             cssRules: [],
+  #|             get rules() { return this.cssRules; },
+  #|             insertRule() { return 0; },
+  #|             deleteRule() {},
+  #|             replaceSync() {},
+  #|             replace() { return Promise.resolve(this); },
+  #|           };
+  #|         }
+  #|         return this._cssomSheet;
+  #|       },
+  #|       configurable: true
+  #|     });
   #|
   #|     function HTMLTableElement() {}
   #|     HTMLTableElement.prototype = Object.create(HTMLElement.prototype);

--- a/scripts/wpt-dom-runner.ts
+++ b/scripts/wpt-dom-runner.ts
@@ -1531,6 +1531,37 @@ function getTestFilesByCategory(category: string): string[] {
   return files;
 }
 
+// Curated wpt/shadow-dom allowlist: DOM-level shadow tests that pass fully
+// against Crater's mock DOM (interface surface, slot assignment, slotchange,
+// composed events). Layout/paint/crash files in wpt/shadow-dom are excluded
+// because the DOM runner cannot meaningfully execute them. Keep this in sync as
+// coverage grows.
+const SHADOW_TESTS = [
+  'ShadowRoot-interface.html',
+  'Element-interface-shadowRoot-attribute.html',
+  'HTMLSlotElement-interface.html',
+  'slotchange.html',
+  'slotchange-event.html',
+  'imperative-slot-api-slotchange.html',
+  'imperative-slot-fallback-clear.html',
+  'event-inside-shadow-tree.html',
+  'event-composed.html',
+  'event-composed-path-after-dom-mutation.html',
+  'Document-prototype-currentScript.html',
+  'getElementById-dynamic-001.html',
+  'getElementById-dynamic-002.html',
+  'scroll-to-the-fragment-in-shadow-tree.html',
+  'assign-slottables-after-removing-shadow-tree-from-document.html',
+  'historical.html',
+];
+
+function getShadowTestFiles(): string[] {
+  const dir = path.join(process.cwd(), 'wpt/shadow-dom');
+  return SHADOW_TESTS.map((name) => path.join(dir, name)).filter((f) =>
+    fs.existsSync(f),
+  );
+}
+
 // List available tests
 function listTests(): void {
   console.log('Available test categories:\n');
@@ -1576,6 +1607,7 @@ function detectTarget(args: string[]): string {
   if (args.includes('--all')) return 'all';
   if (args.includes('--dom')) return 'dom';
   if (args.includes('--svg')) return 'svg';
+  if (args.includes('--shadow')) return 'shadow';
   if (args.length === 0) return 'all';
   return args.join(' ');
 }
@@ -1617,6 +1649,7 @@ async function main(): Promise<void> {
     console.log('  npx tsx scripts/wpt-dom-runner.ts --all       # Run all tests');
     console.log('  npx tsx scripts/wpt-dom-runner.ts --dom       # Run DOM tests only');
     console.log('  npx tsx scripts/wpt-dom-runner.ts --svg       # Run SVG tests only');
+    console.log('  npx tsx scripts/wpt-dom-runner.ts --shadow    # Run curated shadow-dom tests');
     console.log('  npx tsx scripts/wpt-dom-runner.ts --dom --json .wpt-reports/wpt-dom-dom.json');
     console.log('  npx tsx scripts/wpt-dom-runner.ts Document-*  # Run tests matching pattern');
     return;
@@ -1636,6 +1669,8 @@ async function main(): Promise<void> {
     testFiles = getTestFilesByCategory('svg');
   } else if (args[0] === '--dom') {
     testFiles = getTestFilesByCategory('dom');
+  } else if (args[0] === '--shadow') {
+    testFiles = getShadowTestFiles();
   } else {
     for (const arg of args) {
       if (arg.includes('*')) {


### PR DESCRIPTION
## Summary

Follow-ups to #296: close the last `ShadowRoot-interface` gap and make the shadow-dom WPT wins durable in CI.

### (a) `ShadowRoot.styleSheets` + `HTMLStyleElement.sheet`

Implemented in the mock DOM (`runtime/js_runtime_quickjs_ffi.mbt`):
- a `<style>` element exposes a **stable** `CSSStyleSheet` object when its composed root is the document, `null` otherwise;
- a shadow root's `styleSheets` collects those sheets in tree order.

Connectivity uses the **composed** root (`getRootNodePublic(..., {composed:true})`) so shadow content counts as connected when its host is — `getRootNodeInternal` alone stops at the shadow root and would report shadow `<style>` as disconnected.

→ `ShadowRoot-interface.html` now **fully green (12/12)** (was 7/12 before #296, 10/12 after).

### (b) Curated `--shadow` WPT shard in CI

- New `--shadow` category in the runner: an **allowlist** of `wpt/shadow-dom` tests that pass fully against Crater's mock DOM (interface surface, slot assignment, `slotchange`, composed events). Layout/paint/crash files are excluded — the DOM runner can't meaningfully execute them.
- Wired into the CI `wpt-dom` shard (`--shadow --json wpt-reports/wpt-dom-shadow.json`; the existing `wpt-dom-*.json` artifact glob already covers it).
- Added `just wpt-dom-shadow`.

`just wpt-dom-shadow` → **142 passed, 0 failed, 0 errors** across 16 tests.

## Verification

- No `dom/nodes` regressions; `HTMLSlotElement-interface` (18/0), `slotchange-event` (32/0) unchanged.
- `moon check runtime` clean.
- CI checks out the wpt submodule (`submodules: recursive`) and runs the shard with `continue-on-error` (report-based), so the new category is non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_