### PR TITLE
runtime(shadow): clone a clonable shadow root on shallow cloneNode too

### DIFF
--- a/runtime/js_runtime_quickjs_ffi.mbt
+++ b/runtime/js_runtime_quickjs_ffi.mbt
@@ -6233,7 +6233,7 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|                 domOps.push({ op: 'appendChild', parentId: id, childId: clonedChild._mockId });
   #|               }
   #|             }
-  #|             if (isDeep && el._shadowRoot && el._shadowRoot.clonable && typeof clone.attachShadow === 'function' && !clone._shadowRoot) {
+  #|             if (el._shadowRoot && el._shadowRoot.clonable && typeof clone.attachShadow === 'function' && !clone._shadowRoot) {
   #|               const clonedShadow = clone.attachShadow({
   #|                 mode: el._shadowRoot.mode || 'open',
   #|                 delegatesFocus: !!el._shadowRoot.delegatesFocus,


### PR DESCRIPTION
## Summary

A shadow root with `clonable: true` must be cloned whenever its host is cloned, **regardless of the `cloneNode` deep flag**. The element clone path gated shadow cloning behind `isDeep`, so `element.cloneNode(false)` dropped the clonable shadow. This drops the `isDeep` guard on that branch (the shadow's own subtree is still deep-cloned once the shadow itself is cloned).

## WPT delta

`shadow-root-clonable.html`: **4/6 → 5/6** (the shallow-clone case: "shallow clone still deep-clones the shadow root").

The remaining failure ("declarative shadow roots inside templates do not get cloned automatically") needs declarative-shadow-in-`<template>` clone semantics and is out of scope here.

## Verification

- **No regressions**: `Node-prototype-cloneNode` 4/0, `Node-cloneNode.html` **135/0**, other `dom/nodes` clone tests, and the `--shadow` shard (172/0) all unchanged.
- `moon check runtime` clean.

(Not added to the `--shadow` shard since the file isn't fully green yet — kept as a standalone conformance fix validated by the unchanged 135-test `Node-cloneNode`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_