### PR TITLE
perf(html): slice-based scanning in the HTML parser hot loops

### DIFF
--- a/dom/html/parser.mbt
+++ b/dom/html/parser.mbt
@@ -185,14 +185,13 @@ fn Parser::consume(self : Parser) -> Char? {
 
 ///|
 fn Parser::skip_whitespace(self : Parser) -> Unit {
-  while !self.is_eof() {
-    match self.peek() {
-      Some(c) if is_whitespace(c) => {
-        let _ = self.consume()
-      }
-      _ => break
-    }
+  let input = self.input
+  let len = self.len
+  let mut p = self.pos
+  while p < len && is_whitespace(input[p].to_int().unsafe_to_char()) {
+    p = p + 1
   }
+  self.pos = p
 }
 
 ///|
@@ -311,33 +310,33 @@ fn is_name_char(c : Char) -> Bool {
 
 ///|
 fn Parser::consume_name(self : Parser) -> String {
-  let buf = StringBuilder::new()
-  while !self.is_eof() {
-    match self.peek() {
-      Some(c) if is_name_char(c) => {
-        buf.write_char(c)
-        let _ = self.consume()
-      }
-      _ => break
-    }
+  let input = self.input
+  let len = self.len
+  let start = self.pos
+  let mut p = start
+  while p < len && is_name_char(input[p].to_int().unsafe_to_char()) {
+    p = p + 1
   }
-  buf.to_string()
+  self.pos = p
+  if p == start {
+    ""
+  } else {
+    input[start:p].to_owned()
+  }
 }
 
 ///|
 fn Parser::consume_until(self : Parser, end_char : Char) -> String {
-  let buf = StringBuilder::new()
-  while !self.is_eof() {
-    match self.peek() {
-      Some(c) if c == end_char => break
-      Some(c) => {
-        buf.write_char(c)
-        let _ = self.consume()
-      }
-      None => break
-    }
+  let input = self.input
+  let len = self.len
+  let end_code = end_char.to_int()
+  let start = self.pos
+  let mut p = start
+  while p < len && input[p].to_int() != end_code {
+    p = p + 1
   }
-  buf.to_string()
+  self.pos = p
+  input[start:p].to_owned()
 }
 
 ///|


### PR DESCRIPTION
## Summary

Performance tuning of the HTML parser, found by profiling the render benchmarks: `@renderer.render(html)` spends the bulk of its time in **HTML parsing** (e.g. `scrollable_list(1000)` parse ≈ 84ms vs render-from-doc ≈ 23ms), and the cost scales with **attributes** (`parse_styled_200` 2.5ms vs `parse_simple_1000` 0.83ms).

The tokenizer's `consume_until` / `consume_name` / `skip_whitespace` walked one character at a time, allocating an `Option` per char (`peek`/`consume`) and appending each char to a `StringBuilder` for value scans. Rewritten as tight index scans over the input string with a single owned slice at the end — no per-char `Option`, no per-char `StringBuilder` append. Output is byte-identical.

## Benchmarks (JS target, stable samples)

| bench | before | after | Δ |
|---|---|---|---|
| `parse_styled_200` | 2.50ms | 1.41ms | **−44%** |
| `parse_card_100` | 2.03ms | 1.30ms | **−36%** |
| `parse_attrs_500` | 3.85ms | 2.65ms | **−31%** |
| `parse_page_large` | 852µs | 832µs | −2% |
| `parse_simple_1000` | 830µs | 873µs | +5% |

End-to-end `render_scroll_1k` 117ms → 110ms. The bare-tag `simple` case regresses slightly (a short owned slice is marginally costlier than its `StringBuilder`), but realistic attribute-bearing HTML — every element carrying `class`/`style`/`id` — is substantially faster.

## Verification

- Output identical: `dom/html` parser suite **154/154** and renderer suite **392/392** unchanged.
- `moon check` clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_