### PR TITLE
runtime(shadow): cloneNode-on-ShadowRoot + attachShadow host safelist

### DIFF
--- a/runtime/js_runtime_quickjs_ffi.mbt
+++ b/runtime/js_runtime_quickjs_ffi.mbt
@@ -4271,6 +4271,9 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|       shadowRoot.setHTMLUnsafe = function(value) {
   #|         setUnsafeHtmlForNode(this, value);
   #|       };
+  #|       shadowRoot.cloneNode = function() {
+  #|         throw new DOMException('A ShadowRoot node cannot be cloned', 'NotSupportedError');
+  #|       };
   #|       Object.defineProperty(shadowRoot, 'styleSheets', {
   #|         get() {
   #|           const sheets = [];
@@ -6382,6 +6385,12 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|           const mode = init && init.mode;
   #|           if (mode !== 'open' && mode !== 'closed') {
   #|             throw new TypeError("Failed to execute 'attachShadow' on 'Element': mode must be 'open' or 'closed'");
+  #|           }
+  #|           const hostTag = String(this._tagName || '').toLowerCase();
+  #|           const shadowAllowedHosts = ['article', 'aside', 'blockquote', 'body', 'div', 'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'main', 'nav', 'p', 'section', 'span'];
+  #|           const isCustomElementName = hostTag.indexOf('-') !== -1;
+  #|           if (!isCustomElementName && shadowAllowedHosts.indexOf(hostTag) === -1) {
+  #|             throw new DOMException("Failed to execute 'attachShadow' on 'Element': The '" + hostTag + "' element does not support attachShadow", 'NotSupportedError');
   #|           }
   #|           if (this._shadowRoot) {
   #|             throw new DOMException('The element already hosts a shadow tree', 'NotSupportedError');

--- a/scripts/wpt-dom-runner.ts
+++ b/scripts/wpt-dom-runner.ts
@@ -1539,7 +1539,9 @@ function getTestFilesByCategory(category: string): string[] {
 const SHADOW_TESTS = [
   'ShadowRoot-interface.html',
   'Element-interface-shadowRoot-attribute.html',
+  'Element-interface-attachShadow.html',
   'HTMLSlotElement-interface.html',
+  'Node-prototype-cloneNode.html',
   'slotchange.html',
   'slotchange-event.html',
   'imperative-slot-api-slotchange.html',


### PR DESCRIPTION
## Summary

Two more WPT shadow-dom conformance fixes in the mock DOM (continuing #296/#297):

- **`ShadowRoot.cloneNode()` throws `NotSupportedError`** — a shadow root is not cloneable per spec. Implemented as an override in `decorateShadowRoot`.
- **`attachShadow` host safelist** — enforces the *valid shadow host name* rule: non-safelisted built-in elements throw `NotSupportedError`, while the HTML5 shadow-allowed elements (`article`, `div`, `section`, …) and autonomous custom elements (hyphenated names) are accepted.

## WPT shadow-dom deltas

| test | before | after |
|---|---|---|
| `Node-prototype-cloneNode` | 2/4 | **4/4 (green)** |
| `Element-interface-attachShadow` | 5/6 | **6/6 (green)** |
| `Element-interface-attachShadow-custom-element` | 4/6 | 5/6 (customized built-in now throws) |

The two newly-green files are added to the curated `--shadow` CI shard → **18 tests, 152 passed / 0 failed**.

## Verification

- No `dom/nodes` regressions: **1785 passed / 0 failed** across a 30-file sample.
- Full shadow-dom sweep: only failure counts went **down**; no test regressed.
- `moon check runtime` clean.
- `Element-interface-attachShadow` depends on `wpt/html/resources/common.js`, which CI's `submodules: recursive` checkout provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_