### PR TITLE
perf(dom): slice-based class tokenizer in querySelector node projection

### DIFF
--- a/dom/dom/query.mbt
+++ b/dom/dom/query.mbt
@@ -152,30 +152,29 @@ fn dom_node_to_selector_element(
 }
 
 ///|
-fn is_whitespace_char(c : Char) -> Bool {
-  c == ' ' || c == '\t' || c == '\n' || c == '\r'
+fn is_whitespace_code(code : Int) -> Bool {
+  code == 32 || code == 9 || code == 10 || code == 13
 }
 
 ///|
 /// Split a string on ASCII whitespace, dropping empty segments (used for the
-/// `class` attribute's token list).
+/// `class` attribute's token list). Index-scans the input and slices each token
+/// instead of materializing a char array (`to_array`) and a `StringBuilder` per
+/// token, which dominated allocation in `querySelectorAll` node projection.
 fn split_whitespace(s : String) -> Array[String] {
-  let chars = s.to_array()
-  let n = chars.length()
+  let n = s.length()
   let tokens : Array[String] = []
   let mut i = 0
   while i < n {
-    while i < n && is_whitespace_char(chars[i]) {
+    while i < n && is_whitespace_code(s[i].to_int()) {
       i = i + 1
     }
-    let buf = StringBuilder::new()
-    while i < n && !is_whitespace_char(chars[i]) {
-      buf.write_char(chars[i])
+    let start = i
+    while i < n && !is_whitespace_code(s[i].to_int()) {
       i = i + 1
     }
-    let token = buf.to_string()
-    if token.length() > 0 {
-      tokens.push(token)
+    if i > start {
+      tokens.push(s[start:i].to_owned())
     }
   }
   tokens


### PR DESCRIPTION
## Summary

Memory-profiling-driven optimization of a new scenario — **DOM `querySelectorAll`** (via the `moonbit-mem-profile` skill / moon-pprof).

Profiling 40 queries over a 900-element tree showed **1.03M allocations / 20.8MB**, dominated by per-query node projection. `split_whitespace` — which parses the `class` attribute for **every node projected on every query** — was a large, fixable chunk: it materialized the whole string as a char array (`String::iter` / `to_array`) and built each token with a `StringBuilder`.

Rewrite it as an index scan that slices each token (`s[start:i].to_owned()`), with no char-array and no per-token `StringBuilder`.

## Profile (40 queries on a 900-node tree, wasm; `moon-pprof memprofile`)

| metric | before | after | Δ |
|---|---|---|---|
| total allocated | 20.83MB | 14.06MB | **−32.5%** |
| allocation count | 1,034,135 | 638,135 | **−38.3%** |

`unsafe_make_string_raw` 3.66MB → ~0; `StringBuilder` → 0; `i32_array_make_raw` (the `to_array` char arrays) −62%. The smaller `bytes_make_raw` uptick is the owned token slices (far less than what was removed).

## Verification

- `dom` (49) and `dom`+`html` (203) suites pass unchanged.
- The remaining projection cost (`dom_node_to_selector_element` rebuilds an `@selector.Element` per node per query) and the selector-match skip tables are structural / live in the external `mizchi/css` matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_