### PR TITLE
runtime(shadow): slot fallback content only via flatten, not assignedNodes()

### DIFF
--- a/runtime/js_runtime_quickjs_ffi.mbt
+++ b/runtime/js_runtime_quickjs_ffi.mbt
@@ -4163,17 +4163,13 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|       if (!slotElement) return [];
   #|       const shadowRoot = getEnclosingShadowRoot(slotElement);
   #|       if (!shadowRoot || !shadowRoot.host) {
-  #|         return slotElement._children ? slotElement._children.slice() : [];
+  #|         return [];
   #|       }
   #|       if (isManualSlotAssignmentRoot(shadowRoot)) {
-  #|         const manualAssigned = getManualAssignedNodesForSlot(slotElement);
-  #|         if (manualAssigned.length > 0) return manualAssigned;
-  #|         return slotElement._children ? slotElement._children.slice() : [];
+  #|         return getManualAssignedNodesForSlot(slotElement);
   #|       }
   #|       const hostChildren = getChildNodesArray(shadowRoot.host);
-  #|       const assigned = hostChildren.filter((node) => getAssignedSlotForNode(node) === slotElement);
-  #|       if (assigned.length > 0) return assigned;
-  #|       return slotElement._children ? slotElement._children.slice() : [];
+  #|       return hostChildren.filter((node) => getAssignedSlotForNode(node) === slotElement);
   #|     }
   #|     function findFirstSlotForName(shadowRoot, slotName) {
   #|       if (!shadowRoot) return null;
@@ -4216,7 +4212,12 @@ extern "js" fn quickjs_execute_with_mock_dom(
   #|       return findFirstSlotForName(parent._shadowRoot, getSlotNameForLightNode(node));
   #|     }
   #|     function getFlattenedAssignedNodesForSlot(slotElement) {
-  #|       const nodes = getAssignedNodesForSlot(slotElement);
+  #|       let nodes = getAssignedNodesForSlot(slotElement);
+  #|       // A slot with no assigned nodes flattens to its fallback content (its
+  #|       // own children), with nested slots flattened recursively.
+  #|       if (nodes.length === 0 && slotElement && slotElement._children) {
+  #|         nodes = slotElement._children.slice();
+  #|       }
   #|       const flattened = [];
   #|       for (const node of nodes) {
   #|         if (isSlotElementNode(node)) {


### PR DESCRIPTION
## Summary

A slot's **fallback content** (its own children) is part of the *flattened* assignment, not the plain assignment. `assignedNodes()` / `assignedElements()` were returning the fallback for an empty slot, so the non-flatten form was wrong.

Move the fallback out of `getAssignedNodesForSlot` (which now returns only the actually-assigned nodes, `[]` when none) into `getFlattenedAssignedNodesForSlot`, which substitutes the slot's children when nothing is assigned and flattens any nested slots among them.

## WPT delta

`slots-fallback.html`: **0/13 → 6/13** (basic, elements-only, slots-in-slots, "fallback not used when a node is assigned").

The remaining 7 cases are complex multi-shadow flattening and mutation scenarios (test5 chains slots across two nested shadow trees) — a larger separate effort.

## Verification

- **No regressions**: shadow shard 172/0; every previously-green slot test unchanged (`HTMLSlotElement-interface` 18/0, `slotchange` 16/0, `slotchange-event` 32/0, `imperative-slot-api` 16/0); `slots.html` unchanged at 11/15; `slots-fallback-in-document` / `imperative-slot-initial-fallback` identical to baseline (0/2).
- `moon check runtime` clean.

(Not added to the `--shadow` shard since the file isn't fully green yet — a foundational, regression-free conformance fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_