### PR TITLE
perf(layout): allocation-free id prefix test (drops BMH skip-table allocs)

### DIFF
--- a/core/node/node.mbt
+++ b/core/node/node.mbt
@@ -182,3 +182,24 @@ pub fn fallback_layout(
     text: node.text,
   }
 }
+
+///|
+/// Allocation-free prefix test. `String::has_prefix` in core uses Boyer-Moore-
+/// Horspool and allocates a skip table per call; layout calls it per node (text
+/// detection via `id.has_prefix("#text")`), which made it the single largest
+/// allocation site in the render pipeline. This compares the prefix directly.
+pub fn str_has_prefix(s : String, prefix : String) -> Bool {
+  let plen = prefix.length()
+  if plen == 0 {
+    return true
+  }
+  if s.length() < plen {
+    return false
+  }
+  for i = 0; i < plen; i = i + 1 {
+    if s[i].to_int() != prefix[i].to_int() {
+      return false
+    }
+  }
+  true
+}

--- a/core/node/pkg.generated.mbti
+++ b/core/node/pkg.generated.mbti
@@ -13,6 +13,8 @@ pub fn get_layout_dispatcher() -> LayoutDispatchFunc?
 
 pub fn set_layout_dispatcher(LayoutDispatchFunc) -> Unit
 
+pub fn str_has_prefix(String, String) -> Bool
+
 // Errors
 
 // Types and methods

--- a/layout/baseline/baseline.mbt
+++ b/layout/baseline/baseline.mbt
@@ -33,7 +33,7 @@ fn infer_baseline_height(node : @node.Node, fallback_height : Double) -> Double 
     @types.Length(h) => h
     @types.Percent(p) => fallback_height * p
     _ =>
