### PR TITLE
runtime(shadow): spec-correct imperative slot assignment (HTMLSlotElement.assign)

### DIFF
--- a/runtime/js_runtime_quickjs_ffi.mbt
+++ b/runtime/js_runtime_quickjs_ffi.mbt
@@ -4790,21 +4790,28 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|       return this.assignedNodes(options).filter((node) => node && node._nodeType === 1);
   #|     };
   #|     HTMLSlotElement.prototype.assign = function() {
-  #|       const shadowRoot = getEnclosingShadowRoot(this);
-  #|       if (!isManualSlotAssignmentRoot(shadowRoot)) {
-  #|         throw new DOMException('Manual slot assignment requires slotAssignment="manual"', 'NotAllowedError');
+  #|       // WebIDL: assign((Element or Text)... nodes) — argument type errors are
+  #|       // reported before any slot-state checks.
+  #|       const assignArgs = [];
+  #|       for (let i = 0; i < arguments.length; i++) {
+  #|         const node = arguments[i];
+  #|         const nodeType = isNodeLike(node) ? __craterGetNodeType(node) : 0;
+  #|         if (nodeType !== 1 && nodeType !== 3) {
+  #|           throw new TypeError("Failed to execute 'assign' on 'HTMLSlotElement': parameter " + (i + 1) + " is not of type 'Element' or 'Text'");
+  #|         }
+  #|         assignArgs.push(node);
   #|       }
+  #|       // Per spec, assign() records the manually assigned nodes regardless of
+  #|       // the slot's shadow mode or whether the nodes are currently in the host
+  #|       // tree; assignedNodes() reflects them only while applicable (manual
+  #|       // shadow + node is a host child), computed dynamically downstream.
   #|       const nextAssigned = [];
   #|       const nextSet = new Set();
   #|       const affectedSlots = new Set([this]);
-  #|       for (let i = 0; i < arguments.length; i++) {
-  #|         const node = arguments[i];
-  #|         if (!isNodeLike(node)) {
-  #|           throw new TypeError("Failed to execute 'assign' on 'HTMLSlotElement': parameter is not of type Node");
-  #|         }
+  #|       for (let i = 0; i < assignArgs.length; i++) {
+  #|         const node = assignArgs[i];
   #|         const nodeType = __craterGetNodeType(node);
   #|         if (nodeType !== 1 && nodeType !== 3) continue;
-  #|         if (!shadowRoot.host || node._parent !== shadowRoot.host) continue;
   #|         if (nextSet.has(node)) continue;
   #|         const previousSlot = node.__manualAssignedSlot || null;
   #|         if (previousSlot && previousSlot !== this) {
@@ -6399,7 +6406,13 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|           if (hasDefinitionDisabledFeature(definition, 'shadow')) {
   #|             throw new DOMException('Shadow root creation is disabled for this custom element', 'NotSupportedError');
   #|           }
-  #|           const slotAssignment = init && init.slotAssignment === 'manual' ? 'manual' : 'named';
+  #|           let slotAssignment = 'named';
+  #|           if (init && init.slotAssignment !== undefined) {
+  #|             if (init.slotAssignment !== 'named' && init.slotAssignment !== 'manual') {
+  #|               throw new TypeError("Failed to execute 'attachShadow' on 'Element': slotAssignment must be 'named' or 'manual'");
+  #|             }
+  #|             slotAssignment = init.slotAssignment;
+  #|           }
   #|           const shadowId = nodeIdCounter++;
   #|           domOps.push({ op: 'createDocumentFragment', id: shadowId });
   #|           domOps.push({

--- a/scripts/wpt-dom-runner.ts
+++ b/scripts/wpt-dom-runner.ts
@@ -1544,6 +1544,7 @@ const SHADOW_TESTS = [
   'Node-prototype-cloneNode.html',
   'slotchange.html',
   'slotchange-event.html',
+  'imperative-slot-api.html',
   'imperative-slot-api-slotchange.html',
   'imperative-slot-fallback-clear.html',
   'event-inside-shadow-tree.html',


### PR DESCRIPTION
## Summary

Make the imperative slot API (`HTMLSlotElement.assign` + `attachShadow` `slotAssignment`) spec-correct and dynamic.

- **`attachShadow` `slotAssignment` enum validation** — a value other than `'named'`/`'manual'` (or `undefined`) throws `TypeError`.
- **`assign()` argument type errors first** — anything not `Element` or `Text` throws `TypeError`, matching the WebIDL `(Element or Text)...` overload, *before* any slot-state handling (previously a detached slot threw `NotAllowedError` for an `Attr` arg).
- **`assign()` records the full manual assignment** — it no longer throws for non-manual / detached slots and no longer drops nodes that aren't currently host children. `assignedNodes()` / `assignedSlot` already filter dynamically (manual shadow + node currently a host child), so moving a node in/out of the host now correctly reveals/hides the assignment.

## WPT delta

`imperative-slot-api.html`: **12/16 → 16/16 (fully green)**, covering 4 subtests:
attachShadow slotAssignment param, "assigning invalid nodes should be allowed", "nodes can be assigned even if slots/nodes aren't in the same tree", and "throw TypeError if the passed values are neither Element nor Text".

## Verification

- **No regressions** (baseline compared via stash): `HTMLSlotElement-interface` 18/0, `slotchange` 16/0, `slotchange-event` 32/0, `imperative-slot-api-slotchange` 10/0 unchanged; `slots` (10/16), `slots-fallback` (0/13), `Slottable-mixin` (2/2) identical to baseline (pre-existing, named-slot/other gaps).
- Added to the curated `--shadow` CI shard → **19 tests, 168 passed / 0 failed**.
- `moon check runtime` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_