### PR TITLE
perf(dom): cache the per-node selector projection across queries

### DIFF
--- a/dom/dom/dom.mbt
+++ b/dom/dom/dom.mbt
@@ -47,6 +47,11 @@ struct DomNode {
   mut shadow_serializable : Bool
   /// For elements: computed style cache
   mut cached_rect : Rect?
+  /// Cached selector projection of this node's class list and attribute array,
+  /// computed lazily and invalidated when attributes change. Lets querySelector
+  /// reuse them across queries instead of re-splitting / rebuilding per query.
+  mut sel_classes : Array[String]?
+  mut sel_attrs : Array[@selector.Attribute]?
 }
 
 ///|
@@ -73,6 +78,8 @@ fn DomNode::new(
     shadow_clonable: false,
     shadow_serializable: false,
     cached_rect: None,
+    sel_classes: None,
+    sel_attrs: None,
   }
 }
 
@@ -322,6 +329,8 @@ pub fn DomTree::set_attribute(
     Some(n) => {
       let old_value = n.attributes.get(name)
       n.attributes[name] = value
+      n.sel_classes = None
+      n.sel_attrs = None
       // Record mutation
       self.mutations.record_attribute(
         node,
@@ -362,6 +371,8 @@ pub fn DomTree::remove_attribute(
     Some(n) => {
       let old_value = n.attributes.get(name)
       n.attributes.remove(name)
+      n.sel_classes = None
+      n.sel_attrs = None
       // Record mutation
       self.mutations.record_attribute(node, name, old_value~)
       self.invalidate_layout(id)

--- a/dom/dom/query.mbt
+++ b/dom/dom/query.mbt
@@ -136,18 +136,34 @@ fn dom_node_to_selector_element(
   sibling_index : Int,
   sibling_count : Int,
 ) -> @selector.Element {
-  let classes : Array[String] = match node.attributes.get("class") {
-    Some(value) => split_whitespace(value)
-    None => empty_selector_strings
+  // Reuse the parsed class list / attribute array across queries; both are
+  // invalidated when the node's attributes change.
+  let classes : Array[String] = match node.sel_classes {
+    Some(cached) => cached
+    None => {
+      let computed = match node.attributes.get("class") {
+        Some(value) => split_whitespace(value)
+        None => empty_selector_strings
+      }
+      node.sel_classes = Some(computed)
+      computed
+    }
   }
-  let attributes : Array[@selector.Attribute] = if node.attributes.is_empty() {
-    empty_selector_attrs
-  } else {
-    let attrs = []
-    node.attributes.each(fn(name, value) {
-      attrs.push(@selector.Attribute::{ name, value })
-    })
-    attrs
+  let attributes : Array[@selector.Attribute] = match node.sel_attrs {
+    Some(cached) => cached
+    None => {
+      let computed : Array[@selector.Attribute] = if node.attributes.is_empty() {
+        empty_selector_attrs
+      } else {
+        let attrs = []
+        node.attributes.each(fn(name, value) {
+          attrs.push(@selector.Attribute::{ name, value })
+        })
+        attrs
+      }
+      node.sel_attrs = Some(computed)
+      computed
+    }
   }
   // The projection is transient and read-only, so the node's custom_states can
   // be aliased (an empty set is shared) instead of copied.

--- a/dom/dom/query_test.mbt
+++ b/dom/dom/query_test.mbt
@@ -109,3 +109,33 @@ test "query_selector returns first match in document order" {
     Err(err) => fail("\{err}")
   }
 }
+
+///|
+/// The cached selector projection (class list / attribute array on each node)
+/// must be invalidated when attributes change, so repeated queries reflect
+/// mutations rather than returning stale matches.
+test "query_selector projection cache invalidates on attribute change" {
+  let tree = DomTree::new()
+  let doc = tree.get_document()
+  let el = tree.create_element("div")
+  let _ = tree.set_attribute(el, "class", "foo")
+  let _ = tree.append_child(doc, el)
+
+  // Warm the cache, then change the class.
+  inspect(tree.query_selector_all(doc, ".foo").unwrap().length(), content="1")
+  inspect(tree.query_selector_all(doc, ".bar").unwrap().length(), content="0")
+  let _ = tree.set_attribute(el, "class", "bar")
+  inspect(tree.query_selector_all(doc, ".foo").unwrap().length(), content="0")
+  inspect(tree.query_selector_all(doc, ".bar").unwrap().length(), content="1")
+
+  // Removing the class attribute clears the class match.
+  let _ = tree.remove_attribute(el, "class")
+  inspect(tree.query_selector_all(doc, ".bar").unwrap().length(), content="0")
+
+  // A newly added attribute is visible to attribute selectors.
+  let _ = tree.set_attribute(el, "data-x", "1")
+  inspect(
+    tree.query_selector_all(doc, "[data-x]").unwrap().length(),
+    content="1",
+  )
+}


### PR DESCRIPTION
## Summary

Structural follow-up to #307/#308: `querySelector` projected **every node into an `@selector.Element` on every query**, re-splitting the `class` attribute and rebuilding the attribute array each time. On a static tree queried repeatedly this is the dominant cost.

Cache the parsed class list and attribute array on the `DomNode` (computed lazily on first projection), and invalidate both when the node's attributes change (`set_attribute` / `remove_attribute` — the only two attribute-mutation points). The positional wiring (parent / sibling / index) is still built fresh per query, so results stay correct.

A new test covers cache invalidation on class change, attribute removal, and attribute add.

## Profile (40 queries on a 900-node tree, wasm; `moon-pprof memprofile`)

| | bytes | allocs |
|---|---|---|
| this change | 10.82MB → 4.08MB (**−62.3%**) | −70.0% |
| **cumulative with #307/#308** | ~20.8MB → 4.08MB (**~−80%**) | |

`split_whitespace` −97.5%, `ref_array_make_raw` −95.5%, `unsafe_bytes_sub_string` −97.3%.

## Verification

- `dom` (50, including the new invalidation test) and `renderer` (392, shadow uses DomTree) suites pass.
- The two attribute-mutation points are the only places `node.attributes` changes; both clear the cache.
- No public API change (`DomNode` and the cache fields are internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbcp73WCCyzF4HGyKHuNVi)_