-      if node.id.has_prefix("#text") {
+      if @node.str_has_prefix(node.id, "#text") {
         if node.style.line_height > 0.0 {
           node.style.line_height
         } else if node.style.font_size > 0.0 {
@@ -110,27 +110,27 @@ fn is_no_principal_table_internal_display(display : @types.Display) -> Bool {
 ///|
 fn is_ruby_internal_no_principal(node_id : String) -> Bool {
   node_id == "rb" ||
-  node_id.has_prefix("rb#") ||
+  @node.str_has_prefix(node_id, "rb#") ||
   node_id == "rbc" ||
-  node_id.has_prefix("rbc#") ||
+  @node.str_has_prefix(node_id, "rbc#") ||
   node_id == "rt" ||
-  node_id.has_prefix("rt#") ||
+  @node.str_has_prefix(node_id, "rt#") ||
   node_id == "rtc" ||
-  node_id.has_prefix("rtc#")
+  @node.str_has_prefix(node_id, "rtc#")
 }
 
 ///|
 fn is_fieldset_node_id(node_id : String) -> Bool {
   node_id == "fieldset" ||
-  node_id.has_prefix("fieldset#") ||
-  node_id.has_prefix("fieldset.")
+  @node.str_has_prefix(node_id, "fieldset#") ||
+  @node.str_has_prefix(node_id, "fieldset.")
 }
 
 ///|
 fn is_legend_node_id(node_id : String) -> Bool {
   node_id == "legend" ||
-  node_id.has_prefix("legend#") ||
-  node_id.has_prefix("legend.")
+  @node.str_has_prefix(node_id, "legend#") ||
+  @node.str_has_prefix(node_id, "legend.")
 }
 
 ///|
@@ -226,7 +226,7 @@ pub fn compute_node_baseline(node : @node.Node, node_height : Double) -> Double 
   if children.length() == 0 {
     // For text nodes, baseline is ascent + half leading.
     // For other leaf nodes (like images), baseline is the bottom of the box.
-    if node.id.has_prefix("#text") {
+    if @node.str_has_prefix(node.id, "#text") {
       return text_baseline_from_style(style)
     }
     return node_height

--- a/layout/block/block.mbt
+++ b/layout/block/block.mbt
@@ -285,7 +285,7 @@ fn is_table_run_whitespace_char(c : Char) -> Bool {
 
 ///|
 fn is_whitespace_only_table_run_text(node : @node.Node) -> Bool {
-  if !node.id.has_prefix("#text") {
+  if !@node.str_has_prefix(node.id, "#text") {
     return false
   }
   match node.text {
@@ -318,7 +318,7 @@ fn white_space_collapses_edges(white_space : @style.WhiteSpace) -> Bool {
 
 ///|
 fn text_ends_with_collapsible_flow_whitespace(node : @node.Node) -> Bool {
-  if !node.id.has_prefix("#text") ||
+  if !@node.str_has_prefix(node.id, "#text") ||
     !white_space_collapses_edges(node.style.white_space) {
     return false
   }
@@ -339,7 +339,7 @@ fn text_ends_with_collapsible_flow_whitespace(node : @node.Node) -> Bool {
 
 ///|
 fn is_whitespace_only_flow_text(node : @node.Node) -> Bool {
-  if !node.id.has_prefix("#text") {
+  if !@node.str_has_prefix(node.id, "#text") {
     return false
   }
   match node.text {
@@ -357,7 +357,7 @@ fn is_whitespace_only_flow_text(node : @node.Node) -> Bool {
 
 ///|
 fn flow_whitespace_contains_line_break(node : @node.Node) -> Bool {
-  if !node.id.has_prefix("#text") {
+  if !@node.str_has_prefix(node.id, "#text") {
     return false
   }
   match node.text {
@@ -405,7 +405,7 @@ fn participates_inline_for_flow_whitespace(node : @node.Node) -> Bool {
     @types.Float::Left | @types.Float::Right => return false
     @types.Float::None => ()
   }
-  if node.id.has_prefix("#text") {
+  if @node.str_has_prefix(node.id, "#text") {
     match node.text {
       Some(text) => {
         for c in text.iter() {
@@ -4802,10 +4802,11 @@ fn compute_with_collapse(
     )
     // fieldset legend overlays the top border line instead of participating in
     // normal block-flow vertical positioning.
-    if !style.writing_mode.is_vertical() && node.id.has_prefix("fieldset") {
+    if !style.writing_mode.is_vertical() &&
+      @node.str_has_prefix(node.id, "fieldset") {
       for i = 0; i < node.children.length(); i = i + 1 {
         let child = node.children[i]
-        if child.id.has_prefix("legend") {
+        if @node.str_has_prefix(child.id, "legend") {
           match layout_map.get(i) {
             Some(legend_layout) => {
               let overlay = (border.top - legend_layout.height) / 2.0
@@ -5105,7 +5106,7 @@ fn compute_with_collapse(
     !use_ifc &&
     !has_mixed &&
     !has_non_flow_children &&
-    !node.id.has_prefix("fieldset") &&
+    !@node.str_has_prefix(node.id, "fieldset") &&
     float_nodes.length() == 0 &&
     flow_nodes.length() == node.children.length() &&
     flow_children.length() == flow_nodes.length()
@@ -5528,7 +5529,7 @@ fn compute_with_collapse(
     for i = 0; i < flow_nodes.length() && i < flow_styles.length(); i = i + 1 {
       let child_node = flow_nodes[i]
       let child_style = flow_styles[i]
-      if child_node.id == "br" || child_node.id.has_prefix("#text") {
+      if child_node.id == "br" || @node.str_has_prefix(child_node.id, "#text") {
         continue
       }
       if !is_inline_flow_participant(child_node, child_style) {
@@ -5713,7 +5714,7 @@ fn compute_with_collapse(
     let is_inline_float_only_wrapper = !is_vertical_writing &&
       @inline.is_inline_level(child_style.display) &&
       child_node.id != "br" &&
-      !child_node.id.has_prefix("#text") &&
+      !@node.str_has_prefix(child_node.id, "#text") &&
       source_children_only_contribute_floats(child_node.children)
     let participates_in_inline_run = enable_float_inline_run &&
       (
@@ -6233,8 +6234,8 @@ fn compute_with_collapse(
     }
     let is_first_legend_in_fieldset = !is_vertical_writing &&
       i == 0 &&
-      node.id.has_prefix("fieldset") &&
-      child_layout.id.has_prefix("legend")
+      @node.str_has_prefix(node.id, "fieldset") &&
+      @node.str_has_prefix(child_layout.id, "legend")
     let legend_border_overlay_y = if is_first_legend_in_fieldset {
       let overlay = (border.top - child_layout.height) / 2.0
       if overlay > 0.0 {

--- a/layout/block/flow_grouping.mbt
+++ b/layout/block/flow_grouping.mbt
@@ -33,7 +33,7 @@ fn has_mixed_inline_block_content(flow_nodes : Array[@node.Node]) -> Bool {
 
 ///|
 fn is_inline_group_participant(node : @node.Node) -> Bool {
-  if node.id == "br" || node.id.has_prefix("#text") {
+  if node.id == "br" || @node.str_has_prefix(node.id, "#text") {
     return true
   }
   if @inline.is_inline_level(node.style.display) {
@@ -62,7 +62,7 @@ fn contents_is_inline_flow(node : @node.Node) -> Bool {
     if child.style.display == @types.Display::None {
       continue
     }
-    if child.id == "br" || child.id.has_prefix("#text") {
+    if child.id == "br" || @node.str_has_prefix(child.id, "#text") {
       has_inline = true
       continue
     }
@@ -98,7 +98,7 @@ fn should_establish_ifc_with_contents(children : Array[@node.Node]) -> Bool {
     if child.style.display == @types.Display::None {
       continue
     }
-    if child.id == "br" || child.id.has_prefix("#text") {
+    if child.id == "br" || @node.str_has_prefix(child.id, "#text") {
       has_inline = true
       continue
     }

--- a/layout/block/fragmentation.mbt
+++ b/layout/block/fragmentation.mbt
@@ -622,7 +622,7 @@ fn source_children_only_contribute_floats(children : Array[@node.Node]) -> Bool 
       child.style.position == @types.Fixed {
       continue
     }
-    if child.id.has_prefix("#text") {
+    if @node.str_has_prefix(child.id, "#text") {
       match child.text {
         Some(text) =>
           if !is_whitespace_only_flow_text(child) && !text.is_empty() {

--- a/layout/block/multicol_flow.mbt
+++ b/layout/block/multicol_flow.mbt
@@ -398,7 +398,7 @@ fn is_inline_flow_participant(node : @node.Node, style : @style.Style) -> Bool {
     }
   }
   node.id == "br" ||
-  node.id.has_prefix("#text") ||
+  @node.str_has_prefix(node.id, "#text") ||
   (
     @inline.is_inline_level(style.display) &&
     (
@@ -545,7 +545,7 @@ fn has_prior_multicol_column_content(
     if style.column_span == @style.ColumnSpan::All {
       continue
     }
-    if node.id.has_prefix("legend") {
+    if @node.str_has_prefix(node.id, "legend") {
       continue
     }
     return true
@@ -1531,7 +1531,7 @@ fn process_multicol_flow_child(
   let leading_legend_height = if i > 0 {
     match (flow_nodes.get(0), flow_children.get(0)) {
       (Some(first_node), Some(first_child)) =>
-        if first_node.id.has_prefix("legend") {
+        if @node.str_has_prefix(first_node.id, "legend") {
           first_child.layout.height
         } else {
           0.0

--- a/layout/flex/flex.mbt
+++ b/layout/flex/flex.mbt
@@ -583,7 +583,7 @@ fn estimate_flex_text_intrinsic_main_size(
   node : @node.Node,
   is_row : Bool,
 ) -> Double? {
-  if !node.id.has_prefix("#text") {
+  if !@node.str_has_prefix(node.id, "#text") {
     return None
   }
   if !flex_whitespace_collapses(node.style) {
@@ -641,7 +641,7 @@ fn estimate_flex_text_min_main_size(
   node : @node.Node,
   is_row : Bool,
 ) -> Double? {
-  if !node.id.has_prefix("#text") {
+  if !@node.str_has_prefix(node.id, "#text") {
     return None
   }
   if !flex_whitespace_collapses(node.style) {
@@ -711,7 +711,8 @@ priv struct FlattenedChild {
 
 ///|
 fn is_collapsible_flex_text_node(node : @node.Node) -> Bool {
-  node.id.has_prefix("#text") && flex_whitespace_collapses(node.style)
+  @node.str_has_prefix(node.id, "#text") &&
+  flex_whitespace_collapses(node.style)
 }
 
 ///|
@@ -1039,7 +1040,7 @@ fn is_generated_pseudo_contents_text_item(item : FlattenedChild) -> Bool {
     return false
   }
   let ancestor = item.contents_ancestors[0]
-  ancestor.id.has_prefix("#pseudo::") &&
+  @node.str_has_prefix(ancestor.id, "#pseudo::") &&
   ancestor.style.display == @types.Contents
 }
 
@@ -1402,8 +1403,8 @@ fn first_row_flex_line_baseline_override(
 ///|
 fn is_fieldset_flex_item(node : @node.Node) -> Bool {
   node.id == "fieldset" ||
-  node.id.has_prefix("fieldset#") ||
-  node.id.has_prefix("fieldset.")
+  @node.str_has_prefix(node.id, "fieldset#") ||
+  @node.str_has_prefix(node.id, "fieldset.")
 }
 
 ///|
@@ -1449,7 +1450,7 @@ fn resolve_flex_item_cross_alignment(
 
 ///|
 fn uses_svg_default_intrinsic_box(node : @node.Node) -> Bool {
-  if !node.id.has_prefix("svg") {
+  if !@node.str_has_prefix(node.id, "svg") {
     return false
   }
   match (node.style.width, node.style.height) {
@@ -1461,7 +1462,7 @@ fn uses_svg_default_intrinsic_box(node : @node.Node) -> Bool {
 
 ///|
 fn uses_svg_auto_viewbox_box(node : @node.Node) -> Bool {
-  node.id.has_prefix("svg") &&
+  @node.str_has_prefix(node.id, "svg") &&
   node.children.length() == 0 &&
   node.measure is Some(_) &&
   node.style.width == @types.Auto &&

--- a/layout/inline/inline.mbt
+++ b/layout/inline/inline.mbt
@@ -553,7 +553,7 @@ fn id_matches_tag(node_id : String, tag : String) -> Bool {
 
 ///|
 fn is_whitespace_text_node(node : @node.Node) -> Bool {
-  if !node.id.has_prefix("#text") {
+  if !@node.str_has_prefix(node.id, "#text") {
     return false
   }
   match node.text {
@@ -603,7 +603,7 @@ fn has_inflow_block_descendant(node : @node.Node) -> Bool {
       child.style.position == @types.Fixed {
       continue
     }
-    if child.id == "br" || child.id.has_prefix("#text") {
+    if child.id == "br" || @node.str_has_prefix(child.id, "#text") {
       continue
     }
     if child.style.display == @types.Contents {
@@ -688,10 +688,10 @@ fn inline_atomic_box_ignores_descendant_block_breaks(
 
 ///|
 fn is_generated_pseudo_text_only(node : @node.Node) -> Bool {
-  if node.id.has_prefix("#text") {
+  if @node.str_has_prefix(node.id, "#text") {
     return true
   }
-  if !node.id.has_prefix("#pseudo::") {
+  if !@node.str_has_prefix(node.id, "#pseudo::") {
     return false
   }
   for child in node.children {
@@ -852,7 +852,7 @@ fn inline_source_children_only_contribute_floats(
       child.style.position == @types.Fixed {
       continue
     }
-    if child.id.has_prefix("#text") {
+    if @node.str_has_prefix(child.id, "#text") {
       match child.text {
         Some(text) =>
           if !is_whitespace_text_node(child) && !text.is_empty() {
@@ -1433,7 +1433,7 @@ pub fn compute_ifc(
       let raw = font_size * ascender_ratio
       let br_baseline = if raw > 0.0 { raw } else { 0.0 }
       br_baseline + child_layout.padding.top + child_layout.border.top
-    } else if child.id.has_prefix("#text") {
+    } else if @node.str_has_prefix(child.id, "#text") {
       // Text node: use baseline synthesis that includes half-leading.
       @baseline.compute_node_baseline(child, child_layout.height)
     } else if child.style.contain.size &&
@@ -1683,7 +1683,7 @@ pub fn compute_ifc(
       if child.id == "br" && item_index > 0 {
         let prev_item = line.items[item_index - 1]
         let prev_child = children[prev_item.index]
-        if prev_child.id.has_prefix("#text") {
+        if @node.str_has_prefix(prev_child.id, "#text") {
           match layout_map.get(prev_item.index) {
             Some(prev_layout) => {
               let wrap_width = if prev_layout.width > 0.0 {
@@ -2067,7 +2067,7 @@ fn compute_inline_child(
       }
       let text_like_vertical_auto_width = style.writing_mode.is_vertical() &&
         style.width == @types.Auto &&
-        node.id.has_prefix("#text")
+        @node.str_has_prefix(node.id, "#text")
       let width = if text_like_vertical_auto_width {
         constrained.max_width +
         padding.horizontal_sum() +
@@ -2142,7 +2142,8 @@ fn compute_inline_child(
         }
         _ => ()
       }
-      if node.id.has_prefix("#text") && !style.writing_mode.is_vertical() {
+      if @node.str_has_prefix(node.id, "#text") &&
+        !style.writing_mode.is_vertical() {
         match estimate_wrapped_text_metrics(node, content_width) {
           Some(metrics) if metrics.line_count > 1 &&
             metrics.max_line_width > 0.0 => {
@@ -2707,7 +2708,7 @@ fn compute_inline_child(
     // A taller non-text child (e.g. larger font span) does NOT count as text wrap.
     let mut has_text_wrap = false
     for child_layout in children {
-      if child_layout.id.has_prefix("#text") {
+      if @node.str_has_prefix(child_layout.id, "#text") {
         let text_single_line = line_height_from_style(style)
         if child_layout.height > text_single_line + 0.01 {
           has_text_wrap = true
@@ -2968,7 +2969,7 @@ pub fn should_establish_ifc(children : Array[@node.Node]) -> Bool {
     if child.style.display == @types.Display::None {
       continue
     }
-    if child.id == "br" || child.id.has_prefix("#text") {
+    if child.id == "br" || @node.str_has_prefix(child.id, "#text") {
       has_inline = true
       continue
     }

--- a/layout/table/table.mbt
+++ b/layout/table/table.mbt
@@ -237,7 +237,7 @@ fn has_percent_size_for_table_intrinsic(node : @node.Node) -> Bool {
 
 ///|
 fn is_whitespace_only_table_text_node(node : @node.Node) -> Bool {
-  if !node.id.has_prefix("#text") {
+  if !@node.str_has_prefix(node.id, "#text") {
     return false
   }
   match node.text {
@@ -496,7 +496,7 @@ fn get_first_visual_row(table_node : @node.Node) -> @node.Node? {
 ///|
 /// Table row model ignores direct whitespace text children.
 fn is_ignorable_table_text_node(node : @node.Node) -> Bool {
-  if !node.id.has_prefix("#text") {
+  if !@node.str_has_prefix(node.id, "#text") {
     return false
   }
   match node.text {
@@ -596,7 +596,7 @@ fn normalize_row_group_rows(row_group : @node.Node) -> Array[@node.Node] {
 
 ///|
 fn is_inline_intrinsic_child(node : @node.Node) -> Bool {
-  if node.id == "br" || node.id.has_prefix("#text") {
+  if node.id == "br" || @node.str_has_prefix(node.id, "#text") {
     return true
   }
   if node.style.display == @types.Contents {
@@ -1124,7 +1124,7 @@ fn calculate_intrinsic_column_widths(
       // an otherwise-empty spacer <tr>) must not inflate a real column's
       // intrinsic width — their content is layout noise, not the column's
       // max-content. Skip their contribution to column widths.
-      if cell.id.has_prefix("__anon-table-cell-") && span == 1 {
+      if @node.str_has_prefix(cell.id, "__anon-table-cell-") && span == 1 {
         col_index = col_index + raw_colspan
         continue
       }
@@ -1597,7 +1597,7 @@ fn child_layout_extent_bounds(
   let mut bottom = 0.0
   let mut saw_box = false
   for child in children {
-    if child.id.has_prefix("#text") {
+    if @node.str_has_prefix(child.id, "#text") {
       continue
     }
     if table_layouts_only && !is_table_container_layout_id(child.id) {
@@ -1622,7 +1622,9 @@ fn child_layout_extent_bounds(
 
 ///|
 fn is_table_container_layout_id(id : String) -> Bool {
-  id == "table" || id.has_prefix("table#") || id.has_prefix("table.")
+  id == "table" ||
+  @node.str_has_prefix(id, "table#") ||
+  @node.str_has_prefix(id, "table.")
 }
 
 ///|
@@ -2088,7 +2090,7 @@ fn layout_row(
   }
   let row_children : Array[@layout_types.Layout] = []
   for layout in final_cell_layouts {
-    if layout.id.has_prefix("__anon-table-cell-") {
+    if @node.str_has_prefix(layout.id, "__anon-table-cell-") {
       for anon_child in layout.children {
         row_children.push({
           ..anon_child,
@@ -3518,7 +3520,7 @@ pub fn compute(
           group_y = group_y + row_advance
           // Track max row width for consistent group width
           max_row_width = max(max_row_width, row_layout.width)
-          if row.id.has_prefix("__anon-table-rowgrp-row-") {
+          if @node.str_has_prefix(row.id, "__anon-table-rowgrp-row-") {
             for anon_child in row_layout.children {
               group_layouts.push({
                 ..anon_child,
@@ -3877,7 +3879,7 @@ pub fn compute(
     let is_cell_box = inside_cell ||
       layout.id == "td" ||
       layout.id == "th" ||
-      layout.id.has_prefix("__anon-table-cell-")
+      @node.str_has_prefix(layout.id, "__anon-table-cell-")
     let keeps_descendant_negative_offsets = overflow_creates_scroll_container(
         layout.overflow_x,
       ) ||


### PR DESCRIPTION
## Summary

Memory-profiling-driven optimization of the **render pipeline** (via the `moonbit-mem-profile` skill / moon-pprof, profiling a different scenario than #304's parse path).

`moon-pprof memprofile` on a wasm build rendering an attribute-heavy document showed `i32_array_make_raw` as the single largest allocation site — **8.79MB, 36% of all render allocation**. `go tool pprof -peek` traced the callers:

```
String::has_prefix → StringView::find → boyer_moore_horspool_find → i32_array_make
```

`String::has_prefix` (core) is implemented via Boyer-Moore-Horspool and allocates an ~850-byte skip table **per call**. Layout runs it per node for text detection (`id.has_prefix("#text")`) and similar checks — ~10.8k times per render.

Added `node.str_has_prefix` (a direct, allocation-free prefix compare) and used it for the **58** layout id-prefix checks (`#text` / `fieldset` / `legend` / `rb#` / `rt#` / …).

## Profile (3 renders of a 200-row styled list, wasm)

| metric | before | after | Δ |
|---|---|---|---|
| total allocated | 24.20MB | 15.76MB | **−34.9%** |
| `i32_array_make_raw` | 8.79MB | 359kB | **−96%** |

No allocation regressions.

## Verification

- `renderer` suite (392) and `layout` suite pass unchanged; `str_has_prefix` is behavior-identical to `String::has_prefix`.
- `.mbti` delta is the single new function.
- JS target unaffected (the skip-table allocation is wasm-only).

## Note

The other large render sites (`Style::default` 54,945 allocs, `Dimension::resolve` 55,422, `Color::transparent`/`Transform::none` allocating per call) live in the external `mizchi/css` dependency and would need fixes upstream there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_