### PR TITLE
perf(dom): record DOM mutations only when a consumer wants them

### DIFF
--- a/dom/dom/dom.mbt
+++ b/dom/dom/dom.mbt
@@ -188,10 +188,9 @@ pub fn DomTree::append_child(
                 Some(i) => {
                   let _ = old_parent.children.remove(i)
                   // Record removal from old parent
-                  self.mutations.push(
-                    MutationRecord::child_list(NodeId(old_parent_id), removed=[
-                      child,
-                    ]),
+                  self.mutations.record_child_removed(
+                    NodeId(old_parent_id),
+                    child,
                   )
                 }
                 None => ()
@@ -206,7 +205,7 @@ pub fn DomTree::append_child(
       // Add to new parent's children
       p.children.push(child_id)
       // Record mutation
-      self.mutations.push(MutationRecord::child_list(parent, added=[child]))
+      self.mutations.record_child_added(parent, child)
       // Invalidate layout cache
       self.invalidate_layout(parent_id)
       Ok(())
@@ -242,10 +241,9 @@ pub fn DomTree::insert_before(
                     Some(i) => {
                       let _ = old_parent.children.remove(i)
                       // Record removal from old parent
-                      self.mutations.push(
-                        MutationRecord::child_list(NodeId(old_parent_id), removed=[
-                          child,
-                        ]),
+                      self.mutations.record_child_removed(
+                        NodeId(old_parent_id),
+                        child,
                       )
                     }
                     None => ()
@@ -270,7 +268,7 @@ pub fn DomTree::insert_before(
             None => p.children.push(child_id) // No reference, append
           }
           // Record mutation
-          self.mutations.push(MutationRecord::child_list(parent, added=[child]))
+          self.mutations.record_child_added(parent, child)
           self.invalidate_layout(parent_id)
           Ok(())
         }
@@ -295,9 +293,7 @@ pub fn DomTree::remove_child(
           let _ = p.children.remove(i)
           c.parent_id = None
           // Record mutation
-          self.mutations.push(
-            MutationRecord::child_list(parent, removed=[child]),
-          )
+          self.mutations.record_child_removed(parent, child)
           self.invalidate_layout(parent_id)
           Ok(())
         }
@@ -327,8 +323,11 @@ pub fn DomTree::set_attribute(
       let old_value = n.attributes.get(name)
       n.attributes[name] = value
       // Record mutation
-      self.mutations.push(
-        MutationRecord::attribute(node, name, old_value~, new_value=Some(value)),
+      self.mutations.record_attribute(
+        node,
+        name,
+        old_value~,
+        new_value=Some(value),
       )
       self.invalidate_layout(id)
       Ok(())
@@ -364,9 +363,7 @@ pub fn DomTree::remove_attribute(
       let old_value = n.attributes.get(name)
       n.attributes.remove(name)
       // Record mutation
-      self.mutations.push(
-        MutationRecord::attribute(node, name, old_value~, new_value=None),
-      )
+      self.mutations.record_attribute(node, name, old_value~)
       self.invalidate_layout(id)
       Ok(())
     }
@@ -552,21 +549,17 @@ pub fn DomTree::set_text_content(
           let old_value = n.text_content
           n.text_content = content
           // Record mutation
-          self.mutations.push(
-            MutationRecord::character_data(
-              node,
-              old_value=Some(old_value),
-              new_value=Some(content),
-            ),
+          self.mutations.record_character_data(
+            node,
+            old_value=Some(old_value),
+            new_value=Some(content),
           )
         }
         _ => {
           // For elements, remove all children and add text node
           // Record removal of existing children
           for child_id in n.children {
-            self.mutations.push(
-              MutationRecord::child_list(node, removed=[NodeId(child_id)]),
-            )
+            self.mutations.record_child_removed(node, NodeId(child_id))
           }
           n.children.clear()
           let text_node = self.create_text(content)
@@ -739,6 +732,14 @@ pub fn DomTree::get_focus(self : DomTree) -> NodeId? {
 // =============================================================================
 // Mutation Queue API
 // =============================================================================
+
+///|
+/// Enable or disable mutation recording. Off by default: records exist only to
+/// feed the incremental-layout bridge, so a standalone tree (querySelector /
+/// one-shot build) records nothing. The bridge enables it on the trees it owns.
+pub fn DomTree::set_mutation_recording(self : DomTree, on : Bool) -> Unit {
+  self.mutations.set_recording(on)
+}
 
 ///|
 /// Check if there are pending mutations

--- a/dom/dom/mutation_queue.mbt
+++ b/dom/dom/mutation_queue.mbt
@@ -17,6 +17,10 @@ pub struct MutationQueue {
   mut is_flushing : Bool
   /// Records that arrived during flush (processed in next batch)
   mut deferred : Array[MutationRecord]
+  /// Whether mutations are recorded at all. Recording exists solely to feed the
+  /// incremental-layout bridge; a standalone tree (querySelector, one-shot build)
+  /// has no consumer, so recording is off by default and enabled by that bridge.
+  mut recording : Bool
 }
 
 ///|
@@ -40,7 +44,20 @@ pub impl Show for FlushResult with fn output(self, logger) {
 ///|
 /// Create a new empty mutation queue
 pub fn MutationQueue::new() -> MutationQueue {
-  { records: [], dirty_nodes: {}, is_flushing: false, deferred: [] }
+  {
+    records: [],
+    dirty_nodes: {},
+    is_flushing: false,
+    deferred: [],
+    recording: false,
+  }
+}
+
+///|
+/// Enable or disable mutation recording. When disabled (the default), `push` is a
+/// no-op, so building a tree with no mutation consumer allocates no records.
+pub fn MutationQueue::set_recording(self : MutationQueue, on : Bool) -> Unit {
+  self.recording = on
 }
 
 ///|
@@ -49,12 +66,67 @@ pub fn MutationQueue::push(
   self : MutationQueue,
   record : MutationRecord,
 ) -> Unit {
+  if !self.recording {
+    return
+  }
   if self.is_flushing {
     // Queue for next batch to avoid mutation during iteration
     self.deferred.push(record)
   } else {
     self.records.push(record)
     self.dirty_nodes[record.target.to_int()] = true
+  }
+}
+
+///|
+/// Build and queue a child-list "added" record only when recording, so the
+/// record and its single-element array allocate nothing on standalone trees.
+pub fn MutationQueue::record_child_added(
+  self : MutationQueue,
+  target : NodeId,
+  child : NodeId,
+) -> Unit {
+  if self.recording {
+    self.push(MutationRecord::child_list(target, added=[child]))
+  }
+}
+
+///|
+/// Build and queue a child-list "removed" record only when recording.
+pub fn MutationQueue::record_child_removed(
+  self : MutationQueue,
+  target : NodeId,
+  child : NodeId,
+) -> Unit {
+  if self.recording {
+    self.push(MutationRecord::child_list(target, removed=[child]))
+  }
+}
+
+///|
+/// Build and queue an attribute-change record only when recording.
+pub fn MutationQueue::record_attribute(
+  self : MutationQueue,
+  target : NodeId,
+  name : String,
+  old_value? : String? = None,
+  new_value? : String? = None,
+) -> Unit {
+  if self.recording {
+    self.push(MutationRecord::attribute(target, name, old_value~, new_value~))
+  }
+}
+
+///|
+/// Build and queue a character-data record only when recording.
+pub fn MutationQueue::record_character_data(
+  self : MutationQueue,
+  target : NodeId,
+  old_value? : String? = None,
+  new_value? : String? = None,
+) -> Unit {
+  if self.recording {
+    self.push(MutationRecord::character_data(target, old_value~, new_value~))
   }
 }
 

--- a/dom/dom/mutation_test.mbt
+++ b/dom/dom/mutation_test.mbt
@@ -55,6 +55,7 @@ test "MutationRecord::affects_layout detects layout properties" {
 ///|
 test "MutationQueue basic operations" {
   let queue = MutationQueue::new()
+  queue.set_recording(true)
   inspect(queue.is_empty(), content="true")
   let target = NodeId::from_int(1)
   queue.push(MutationRecord::style_change(target, ["width"]))
@@ -67,6 +68,7 @@ test "MutationQueue basic operations" {
 ///|
 test "MutationQueue flush returns optimized records" {
   let queue = MutationQueue::new()
+  queue.set_recording(true)
   let target = NodeId::from_int(1)
 
   // Add multiple style changes to same node
@@ -88,6 +90,7 @@ test "MutationQueue flush returns optimized records" {
 ///|
 test "MutationQueue merges add/remove pairs" {
   let queue = MutationQueue::new()
+  queue.set_recording(true)
   let parent = NodeId::from_int(1)
   let child = NodeId::from_int(2)
 
@@ -112,6 +115,7 @@ test "MutationQueue merges add/remove pairs" {
 ///|
 test "MutationQueue handles deferred mutations during flush" {
   let queue = MutationQueue::new()
+  queue.set_recording(true)
   let target = NodeId::from_int(1)
   queue.push(MutationRecord::style_change(target, ["width"]))
 
@@ -129,6 +133,7 @@ test "MutationQueue handles deferred mutations during flush" {
 ///|
 test "DomTree records append_child mutations" {
   let tree = DomTree::new()
+  tree.set_mutation_recording(true)
   let doc = tree.get_document()
   let div = tree.create_element("div")
   inspect(tree.has_pending_mutations(), content="false")
@@ -149,6 +154,7 @@ test "DomTree records append_child mutations" {
 ///|
 test "DomTree records remove_child mutations" {
   let tree = DomTree::new()
+  tree.set_mutation_recording(true)
   let doc = tree.get_document()
   let div = tree.create_element("div")
   let _ = tree.append_child(doc, div)
@@ -166,6 +172,7 @@ test "DomTree records remove_child mutations" {
 ///|
 test "DomTree records set_attribute mutations" {
   let tree = DomTree::new()
+  tree.set_mutation_recording(true)
   let doc = tree.get_document()
   let div = tree.create_element("div")
   let _ = tree.append_child(doc, div)
@@ -183,6 +190,7 @@ test "DomTree records set_attribute mutations" {
 ///|
 test "DomTree records attribute update with old value" {
   let tree = DomTree::new()
+  tree.set_mutation_recording(true)
   let doc = tree.get_document()
   let div = tree.create_element("div")
   let _ = tree.append_child(doc, div)
@@ -198,6 +206,7 @@ test "DomTree records attribute update with old value" {
 ///|
 test "DomTree records set_text_content mutations for text nodes" {
   let tree = DomTree::new()
+  tree.set_mutation_recording(true)
   let text = tree.create_text("hello")
   tree.clear_mutations()
   let _ = tree.set_text_content(text, "world")
@@ -212,6 +221,7 @@ test "DomTree records set_text_content mutations for text nodes" {
 ///|
 test "DomTree batches multiple mutations" {
   let tree = DomTree::new()
+  tree.set_mutation_recording(true)
   let doc = tree.get_document()
 
   // Create and append multiple elements
@@ -241,6 +251,7 @@ test "DomTree batches multiple mutations" {
 ///|
 test "DomTree move child records both removal and addition" {
   let tree = DomTree::new()
+  tree.set_mutation_recording(true)
   let doc = tree.get_document()
   let parent1 = tree.create_element("div")
   let parent2 = tree.create_element("div")

--- a/dom/dom/pkg.generated.mbti
+++ b/dom/dom/pkg.generated.mbti
@@ -108,6 +108,7 @@ pub fn DomTree::set_cached_rect(Self, NodeId, Rect) -> Unit
 pub fn DomTree::set_custom_states(Self, NodeId, Array[String]) -> Result[Unit, CoreError]
 pub fn DomTree::set_focus(Self, NodeId?) -> Unit
 pub fn DomTree::set_form_associated_state(Self, NodeId, String?, String?) -> Result[Unit, CoreError]
+pub fn DomTree::set_mutation_recording(Self, Bool) -> Unit
 pub fn DomTree::set_text_content(Self, NodeId, String) -> Result[Unit, CoreError]
 pub fn DomTree::shadow_cascaded_values(Self, NodeId, Array[@cascade.CSSRule], NodeId) -> @cascade.CascadedValues
 pub fn DomTree::shadow_query_selector(Self, NodeId, String) -> Result[NodeId?, CoreError]
@@ -138,6 +139,7 @@ pub struct MutationQueue {
   dirty_nodes : Map[Int, Bool]
   mut is_flushing : Bool
   mut deferred : Array[MutationRecord]
+  mut recording : Bool
 }
 pub fn MutationQueue::clear(Self) -> Unit
 pub fn MutationQueue::flush(Self) -> (Array[MutationRecord], FlushResult)
@@ -148,6 +150,11 @@ pub fn MutationQueue::length(Self) -> Int
 pub fn MutationQueue::new() -> Self
 pub fn MutationQueue::optimize(Self) -> Array[MutationRecord]
 pub fn MutationQueue::push(Self, MutationRecord) -> Unit
+pub fn MutationQueue::record_attribute(Self, NodeId, String, old_value? : String?, new_value? : String?) -> Unit
+pub fn MutationQueue::record_character_data(Self, NodeId, old_value? : String?, new_value? : String?) -> Unit
+pub fn MutationQueue::record_child_added(Self, NodeId, NodeId) -> Unit
+pub fn MutationQueue::record_child_removed(Self, NodeId, NodeId) -> Unit
+pub fn MutationQueue::set_recording(Self, Bool) -> Unit
 
 pub struct MutationRecord {
   type_ : MutationType

--- a/dom/layout/dom_bridge/top.mbt
+++ b/dom/layout/dom_bridge/top.mbt
@@ -30,6 +30,9 @@ pub fn Document::new(
   viewport_height : Double,
 ) -> Document {
   let dom = @dom.DomTree::new()
+  // The incremental-layout bridge consumes mutations, so record them on the
+  // trees it owns (recording is off by default for standalone trees).
+  dom.set_mutation_recording(true)
   // Create a minimal root @tree.LayoutNode
   let root_layout = @tree.LayoutNode::create_with_id("root")
   root_layout.style.width = @types.Percent(1.0)


### PR DESCRIPTION
## Summary

Memory-profiling-driven optimization of a new scenario — **DOM tree construction** (via the `moonbit-mem-profile` skill / moon-pprof).

Profiling 10× building an ~800-node tree showed `MutationRecord` allocation (`attribute` + `child_list`) at **~25% of all build allocation**. These records exist solely to feed the incremental-layout bridge — `Document::process_mutations` is the **only** flush consumer, and the JS-runtime `MutationObserver` uses a separate mock DOM — so a standalone tree built for `querySelector` or one-shot use allocated records that were never read.

Gate recording:
- `MutationQueue` gains a `recording` flag (**off by default**) and typed `record_*` helpers that build the record (and its arrays/options) only when recording, so nothing is constructed when there is no consumer.
- The incremental-layout bridge enables recording on the trees it owns (`Document::new`).
- The mutation tests, which exercise the queue on standalone trees, enable it explicitly.

## Profile (build 10× an ~800-node tree, wasm; `moon-pprof memprofile`)

| metric | before | after | Δ |
|---|---|---|---|
| total allocated | 6.67MB | 3.88MB | **−41.8%** |
| allocation count | 240,698 | 124,418 | **−48.3%** |

## Verification

- `dom` (213), `dom_bridge` (10), and `renderer` (392, shadow uses DomTree) suites pass unchanged.
- `Document` is the only mutation consumer in the codebase (the JS `MutationObserver` uses its own mock DOM), and it enables recording — so the incremental-layout path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_