### PR TITLE
runtime(shadow): Slottable.assignedSlot placement + closed-shadow visibility

### DIFF
--- a/runtime/js_runtime_quickjs_ffi.mbt
+++ b/runtime/js_runtime_quickjs_ffi.mbt
@@ -439,10 +439,9 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|       set(v) { this._parent = v; },
   #|       configurable: true
   #|     });
-  #|     Object.defineProperty(Node.prototype, 'assignedSlot', {
-  #|       get() { return getAssignedSlotForNode(this); },
-  #|       configurable: true
-  #|     });
+  #|     // assignedSlot belongs to the Slottable mixin (Element + Text), not all
+  #|     // Nodes; it is defined on Element.prototype / Text.prototype by the host
+  #|     // harness so comment / PI / document nodes do not expose it.
   #|     Object.defineProperty(Node.prototype, 'parentElement', {
   #|       get() {
   #|         const p = this.parentNode;
@@ -4189,6 +4188,17 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|         return false;
   #|       });
   #|       return found;
+  #|     }
+  #|     // Public Slottable.assignedSlot: like getAssignedSlotForNode, but a slot
+  #|     // inside a closed shadow tree is not observable from the light tree, so it
+  #|     // reports null. The internal helper stays closed-agnostic because the slot
+  #|     // still has assigned nodes from inside its own (closed) tree.
+  #|     function getAssignedSlotPublic(node) {
+  #|       const parent = node && node._parent;
+  #|       if (parent && parent._shadowRoot && parent._shadowRoot.mode === 'closed') {
+  #|         return null;
+  #|       }
+  #|       return getAssignedSlotForNode(node);
   #|     }
   #|     function getAssignedSlotForNode(node) {
   #|       if (!node) return null;

--- a/scripts/wpt-dom-runner.ts
+++ b/scripts/wpt-dom-runner.ts
@@ -260,6 +260,13 @@ function createTestHarness() {
       if (Object.getPrototypeOf(Text.prototype) !== CharacterData.prototype) {
         Object.setPrototypeOf(Text.prototype, CharacterData.prototype);
       }
+      // assignedSlot is part of the Slottable mixin (Element + Text only).
+      if (typeof getAssignedSlotPublic === 'function' && !('assignedSlot' in Text.prototype)) {
+        Object.defineProperty(Text.prototype, 'assignedSlot', {
+          get() { return getAssignedSlotPublic(this); },
+          configurable: true,
+        });
+      }
     }
 
     if (typeof Comment !== 'undefined' && Comment.prototype) {
@@ -272,6 +279,15 @@ function createTestHarness() {
     function Element() {}
     Element.prototype = Object.create(Node.prototype);
     Element.prototype.constructor = Element;
+    // assignedSlot is part of the Slottable mixin (Element + Text only), not all
+    // Nodes, so it lives on Element.prototype / Text.prototype rather than
+    // Node.prototype (keeping it off comment / PI / document nodes).
+    if (typeof getAssignedSlotPublic === 'function' && !('assignedSlot' in Element.prototype)) {
+      Object.defineProperty(Element.prototype, 'assignedSlot', {
+        get() { return getAssignedSlotPublic(this); },
+        configurable: true,
+      });
+    }
     // Shadow DOM interface surface on Element.prototype. Instances carry their
     // own shadowRoot/attachShadow from the mock DOM; these make the members
     // visible on the interface prototype (per the Element interface) and
@@ -1541,6 +1557,7 @@ const SHADOW_TESTS = [
   'Element-interface-shadowRoot-attribute.html',
   'Element-interface-attachShadow.html',
   'HTMLSlotElement-interface.html',
+  'Slottable-mixin.html',
   'Node-prototype-cloneNode.html',
   'slotchange.html',
   'slotchange-event.html',


### PR DESCRIPTION
## Summary

Align `assignedSlot` with the Slottable mixin and shadow encapsulation.

- **`assignedSlot` placement** — exposed on `Element.prototype` / `Text.prototype` (the Slottable mixin) only, not the shared `Node.prototype`, so comment / processing-instruction / document nodes no longer expose it.
- **Closed-shadow visibility** — a slot inside a *closed* shadow tree is not observable from the light tree, so the public `assignedSlot` reports `null`. Applied in a public wrapper (`getAssignedSlotPublic`); the **internal** slot-assignment helper stays closed-agnostic, so a slot still computes its own `assignedNodes()` inside a closed tree (this distinction was the key — putting the closed check in the shared internal helper regressed `assignedNodes` and was corrected).

## WPT delta

- `Slottable-mixin.html`: **2/4 → 4/4 (fully green)**
- `slots.html`: incidentally 10/16 → 11/15

## Verification

- **No regressions** (baseline compared via stash): shadow shard and all previously-green slot tests unchanged (`HTMLSlotElement-interface` 18/0, `slotchange`/`-event`, `imperative-slot-*`); `event-inside-slotted-node` 0/20 identical to baseline; `dom/nodes` sample clean (`Element-closest` 29/0, `MutationObserver-childList` 38/0).
- Added to the curated `--shadow` CI shard → **20 tests, 172 passed / 0 failed**.
- `moon check runtime` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_