### PR TITLE
Narrow incremental reflow dirty seeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -757,6 +757,14 @@ jobs:
       - name: Setup Crater toolchain
         uses: ./.github/actions/setup-crater
 
+      # The VRT bench is a pure JS-target build (mizchi/crater-benchmarks); it
+      # never links V8. Drop the V8-pulling workspace members so neither the
+      # prefetch nor the bench resolves mizchi/v8 and runs its postadd
+      # (git clone denoland/rusty_v8), which only adds latency and network-flake
+      # risk here. The runner is ephemeral, so no restore is needed.
+      - name: Drop V8 workspace members (not needed for the JS bench)
+        run: bash scripts/ci/drop-v8-members.sh
+
       - name: Prefetch MoonBit dependencies
         uses: ./.github/actions/moon-prefetch
 

--- a/aomx/moon.mod
+++ b/aomx/moon.mod
@@ -1,9 +1,9 @@
 name = "mizchi/crater-aomx"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-dom@0.18.0",
+  "mizchi/crater-dom@0.18.1",
 }
 
 readme = "README.md"

--- a/benchmarks/moon.mod
+++ b/benchmarks/moon.mod
@@ -1,15 +1,15 @@
 name = "mizchi/crater-benchmarks"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-core@0.18.0",
-  "mizchi/crater-browser@0.18.0",
+  "mizchi/crater-core@0.18.1",
+  "mizchi/crater-browser@0.18.1",
   "mizchi/css@0.7.3",
-  "mizchi/crater-dom@0.18.0",
-  "mizchi/crater-layout@0.18.0",
-  "mizchi/crater-painter@0.18.0",
-  "mizchi/crater-renderer@0.18.0",
+  "mizchi/crater-dom@0.18.1",
+  "mizchi/crater-layout@0.18.1",
+  "mizchi/crater-painter@0.18.1",
+  "mizchi/crater-renderer@0.18.1",
   "mizchi/svg@0.2.1",
 }
 

--- a/benchmarks/moon.mod
+++ b/benchmarks/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-browser@0.18.0",
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/browser/main/moon.pkg
+++ b/browser/main/moon.pkg
@@ -12,5 +12,5 @@ supported_targets = "js+native"
 
 options(
   "is-main": true,
-  link: { "native": { "cc-link-flags": "tui/tui_native.c" } },
+  link: { "native": { "cc-link-flags": "browser/tui/tui_native.c" } },
 )

--- a/browser/moon.mod
+++ b/browser/moon.mod
@@ -1,21 +1,21 @@
 name = "mizchi/crater-browser"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-core@0.18.0",
-  "mizchi/crater-aomx@0.18.0",
-  "mizchi/crater-dom@0.18.0",
+  "mizchi/crater-core@0.18.1",
+  "mizchi/crater-aomx@0.18.1",
+  "mizchi/crater-dom@0.18.1",
   "mizchi/css@0.7.3",
-  "mizchi/crater-layout@0.18.0",
-  "mizchi/crater-painter@0.18.0",
-  "mizchi/crater-renderer@0.18.0",
-  "mizchi/crater-browser-runtime@0.18.0",
-  "mizchi/crater-browser-helpers@0.18.0",
-  "mizchi/crater-browser-http@0.18.0",
-  "mizchi/crater-html-assets@0.18.0",
-  "mizchi/crater-terminal-image-cache@0.18.0",
-  "mizchi/crater-terminal-protocol@0.18.0",
+  "mizchi/crater-layout@0.18.1",
+  "mizchi/crater-painter@0.18.1",
+  "mizchi/crater-renderer@0.18.1",
+  "mizchi/crater-browser-runtime@0.18.1",
+  "mizchi/crater-browser-helpers@0.18.1",
+  "mizchi/crater-browser-http@0.18.1",
+  "mizchi/crater-html-assets@0.18.1",
+  "mizchi/crater-terminal-image-cache@0.18.1",
+  "mizchi/crater-terminal-protocol@0.18.1",
   "mizchi/font@0.7.3",
   "mizchi/tui-terminal-buffer@0.1.3",
   "mizchi/x@0.3.0",

--- a/browser/moon.mod
+++ b/browser/moon.mod
@@ -6,7 +6,7 @@ import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
   "mizchi/crater-dom@0.18.0",
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",
   "mizchi/crater-renderer@0.18.0",

--- a/browser/native/moon.mod
+++ b/browser/native/moon.mod
@@ -1,10 +1,10 @@
 name = "mizchi/crater-browser-native"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-browser-runtime@0.18.0",
-  "mizchi/crater-dom@0.18.0",
+  "mizchi/crater-browser-runtime@0.18.1",
+  "mizchi/crater-dom@0.18.1",
   "mizchi/v8@0.2.0",
 }
 

--- a/browser/scripts/mizchi-v8-consumer-prebuild.test.mjs
+++ b/browser/scripts/mizchi-v8-consumer-prebuild.test.mjs
@@ -84,3 +84,11 @@ test("platform_link_flags includes libm on linux", () => {
   assert.match(flags, /-pthread/)
   assert.match(flags, /-lm(\s|$)/)
 })
+
+test("platform_link_flags includes libc++ on darwin", () => {
+  const flags = platform_link_flags("darwin", "/tmp/mizchi-v8")
+  assert.match(flags, /librusty_v8_bridge\.a/)
+  assert.match(flags, /-lc\+\+/)
+  assert.match(flags, /-pthread/)
+  assert.match(flags, /-framework CoreFoundation/)
+})

--- a/browser/shell/incremental_reflow.mbt
+++ b/browser/shell/incremental_reflow.mbt
@@ -16,14 +16,10 @@ pub fn Browser::set_incremental_reflow(self : Browser, enabled : Bool) -> Unit {
 ///
 /// On: stabilize uids against the persistent registry (so a node maps to the
 /// same uid across rebuilds), then reconcile against the prior tree, migrating
-/// cached geometry. The dirty set is currently *every* uid — correct (equivalent
-/// to a full recompute) and end-to-end wired. The layout engine now memoizes
-/// in-flow block subtrees per uid (block-flow memoization, see
-/// docs/incremental-reflow-design.md), so a *narrower* dirty set here would let
-/// unchanged block subtrees be reused — narrowing it (paint-only via the mutation
-/// queue, or a layout-relevant `@style.Style` diff) is the remaining optimization
-/// to realize that win on this path. The result is recorded as the next
-/// reconcile baseline.
+/// cached geometry. The dirty seed is the set of nodes whose own layout inputs
+/// changed; `flow_dirty_uids` expands that seed for crater's absolute-geometry
+/// cache so following in-flow siblings remain correct. The result is recorded as
+/// the next reconcile baseline.
 fn Browser::build_dynamic_layout_tree(
   self : Browser,
   node : @node.Node,
@@ -35,7 +31,10 @@ fn Browser::build_dynamic_layout_tree(
   }
   @node.stabilize_uids(node, self.uid_registry)
   let tree = match self.incremental_prev_tree {
-    Some(prev) => prev.reconcile_from(node, collect_node_uids(node), vw, vh)
+    Some(prev) => {
+      let seeds = changed_seed_uids(node, prev)
+      prev.reconcile_from(node, prev.flow_dirty_uids(seeds), vw, vh)
+    }
     None => @layout.LayoutTree::from_node(node, vw, vh)
   }
   self.incremental_prev_tree = Some(tree)
@@ -43,17 +42,47 @@ fn Browser::build_dynamic_layout_tree(
 }
 
 ///|
-/// Every uid in the tree, in document order.
-fn collect_node_uids(node : @node.Node) -> Array[Int] {
+/// Directly changed layout-input uids, before flow-shift expansion.
+fn changed_seed_uids(node : @node.Node, prev : @layout.LayoutTree) -> Array[Int] {
   let out : Array[Int] = []
-  collect_node_uids_into(node, out)
+  changed_seed_uids_into(node, prev, out)
   out
 }
 
 ///|
-fn collect_node_uids_into(node : @node.Node, out : Array[Int]) -> Unit {
-  out.push(node.uid)
+fn changed_seed_uids_into(
+  node : @node.Node,
+  prev : @layout.LayoutTree,
+  out : Array[Int],
+) -> Unit {
+  match prev.find_node(node.uid) {
+    Some(old) =>
+      if node_layout_input_changed(node, old) {
+        out.push(node.uid)
+      }
+    None => ()
+  }
   for child in node.children {
-    collect_node_uids_into(child, out)
+    changed_seed_uids_into(child, prev, out)
+  }
+}
+
+///|
+fn node_layout_input_changed(node : @node.Node, old : @layout.LayoutNode) -> Bool {
+  !node.style.layout_eq(old.style) ||
+  node.text != old.text ||
+  node.src != old.src ||
+  measure_presence_changed(node.measure, old.measure)
+}
+
+///|
+fn measure_presence_changed(
+  next : @layout_types.MeasureFunc?,
+  old : @layout_types.MeasureFunc?,
+) -> Bool {
+  match (next, old) {
+    (Some(_), Some(_)) => false
+    (None, None) => false
+    _ => true
   }
 }

--- a/browser/shell/incremental_reflow.mbt
+++ b/browser/shell/incremental_reflow.mbt
@@ -17,9 +17,13 @@ pub fn Browser::set_incremental_reflow(self : Browser, enabled : Bool) -> Unit {
 /// On: stabilize uids against the persistent registry (so a node maps to the
 /// same uid across rebuilds), then reconcile against the prior tree, migrating
 /// cached geometry. The dirty set is currently *every* uid — correct (equivalent
-/// to a full recompute) and end-to-end wired; narrowing it (paint-only via the
-/// mutation queue, or a layout-style diff) is the remaining optimization noted in
-/// the design memo. The result is recorded as the next reconcile baseline.
+/// to a full recompute) and end-to-end wired. The layout engine now memoizes
+/// in-flow block subtrees per uid (block-flow memoization, see
+/// docs/incremental-reflow-design.md), so a *narrower* dirty set here would let
+/// unchanged block subtrees be reused — narrowing it (paint-only via the mutation
+/// queue, or a layout-relevant `@style.Style` diff) is the remaining optimization
+/// to realize that win on this path. The result is recorded as the next
+/// reconcile baseline.
 fn Browser::build_dynamic_layout_tree(
   self : Browser,
   node : @node.Node,

--- a/browser/shell/incremental_reflow_wbtest.mbt
+++ b/browser/shell/incremental_reflow_wbtest.mbt
@@ -4,7 +4,7 @@
 /// tree, and the output must match a plain full-rebuild render.
 
 ///|
-test "incremental reflow flag preserves the rendered output" {
+test "incremental reflow flag preserves the dynamic rendered output" {
   let html =
     #|<html><body style="margin:0">
     #|<div style="width:120px;height:40px">a</div>
@@ -13,7 +13,7 @@ test "incremental reflow flag preserves the rendered output" {
   // Baseline: flag off (full rebuild every time).
   let baseline = Browser::new(400, 300)
   baseline.set_html_content(html)
-  let want = baseline.render_text_full_page()
+  let want = baseline.render_text()
 
   // Flag on: render once (prev = None -> from_node, records baseline tree), then
   // force a rebuild and render again so the second render reconciles against the
@@ -21,8 +21,207 @@ test "incremental reflow flag preserves the rendered output" {
   let incremental = Browser::new(400, 300)
   incremental.set_incremental_reflow(true)
   incremental.set_html_content(html)
-  let _ = incremental.render_text_full_page()
+  let _ = incremental.render_text()
   incremental.clear_render_cache()
-  let got = incremental.render_text_full_page()
+  let got = incremental.render_text()
   inspect(got == want, content="true")
+}
+
+///|
+fn render_after_html_swap(
+  first : String,
+  second : String,
+  incremental : Bool,
+) -> String {
+  let browser = Browser::new(400, 300)
+  browser.set_incremental_reflow(incremental)
+  browser.set_html_content(first)
+  let _ = browser.render_text()
+  browser.set_html_content(second)
+  browser.render_text()
+}
+
+///|
+fn incremental_swap_matches_full(first : String, second : String) -> Bool {
+  render_after_html_swap(first, second, false) ==
+  render_after_html_swap(first, second, true)
+}
+
+///|
+test "incremental reflow equals full rebuild across common mutations" {
+  let text1 =
+    #|<html><body style="margin:0"><p>alpha</p></body></html>
+  let text2 =
+    #|<html><body style="margin:0"><p>beta</p></body></html>
+  inspect(incremental_swap_matches_full(text1, text2), content="true")
+
+  let size1 =
+    #|<html><body style="margin:0"><div style="width:80px;height:20px">box</div><div>tail</div></body></html>
+  let size2 =
+    #|<html><body style="margin:0"><div style="width:160px;height:20px">box</div><div>tail</div></body></html>
+  inspect(incremental_swap_matches_full(size1, size2), content="true")
+
+  let display1 =
+    #|<html><body style="margin:0"><div style="display:block">shown</div><div>tail</div></body></html>
+  let display2 =
+    #|<html><body style="margin:0"><div style="display:none">shown</div><div>tail</div></body></html>
+  inspect(incremental_swap_matches_full(display1, display2), content="true")
+
+  let append1 =
+    #|<html><body style="margin:0"><div>a</div></body></html>
+  let append2 =
+    #|<html><body style="margin:0"><div>a</div><div>b</div></body></html>
+  inspect(incremental_swap_matches_full(append1, append2), content="true")
+
+  let remove1 =
+    #|<html><body style="margin:0"><div>a</div><div>b</div></body></html>
+  let remove2 =
+    #|<html><body style="margin:0"><div>a</div></body></html>
+  inspect(incremental_swap_matches_full(remove1, remove2), content="true")
+
+  let move1 =
+    #|<html><body style="margin:0"><div>a</div><div>b</div></body></html>
+  let move2 =
+    #|<html><body style="margin:0"><div>b</div><div>a</div></body></html>
+  inspect(incremental_swap_matches_full(move1, move2), content="true")
+}
+
+///|
+fn seed_box_style(w : Double, h : Double) -> @style.Style {
+  @style.Style::{
+    ..@style.Style::default(),
+    width: @types.Length(w),
+    height: @types.Length(h),
+  }
+}
+
+///|
+fn seed_node(
+  uid : Int,
+  style : @style.Style,
+  children : Array[@node.Node],
+) -> @node.Node {
+  @node.Node::with_uid("n" + uid.to_string(), uid, style, children)
+}
+
+///|
+fn seed_tree(child : @node.Node) -> @layout.LayoutTree {
+  let root = seed_node(1, seed_box_style(200.0, 200.0), [child])
+  @layout.LayoutTree::from_node(root, 200.0, 200.0)
+}
+
+///|
+fn seed_has_uid(uids : Array[Int], uid : Int) -> Bool {
+  for item in uids {
+    if item == uid {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn seed_measure() -> @layout_types.MeasureFunc {
+  {
+    func: fn(_w : Double, _h : Double) -> @layout_types.IntrinsicSize {
+      { min_width: 10.0, max_width: 10.0, min_height: 10.0, max_height: 10.0 }
+    },
+  }
+}
+
+///|
+test "changed_seed_uids tracks layout-relevant changes only" {
+  let base_child = seed_node(2, seed_box_style(100.0, 50.0), [])
+  let prev = seed_tree(base_child)
+
+  let layout_child = seed_node(2, seed_box_style(120.0, 50.0), [])
+  let layout_seeds = changed_seed_uids(
+    seed_node(1, seed_box_style(200.0, 200.0), [layout_child]),
+    prev,
+  )
+  inspect(seed_has_uid(layout_seeds, 2), content="true")
+
+  let paint_child = seed_node(2, {
+    ..seed_box_style(100.0, 50.0),
+    opacity: 0.5,
+  }, [])
+  let paint_seeds = changed_seed_uids(
+    seed_node(1, seed_box_style(200.0, 200.0), [paint_child]),
+    prev,
+  )
+  inspect(seed_has_uid(paint_seeds, 2), content="false")
+}
+
+///|
+test "changed_seed_uids tracks text src and measure presence changes" {
+  let base_child = @node.Node::with_uid_and_measure(
+    "n2",
+    2,
+    seed_box_style(100.0, 50.0),
+    [],
+    Some(seed_measure()),
+    Some("a"),
+    src=Some("a.png"),
+  )
+  let prev = seed_tree(base_child)
+
+  let same_child = @node.Node::with_uid_and_measure(
+    "n2",
+    2,
+    seed_box_style(100.0, 50.0),
+    [],
+    Some(seed_measure()),
+    Some("a"),
+    src=Some("a.png"),
+  )
+  let same_seeds = changed_seed_uids(
+    seed_node(1, seed_box_style(200.0, 200.0), [same_child]),
+    prev,
+  )
+  inspect(seed_has_uid(same_seeds, 2), content="false")
+
+  let text_child = @node.Node::with_uid_and_measure(
+    "n2",
+    2,
+    seed_box_style(100.0, 50.0),
+    [],
+    Some(seed_measure()),
+    Some("b"),
+    src=Some("a.png"),
+  )
+  let text_seeds = changed_seed_uids(
+    seed_node(1, seed_box_style(200.0, 200.0), [text_child]),
+    prev,
+  )
+  inspect(seed_has_uid(text_seeds, 2), content="true")
+
+  let src_child = @node.Node::with_uid_and_measure(
+    "n2",
+    2,
+    seed_box_style(100.0, 50.0),
+    [],
+    Some(seed_measure()),
+    Some("a"),
+    src=Some("b.png"),
+  )
+  let src_seeds = changed_seed_uids(
+    seed_node(1, seed_box_style(200.0, 200.0), [src_child]),
+    prev,
+  )
+  inspect(seed_has_uid(src_seeds, 2), content="true")
+
+  let measure_child = @node.Node::with_uid_and_measure(
+    "n2",
+    2,
+    seed_box_style(100.0, 50.0),
+    [],
+    None,
+    Some("a"),
+    src=Some("a.png"),
+  )
+  let measure_seeds = changed_seed_uids(
+    seed_node(1, seed_box_style(200.0, 200.0), [measure_child]),
+    prev,
+  )
+  inspect(seed_has_uid(measure_seeds, 2), content="true")
 }

--- a/browser/shell/link_extraction.mbt
+++ b/browser/shell/link_extraction.mbt
@@ -73,7 +73,7 @@ fn extract_links_fallback(html : String) -> Array[Link] {
         let text = html
           .unsafe_substring(start=text_start, end=text_end)
           .trim()
-          .to_string()
+          .to_owned()
         if href.length() > 0 {
           links.push({ href, text, source_id })
         }

--- a/browser/shell/moon.pkg
+++ b/browser/shell/moon.pkg
@@ -9,6 +9,7 @@ import {
   "mizchi/crater-browser-helpers" @browser_helpers,
   "mizchi/crater-dom/aom",
   "mizchi/crater-layout" @layout,
+  "mizchi/css/style" @style,
   "mizchi/css/values" @types,
   "mizchi/crater-core" @layout_types,
   "mizchi/crater-dom/dom",

--- a/browser/tui/moon.pkg
+++ b/browser/tui/moon.pkg
@@ -21,7 +21,7 @@ import {
 warnings = "-unused_package"
 
 options(
-  link: { "native": { "cc-link-flags": "tui/tui_native.c" } },
+  link: { "native": { "cc-link-flags": "browser/tui/tui_native.c" } },
   targets: {
     "codeblock_test.mbt": [ "wasm-gc", "native" ],
     "render_test.mbt": [ "wasm-gc", "js" ],

--- a/browser/tui/tui_native_input.mbt
+++ b/browser/tui/tui_native_input.mbt
@@ -188,9 +188,9 @@ fn parse_mouse_event(key : String) -> String? {
   let payload = key.unsafe_substring(start=3, end=key.length() - 1)
   let parts = payload.split(";").collect()
   guard parts.length() == 3 else { return None }
-  let btn = @string.parse_int(parts[0].to_string()) catch { _ => return None }
-  let col = @string.parse_int(parts[1].to_string()) catch { _ => return None }
-  let row = @string.parse_int(parts[2].to_string()) catch { _ => return None }
+  let btn = @string.parse_int(parts[0].to_owned()) catch { _ => return None }
+  let col = @string.parse_int(parts[1].to_owned()) catch { _ => return None }
+  let row = @string.parse_int(parts[2].to_owned()) catch { _ => return None }
   if btn == 0 && suffix == 'M' {
     return Some("MouseDown:\{col},\{row}")
   }

--- a/browser_helpers/moon.mod
+++ b/browser_helpers/moon.mod
@@ -1,12 +1,12 @@
 name = "mizchi/crater-browser-helpers"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-renderer@0.18.0",
+  "mizchi/crater-renderer@0.18.1",
   "mizchi/css@0.7.3",
-  "mizchi/crater-dom@0.18.0",
-  "mizchi/crater-aomx@0.18.0",
+  "mizchi/crater-dom@0.18.1",
+  "mizchi/crater-aomx@0.18.1",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/browser_helpers/moon.mod
+++ b/browser_helpers/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-renderer@0.18.0",
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-aomx@0.18.0",
 }

--- a/conformance/moon.mod.json
+++ b/conformance/moon.mod.json
@@ -1,31 +1,31 @@
 {
   "name": "mizchi/crater-conformance",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "deps": {
     "mizchi/crater-core": {
       "path": "../core",
-      "version": "0.18.0"
+      "version": "0.18.1"
     },
     "mizchi/css": "0.7.0",
     "mizchi/crater-dom": {
       "path": "../dom",
-      "version": "0.18.0"
+      "version": "0.18.1"
     },
     "mizchi/crater-painter": {
       "path": "../painter",
-      "version": "0.18.0"
+      "version": "0.18.1"
     },
     "mizchi/crater-webvitals": {
       "path": "../webvitals",
-      "version": "0.18.0"
+      "version": "0.18.1"
     },
     "mizchi/crater-layout": {
       "path": "../layout",
-      "version": "0.18.0"
+      "version": "0.18.1"
     },
     "mizchi/crater-renderer": {
       "path": "../renderer",
-      "version": "0.18.0"
+      "version": "0.18.1"
     }
   },
   "repository": "https://github.com/mizchi/crater",

--- a/core/moon.mod
+++ b/core/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-core"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/core/moon.mod
+++ b/core/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/crater-core"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
   "mizchi/css@0.7.3",

--- a/core/node/node.mbt
+++ b/core/node/node.mbt
@@ -181,6 +181,53 @@ pub fn get_layout_dispatcher() -> LayoutDispatchFunc? {
 }
 
 ///|
+/// Global "is this node's whole subtree unchanged since the last layout?"
+/// predicate, keyed by `uid`. Installed by the incremental layout driver
+/// (`compute_tree_incremental`) over the `LayoutTree`'s dirty state, and read by
+/// the block-flow memoization in `layout/block` to decide whether a clean child
+/// subtree can be served from its cached `compute_with_collapse` result.
+///
+/// Dependency-inverted on purpose: `layout/block` cannot depend on `layout/tree`
+/// (the dispatcher cycle), so the cleanliness signal flows through this core hook
+/// the same way the layout dispatcher does. Absent an installed predicate (the
+/// non-incremental / full-layout path) it returns `false`, so memoization is off
+/// by default and the static path is byte-for-byte unchanged.
+let node_clean_predicate : Ref[((Int) -> Bool)?] = { val: None }
+
+///|
+/// Install the subtree-clean predicate for the duration of an incremental layout.
+/// Pass `None` (via `clear_node_clean_predicate`) to remove it afterwards.
+pub fn set_node_clean_predicate(f : (Int) -> Bool) -> Unit {
+  node_clean_predicate.val = Some(f)
+}
+
+///|
+/// Remove the subtree-clean predicate (back to the conservative default where
+/// every node reports not-clean, disabling block-flow memoization).
+pub fn clear_node_clean_predicate() -> Unit {
+  node_clean_predicate.val = None
+}
+
+///|
+/// Whether the node with this `uid` has an entirely unchanged subtree since the
+/// last layout, per the installed predicate. `false` when no predicate is
+/// installed (the safe default: recompute).
+pub fn node_is_clean(uid : Int) -> Bool {
+  match node_clean_predicate.val {
+    Some(pred) => pred(uid)
+    None => false
+  }
+}
+
+///|
+/// Whether an incremental layout is in progress (the clean predicate is
+/// installed). Block-flow memoization populates its cache only while this is
+/// true, so the static / full-layout path neither reads nor writes it.
+pub fn node_incremental_active() -> Bool {
+  node_clean_predicate.val is Some(_)
+}
+
+///|
 /// Create a minimal fallback layout for a node (used when dispatch is unavailable)
 pub fn fallback_layout(
   node : Node,

--- a/core/node/pkg.generated.mbti
+++ b/core/node/pkg.generated.mbti
@@ -7,11 +7,19 @@ import {
 }
 
 // Values
+pub fn clear_node_clean_predicate() -> Unit
+
 pub fn fallback_layout(Node, @crater-core.LayoutContext) -> @crater-core.Layout
 
 pub fn get_layout_dispatcher() -> LayoutDispatchFunc?
 
+pub fn node_incremental_active() -> Bool
+
+pub fn node_is_clean(Int) -> Bool
+
 pub fn set_layout_dispatcher(LayoutDispatchFunc) -> Unit
+
+pub fn set_node_clean_predicate((Int) -> Bool) -> Unit
 
 pub fn stabilize_uids(Node, UidRegistry) -> Unit
 

--- a/docs/incremental-reflow-design.md
+++ b/docs/incremental-reflow-design.md
@@ -104,16 +104,38 @@ structural append, and an unchanged re-render (the last reuses the cache —
   this to `reconcile_from` makes the incremental layout equal a full recompute
   while keeping the dirty set tight.
 - **but** the practical speedup is currently bounded by the layout engine's
-  per-node cache, not by the dirty set: a *migrated* child cache frequently
-  misses on `can_use_cache`'s constraint comparison, and `children_dirty`
-  propagates to the root on any change, so the reliable reuse today is the
-  **root / high-subtree short-circuit** (a clean subtree returns its cached
-  layout without descending) — i.e. no-op and paint-only re-renders. Making a
-  change to a *late* element reuse the *earlier* elements needs the per-node
-  child cache to hit across trees (relative-position caching / a style
-  fingerprint on the cache key). That is the next layout-engine lever; the
-  reflow plumbing (stable uids → reconcile → flow-aware dirty) is correct and
-  ready to exploit it.
+  per-node cache, not by the dirty set: `children_dirty` propagates to the root
+  on any change, so the reliable reuse today is the **root / high-subtree
+  short-circuit** (a clean subtree returns its cached layout without descending)
+  — i.e. no-op, paint-only, and disjoint-subtree re-renders.
+
+  **Measured root cause (item 3).** The per-uid cache (`try_cache_by_uid`,
+  `incremental_compute.mbt`) is only consulted for children dispatched through
+  the cache-aware callback — i.e. **flex / grid / table / inline-block BFC
+  roots** (`block.mbt:5609`, `dispatch_fn(child_for_layout, …)`). Ordinary
+  **in-flow block children** are laid out by `compute_with_collapse` directly
+  (`block.mbt:5623`), which never reads the cache. So a `display:block` stack
+  recomputes in full no matter how little changed — a late-element change reuses
+  nothing earlier. Pinned by `layout/tree/incremental_perf_wbtest.mbt`: a
+  12-block stack reports `hits=0` after a one-node change, while an unchanged,
+  unmoved BFC subtree is reused whole (`hits>0`, the short-circuit above).
+
+  **Why a local fix doesn't work.** Routing in-flow block children through
+  `dispatch_fn` changes their layout path from `compute_with_collapse`
+  (margin-collapse aware, returns the child's *escaping* top/bottom margins to
+  the parent for sibling positioning and the parent's own collapsed margins) to
+  `@dispatch.compute` → `@block.compute` (a fresh BFC root, **no** collapse with
+  parent/siblings). The per-uid cache stores only `@layout_types.Layout`, which
+  carries no margin-collapse data, so a cached hit silently drops escaping
+  margins. The correct fix is therefore a **cross-package change**: widen the
+  cache to carry the escaping collapse margins (they reduce to a pair of
+  numbers) so a clean in-flow block child can be served from cache *with* its
+  collapse contribution, then gate the block-flow loop on it. That touches
+  `compute_with_collapse` (IFC, floats, `display:contents`, collapse-through)
+  and must be validated against the full layout + paint/WPT suites — it is the
+  next layout-engine lever, scoped on its own; the reflow plumbing (stable uids
+  → reconcile → flow-aware dirty) is correct and ready to exploit it once the
+  block-flow cache lands.
 
 The remaining (B) work is the shell integration that produces `dirty_uids` and a
 new render node tree with stable uids (phase A's `dom_id`), then calls

--- a/docs/incremental-reflow-design.md
+++ b/docs/incremental-reflow-design.md
@@ -169,6 +169,39 @@ records (`@dom.MutationRecord::affects_layout`, `dom/dom/mutation.mbt:148`). A
 paint-only attribute edit (e.g. `color`) can skip `mark_dirty` for layout and
 only invalidate paint; a layout attribute (`width`, `display`, …) marks dirty.
 
+> **Note — the mutation queue is *not* a safe substitute for the style diff.**
+> A mutation on node X can change node Y's *computed* style via a combinator
+> (`:has()`, `+`, `~`, `:nth-child`). Dirtying only the mutated DomTree nodes
+> would leave Y reading stale cache. The only fully-correct seed is comparing the
+> freshly-cascaded computed `@style.Style` (step 3), which reflects every
+> combinator. The mutation queue is a *paint-vs-layout* refinement on top of a
+> correct seed, not a replacement for it.
+
+#### Blocker / plan for step 3: `@style.Style` needs `Eq`
+
+The shell currently passes **every** uid as `dirty_uids`
+(`Browser::build_dynamic_layout_tree`) — correct (== full recompute) but it
+defeats the block-flow memoization, which only reuses nodes the driver reports
+clean. Narrowing the seed needs `old_style != new_style` per uid, and
+`@style.Style` (mizchi/css) is a 99-field struct with **no `derive`** — no `Eq`,
+`Show`, or `Hash` — so there is no safe, complete, maintainable comparison in
+crater. A hand-rolled 99-field comparator under-reports the moment a field is
+missed (or upstream adds one) → silent stale-layout, on the opt-in path.
+
+- **Upstream (mizchi/css), one line:** add `derive(Eq, @debug.Debug)` to the
+  `Style` struct. Every field type already derives `Eq` (`@values.Dimension`,
+  `Rect`, `Display`, …), so this is mechanical and auto-covers future fields.
+- **crater follow-up (small, then testable):** in
+  `Browser::build_dynamic_layout_tree`, replace `collect_node_uids(node)` (all
+  uids) with
+  `prev.flow_dirty_uids(seeds)` where
+  `seeds = { uid : old_style != new_style || text/src/measure-presence differ }`
+  computed by walking the new node tree against `prev.node_map`. `flow_dirty_uids`
+  expands for crater's absolute-geometry flow shift; `reconcile_from`'s structural
+  pass already covers add/remove/move. Validate with an on-vs-off render
+  equivalence test per mutation kind (text, size, display, append, remove, move).
+  Until the upstream `Eq` lands, the safe all-uids behavior stays.
+
 ### (C) Validation without V8 (js target)
 
 Correctness is a pure layout property and is testable on the **js** target, no
@@ -192,10 +225,13 @@ attr, layout attr, append, remove, move) and a fuzz-ish sequence.
    used by the text render path). Off by default → byte-for-byte the current
    behavior; js-tested that on vs off render identically. **The dirty set is
    currently every uid** (correct, == full recompute) — the remaining work is to
-   narrow it so the flag is also *faster*: a paint-only fast path via the DomTree
-   mutation queue (`MutationRecord::affects_layout`), and/or a layout-relevant
-   style diff (`@style.Style` has no `Eq`, so this needs a focused comparator or
-   the mutation classification). Validate the dynamic round-trip with native V8.
+   narrow it so the flag is also *faster*. The **layout engine now memoizes
+   in-flow block subtrees per uid** (block-flow memoization — landed, see the
+   "Fix (landed)" section above), so once the seed is narrowed the unchanged
+   block subtrees are reused. Narrowing is **blocked on `@style.Style` gaining
+   `Eq` upstream** (see "Blocker / plan for step 3" above): the seed needs
+   `old_style != new_style` per uid and `Style` has no `derive`. Validate the
+   dynamic round-trip with native V8.
 3. **paint-only fast path** — use `affects_layout` to keep layout and re-paint
    only (the dynamic-path analogue of `branch_reusing_layout`).
 4. **forced reflow read path** (separate memo) — on a measuring read after a

--- a/docs/incremental-reflow-design.md
+++ b/docs/incremental-reflow-design.md
@@ -110,32 +110,43 @@ structural append, and an unchanged re-render (the last reuses the cache —
   — i.e. no-op, paint-only, and disjoint-subtree re-renders.
 
   **Measured root cause (item 3).** The per-uid cache (`try_cache_by_uid`,
-  `incremental_compute.mbt`) is only consulted for children dispatched through
+  `incremental_compute.mbt`) was only consulted for children dispatched through
   the cache-aware callback — i.e. **flex / grid / table / inline-block BFC
-  roots** (`block.mbt:5609`, `dispatch_fn(child_for_layout, …)`). Ordinary
-  **in-flow block children** are laid out by `compute_with_collapse` directly
-  (`block.mbt:5623`), which never reads the cache. So a `display:block` stack
-  recomputes in full no matter how little changed — a late-element change reuses
-  nothing earlier. Pinned by `layout/tree/incremental_perf_wbtest.mbt`: a
-  12-block stack reports `hits=0` after a one-node change, while an unchanged,
-  unmoved BFC subtree is reused whole (`hits>0`, the short-circuit above).
+  roots** (`block.mbt`, `dispatch_fn(child_for_layout, …)`). Ordinary **in-flow
+  block children** were laid out by `compute_with_collapse` directly, which never
+  read the cache. So a `display:block` stack recomputed in full no matter how
+  little changed — a late-element change reused nothing earlier. Pinned by
+  `layout/tree/incremental_perf_wbtest.mbt`.
 
-  **Why a local fix doesn't work.** Routing in-flow block children through
-  `dispatch_fn` changes their layout path from `compute_with_collapse`
-  (margin-collapse aware, returns the child's *escaping* top/bottom margins to
-  the parent for sibling positioning and the parent's own collapsed margins) to
-  `@dispatch.compute` → `@block.compute` (a fresh BFC root, **no** collapse with
-  parent/siblings). The per-uid cache stores only `@layout_types.Layout`, which
-  carries no margin-collapse data, so a cached hit silently drops escaping
-  margins. The correct fix is therefore a **cross-package change**: widen the
-  cache to carry the escaping collapse margins (they reduce to a pair of
-  numbers) so a clean in-flow block child can be served from cache *with* its
-  collapse contribution, then gate the block-flow loop on it. That touches
-  `compute_with_collapse` (IFC, floats, `display:contents`, collapse-through)
-  and must be validated against the full layout + paint/WPT suites — it is the
-  next layout-engine lever, scoped on its own; the reflow plumbing (stable uids
-  → reconcile → flow-aware dirty) is correct and ready to exploit it once the
-  block-flow cache lands.
+  **Fix (landed): block-flow memoization.** `compute_with_collapse(child, ctx)`
+  is a *pure* function of the child subtree and the constraint, so it is
+  memoized per `uid` (`block_flow_cache` in `block.mbt`): an in-flow block child
+  whose whole subtree is unchanged is served from its cached
+  `LayoutWithCollapse` — layout **and** escaping collapse margins together — so
+  the parent's stacking / shift passes treat it identically to a fresh compute.
+  No coordinate or collapse-through reasoning is needed: a clean child under the
+  same constraint returns exactly what a recompute would. Two correctness gates,
+  both required before reuse:
+
+  - the child's subtree is unchanged — `@node.node_is_clean(uid)`, a core hook
+    installed by `compute_tree_incremental` over the `LayoutTree`'s dirty state
+    (`!dirty && !children_dirty`, dependency-inverted like the layout dispatcher
+    so `layout/block` need not depend on `layout/tree`); and
+  - the constraint matches — the cache key encodes available width/height,
+    sizing mode, and viewport.
+
+  The cache is populated only while an incremental layout is active
+  (`@node.node_incremental_active()`), so the static / full-layout path neither
+  reads nor writes it and is byte-for-byte unchanged. Validated on the js target:
+  a 12-block stack with the last block changed now reuses all 11 preceding
+  blocks (`block_flow_cache_hit_count() == 11`) and the incremental layout is
+  byte-identical to a full recompute; a width change misses the key (no stale
+  reuse); nested block subtrees reuse the unchanged sibling branch. The whole
+  layout (326) and renderer/vrt (410) suites stay green.
+
+  The remaining ceiling is the **cascade** (still O(n) per mutation) and the
+  flex/grid cross-axis perturbation (a change to one flex item can legitimately
+  dirty its line); those are separate levers.
 
 The remaining (B) work is the shell integration that produces `dirty_uids` and a
 new render node tree with stable uids (phase A's `dom_id`), then calls

--- a/docs/v8-build-egress.md
+++ b/docs/v8-build-egress.md
@@ -33,7 +33,25 @@ wall.
 
 Mitigation that exists today: `scripts/moon-test-no-v8.sh` drops `./browser/native`
 and `./testing` from `moon.work` and sets `MIZCHI_V8_OPTIONAL=1`, so the non-v8
-packages resolve and test.
+packages resolve and test. The member-trimming is factored into
+`scripts/ci/drop-v8-members.sh` (idempotent, in-place) so the same trim is reused
+by CI jobs that don't link V8 — `moon-test-no-v8.sh` wraps it with backup/restore,
+while an ephemeral CI runner can call it directly with no restore.
+
+### Which CI jobs need the trim
+
+A job that runs `moon` over the workspace (e.g. via `./.github/actions/moon-prefetch`,
+which runs `moon tree` + `moon fetch`) resolves the full graph and triggers the v8
+postadd. A job that **links V8** (the native `test`, `wpt-webdriver-tests`,
+`playwright-*`) pairs `moon-prefetch` with `./.github/actions/rusty-v8-prefetch` and
+*should* build it. A job that is **JS/wasm-only** pays the `git clone` for nothing
+and inherits its flake risk. `vrt-bench` (a pure `--target js`
+`mizchi/crater-benchmarks` build — verified to build with the members trimmed and
+**zero** network) now runs `scripts/ci/drop-v8-members.sh` before its prefetch.
+The same step can be added to other JS/wasm-only `moon-prefetch` jobs
+(`js-package`, `wasm-component`, `wpt-css-tests`, `wpt-dom-tests`) once it's
+confirmed they don't intend to compile-check the trimmed members on their target;
+apply it per-job deliberately rather than globally.
 
 ## The HTTPS build path (verified to work in-sandbox)
 
@@ -71,6 +89,39 @@ the proxy, even though the same URL is byte-perfect via `curl`. **Always fetch t
 archive with `curl` and hand it to `build.rs` via `RUSTY_V8_ARCHIVE`.** No `gn`,
 `depot_tools`, or V8-from-source checkout is needed for the prebuilt path.
 
+## Native validation (run these in a real environment)
+
+The MoonBit **js** target never executes real JS, so the V8 round-trip — page JS
+reading crater's real layout through the bridge (`getBoundingClientRect`,
+`offset*`, `getComputedStyle`) and the `run_event_loop` driving timers / rAF — is
+covered only by **native-target** tests. Once the bridge is built (the HTTPS path
+above, or a normal `git`-capable host where the postadd just works), validate with:
+
+```bash
+# Layout/computed-style bridge unit coverage (mock DOM reads injected globals)
+moon -C browser/native test -p mizchi/crater-browser-native/js_v8 \
+  -f js_runtime_v8_bridge_wbtest.mbt --target native -j 1
+# or the whole V8 runtime suite:
+just test-native-v8
+
+# Full browser <-> V8 e2e (new_v8_browser/connect_v8, real getBoundingClientRect,
+# run_event_loop settle, DOM mutation round-trips):
+just test-native-full     # moon -C testing test -p .../e2e/native_v8 --target native
+```
+
+`js_runtime_v8_bridge_wbtest.mbt` asserts the four bridge cases (boxes read,
+computed styles read, fallback-to-zero when nothing injected, id-less fallback);
+`testing/e2e/native_v8/browser_v8_e2e_test.mbt` drives the whole shell.
+
+### Caveat: V8 SIGSEGVs at isolate init in the web sandbox
+
+In the Claude-Code-on-the-web container the bridge **builds** (HTTPS path) but the
+resulting binary **segfaults at `v8::Isolate` creation** — a bare `eval("1+1")`
+crashes too, so it is environment (container vaddr / sandbox), not crater code.
+The native tests above therefore can't run here; run them on a normal host. If you
+see the segfault, it is not a regression in the bridge — confirm with a minimal
+isolate-only program before suspecting crater.
+
 ## Recurrence prevention
 
 1. **Probe before claiming "blocked."** Egress is per-channel. Before writing or
@@ -85,10 +136,15 @@ archive with `curl` and hand it to `build.rs` via `RUSTY_V8_ARCHIVE`.** No `gn`,
    `build-rusty-v8.sh`.
 3. **Always pass `RUSTY_V8_ARCHIVE` (curl-fetched) in CI/sandboxes.** Never rely on
    the crate's built-in downloader behind a proxy.
-4. **Decouple the v8 postadd from non-native resolution** (#312 option C): make the
-   prebuild a no-op unless the target is native, or keep `./browser/native` /
-   `./testing` out of the default `moon.work` for `--target js` runs. Until then,
-   route v8-free testing through `scripts/moon-test-no-v8.sh`.
+4. **Decouple the v8 postadd from non-native resolution** (#312 option C). The
+   postadd is upstream in `mizchi/v8` and the `MIZCHI_V8_OPTIONAL` /
+   `CRATER_SKIP_V8_BUILD` degrade only covers crater's *prebuild* script, not the
+   vendored postadd, so it cannot stop the `git clone` from a `moon` run that
+   resolves the v8 members. The crater-side lever is therefore to keep
+   `./browser/native` / `./testing` out of `moon.work` for non-native work:
+   `scripts/ci/drop-v8-members.sh` for both local (`moon-test-no-v8.sh`) and CI
+   (the `vrt-bench` job). The durable upstream fix is to make the postadd honor
+   the skip env and prefer the HTTPS source fetch over `git clone`.
 5. **Keep `deps/rusty_v8.rev` and the binding/lib suffix in lockstep.** The
    prebuilt lib, the `src_binding_release_*.rs`, and the source tarball must all be
    the same tag, matched to the host triple.

--- a/dom/moon.mod
+++ b/dom/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-layout@0.18.0",
 }
 

--- a/dom/moon.mod
+++ b/dom/moon.mod
@@ -1,11 +1,11 @@
 name = "mizchi/crater-dom"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-core@0.18.0",
+  "mizchi/crater-core@0.18.1",
   "mizchi/css@0.7.3",
-  "mizchi/crater-layout@0.18.0",
+  "mizchi/crater-layout@0.18.1",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/html_assets/moon.mod
+++ b/html_assets/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/crater-html-assets"
 
-version = "0.18.0"
+version = "0.18.1"
 
 repository = "https://github.com/mizchi/crater"
 

--- a/http/http_native.mbt
+++ b/http/http_native.mbt
@@ -50,7 +50,7 @@ pub async fn fetch(
   let host_url = extract_host_url(url)
   let path = extract_path_from_url(url)
   // Create HTTP client with just the host
-  let client = @async_http.Client::new(host_url, headers=prepared.headers) catch {
+  let client = @async_http.Client(host_url, headers=prepared.headers) catch {
     _ => raise InvalidUrl(url)
   }
   // Perform request based on method

--- a/http/moon.mod
+++ b/http/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/crater-browser-http"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
   "moonbitlang/async@0.19.0",

--- a/js/moon.mod
+++ b/js/moon.mod
@@ -1,15 +1,15 @@
 name = "mizchi/crater-js"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-core@0.18.0",
-  "mizchi/crater-aomx@0.18.0",
+  "mizchi/crater-core@0.18.1",
+  "mizchi/crater-aomx@0.18.1",
   "mizchi/css@0.7.3",
-  "mizchi/crater-dom@0.18.0",
-  "mizchi/crater-layout@0.18.0",
-  "mizchi/crater-painter@0.18.0",
-  "mizchi/crater-renderer@0.18.0",
+  "mizchi/crater-dom@0.18.1",
+  "mizchi/crater-layout@0.18.1",
+  "mizchi/crater-painter@0.18.1",
+  "mizchi/crater-renderer@0.18.1",
   "mizchi/gfx@0.1.0",
 }
 

--- a/js/moon.mod
+++ b/js/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 import {
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-aomx@0.18.0",
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/js/moon.pkg
+++ b/js/moon.pkg
@@ -20,6 +20,8 @@ import {
   "mizchi/crater-dom/layout/html_tree" @layout_html_tree,
 }
 
+warnings = "-unused_package"
+
 options(
   link: {
     "js": {

--- a/layout/absolute/mathfn_test.mbt
+++ b/layout/absolute/mathfn_test.mbt
@@ -64,7 +64,7 @@ test "mathfn_term_with_both_units" {
 ///|
 test "mathfn_inset_returns_resolved_length" {
   // resolve_inset wraps the same resolution in Some(..).
-  inspect(
+  debug_inspect(
     resolve_inset(
       @types.MathFn(@types.MathOp::Min, [(20.0, 0.5), (200.0, 0.0)]),
       400.0,

--- a/layout/block/block.mbt
+++ b/layout/block/block.mbt
@@ -1186,6 +1186,110 @@ pub fn clear_block_intrinsic_caches() -> Unit {
 }
 
 ///|
+/// Block-flow memoization: per-`uid` cache of an in-flow block child's
+/// `compute_with_collapse` result (layout + escaping collapse margins), so an
+/// incremental relayout can skip recomputing a child whose whole subtree is
+/// unchanged. `compute_with_collapse(child, ctx)` is a pure function of the
+/// child subtree and the constraint, so reusing it for a clean child under the
+/// same constraint is exact — the parent's stacking / shift passes treat a
+/// cached result identically to a freshly computed one.
+///
+/// Correctness gates (both required before reuse): the child is reported clean
+/// by the incremental driver (`@node.node_is_clean(uid)` — its subtree did not
+/// change) AND the cached constraint key matches the current child constraint.
+/// The cache is populated only while an incremental layout is active
+/// (`@node.node_incremental_active()`), so the static / full-layout path never
+/// reads or writes it and is byte-for-byte unchanged. `uid`s are stabilized
+/// across rebuilds by the reconcile registry, so an entry keeps tracking the
+/// same element.
+priv struct BlockFlowCacheEntry {
+  key : String
+  result : LayoutWithCollapse
+}
+
+///|
+let block_flow_cache : Ref[Map[Int, BlockFlowCacheEntry]] = { val: Map::new() }
+
+///|
+let block_flow_cache_hits : Ref[Int] = { val: 0 }
+
+///|
+/// Number of in-flow block children served from the block-flow cache since the
+/// last `reset_block_flow_cache_hits`. For tests / perf characterization.
+pub fn block_flow_cache_hit_count() -> Int {
+  block_flow_cache_hits.val
+}
+
+///|
+/// Reset the block-flow cache hit counter (tests / perf characterization).
+pub fn reset_block_flow_cache_hits() -> Unit {
+  block_flow_cache_hits.val = 0
+}
+
+///|
+/// Drop the whole block-flow memoization cache (memory hygiene / test isolation).
+pub fn clear_block_flow_cache() -> Unit {
+  block_flow_cache.val = Map::new()
+  block_flow_cache_hits.val = 0
+}
+
+///|
+/// Build the constraint key for the block-flow cache from a child layout
+/// context. Includes every field that can change the child's computed layout.
+fn block_flow_cache_key(ctx : @layout_types.LayoutContext) -> String {
+  let ah = match ctx.available_height {
+    Some(h) => h.to_string()
+    None => "_"
+  }
+  let sizing = match ctx.sizing_mode {
+    @layout_types.Definite => "d"
+    @layout_types.MaxContent => "max"
+  }
+  ctx.available_width.to_string() +
+  "|" +
+  ah +
+  "|" +
+  sizing +
+  "|" +
+  ctx.viewport_width.to_string() +
+  "|" +
+  ctx.viewport_height.to_string() +
+  "|" +
+  (if ctx.stretch_width { "1" } else { "0" }) +
+  (if ctx.stretch_height { "1" } else { "0" })
+}
+
+///|
+/// Compute an in-flow block child's layout, reusing the cached
+/// `compute_with_collapse` result when the child's subtree is unchanged
+/// (see `block_flow_cache`). On a miss it computes and (while incremental is
+/// active) stores the result.
+fn compute_block_child_memoized(
+  child : @node.Node,
+  ctx : @layout_types.LayoutContext,
+  warnings : Array[@layout_types.LayoutWarning],
+  dispatch : @node.DispatchFn,
+) -> LayoutWithCollapse {
+  let key = block_flow_cache_key(ctx)
+  if @node.node_is_clean(child.uid) {
+    match block_flow_cache.val.get(child.uid) {
+      Some(entry) =>
+        if entry.key == key {
+          block_flow_cache_hits.val = block_flow_cache_hits.val + 1
+          return entry.result
+        }
+      None => ()
+    }
+  }
+  let raw = compute_with_collapse(child, ctx, warnings, dispatch)
+  let result = { ..raw, layout: apply_initial_scroll_snap(child, raw.layout) }
+  if @node.node_incremental_active() {
+    block_flow_cache.val.set(child.uid, { key, result })
+  }
+  result
+}
+
+///|
 fn calculate_children_max_content_width(
   node : @node.Node,
   parent_width : Double,
@@ -5620,13 +5724,11 @@ fn compute_with_collapse(
           stretch_width: false,
           stretch_height: false,
         }
-        let raw = compute_with_collapse(
+        // Memoized: a clean (unchanged-subtree) child under the same constraint
+        // reuses its cached compute_with_collapse result instead of recomputing.
+        compute_block_child_memoized(
           child_for_layout, child_ctx, warnings, dispatch,
         )
-        {
-          ..raw,
-          layout: apply_initial_scroll_snap(child_for_layout, raw.layout),
-        }
       }
     }
     flow_children.push(child_result)

--- a/layout/block/block.mbt
+++ b/layout/block/block.mbt
@@ -1172,17 +1172,17 @@ fn layout_simple_block_stack(
 // correctness. This collapses the otherwise exponential mutual recursion
 // between min/max-content over deep trees (the dominant layout cost on
 // text-heavy pages — see #316).
-let min_intrinsic_width_cache : Ref[Map[String, Double]] = { val: Map::new() }
+let min_intrinsic_width_cache : Ref[Map[String, Double]] = { val: Map([]) }
 
 ///|
-let max_intrinsic_width_cache : Ref[Map[String, Double]] = { val: Map::new() }
+let max_intrinsic_width_cache : Ref[Map[String, Double]] = { val: Map([]) }
 
 ///|
 /// Reset the intrinsic-width memoization caches. Called once at the start of a
 /// top-level layout so they don't accumulate across renders.
 pub fn clear_block_intrinsic_caches() -> Unit {
-  min_intrinsic_width_cache.val = Map::new()
-  max_intrinsic_width_cache.val = Map::new()
+  min_intrinsic_width_cache.val = Map([])
+  max_intrinsic_width_cache.val = Map([])
 }
 
 ///|
@@ -1208,7 +1208,7 @@ priv struct BlockFlowCacheEntry {
 }
 
 ///|
-let block_flow_cache : Ref[Map[Int, BlockFlowCacheEntry]] = { val: Map::new() }
+let block_flow_cache : Ref[Map[Int, BlockFlowCacheEntry]] = { val: Map([]) }
 
 ///|
 let block_flow_cache_hits : Ref[Int] = { val: 0 }
@@ -1229,7 +1229,7 @@ pub fn reset_block_flow_cache_hits() -> Unit {
 ///|
 /// Drop the whole block-flow memoization cache (memory hygiene / test isolation).
 pub fn clear_block_flow_cache() -> Unit {
-  block_flow_cache.val = Map::new()
+  block_flow_cache.val = Map([])
   block_flow_cache_hits.val = 0
 }
 

--- a/layout/block/pkg.generated.mbti
+++ b/layout/block/pkg.generated.mbti
@@ -7,9 +7,17 @@ import {
 }
 
 // Values
+pub fn block_flow_cache_hit_count() -> Int
+
+pub fn clear_block_flow_cache() -> Unit
+
+pub fn clear_block_intrinsic_caches() -> Unit
+
 pub fn compute(@node.Node, @crater-core.LayoutContext, @node.DispatchFn) -> @crater-core.Layout
 
 pub fn compute_with_warnings(@node.Node, @crater-core.LayoutContext, @node.DispatchFn) -> @crater-core.LayoutResult
+
+pub fn reset_block_flow_cache_hits() -> Unit
 
 // Errors
 

--- a/layout/flex/flex.mbt
+++ b/layout/flex/flex.mbt
@@ -3081,7 +3081,6 @@ fn compute_intrinsic_flex_main_size(
     }
     let mut total_main = 0.0
     let mut total_main_margins = 0.0
-    let mut has_flex_grow = false
     let mut item_count = 0
     for i = 0; i < flattened.length(); i = i + 1 {
       let child = flattened[i].node
@@ -3106,9 +3105,6 @@ fn compute_intrinsic_flex_main_size(
         child_border.horizontal_sum()
       let child_min_height = child_padding.vertical_sum() +
         child_border.vertical_sum()
-      if child_style.flex_grow > 0.0 {
-        has_flex_grow = true
-      }
       let child_main = if child_is_row {
         let intrinsic_cross_for_aspect : Double? = match style.height {
           @types.Length(h) =>

--- a/layout/moon.mod
+++ b/layout/moon.mod
@@ -1,12 +1,12 @@
 name = "mizchi/crater-layout"
 
-version = "0.18.0"
+version = "0.18.1"
 
 description = "Layout kernel for crater CSS layout engine"
 
 import {
   "mizchi/css@0.7.3",
-  "mizchi/crater-core@0.18.0",
+  "mizchi/crater-core@0.18.1",
   "mizchi/layout@0.2.0",
 }
 

--- a/layout/moon.mod
+++ b/layout/moon.mod
@@ -5,7 +5,7 @@ version = "0.18.0"
 description = "Layout kernel for crater CSS layout engine"
 
 import {
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-core@0.18.0",
   "mizchi/layout@0.2.0",
 }

--- a/layout/tree/incremental_compute.mbt
+++ b/layout/tree/incremental_compute.mbt
@@ -434,6 +434,19 @@ pub fn compute_tree_incremental(
   // 2. Set up global stats reference
   global_cache_stats.val = Some(stats)
 
+  // 2b. Install the subtree-clean predicate so block-flow memoization
+  // (layout/block) can reuse a clean child's cached `compute_with_collapse`
+  // result. A node is reusable iff neither it nor any descendant changed —
+  // `children_dirty` propagates descendant changes up, so `!dirty &&
+  // !children_dirty` is exactly "whole subtree unchanged".
+  let node_map = tree.node_map
+  @node.set_node_clean_predicate(fn(uid) {
+    match node_map.get(uid) {
+      Some(n) => !n.dirty && !n.children_dirty
+      None => false
+    }
+  })
+
   // 3. Save original dispatcher and set up cached dispatcher
   let original_dispatcher = @node.get_layout_dispatcher()
   match original_dispatcher {
@@ -461,6 +474,7 @@ pub fn compute_tree_incremental(
     Some(d) => @node.set_layout_dispatcher(d)
     None => ()
   }
+  @node.clear_node_clean_predicate()
   global_cache_stats.val = None
   layout_node_cache_map.val = {}
   result

--- a/layout/tree/incremental_perf_wbtest.mbt
+++ b/layout/tree/incremental_perf_wbtest.mbt
@@ -15,6 +15,30 @@
 /// cache for unchanged children.
 
 ///|
+fn recon_flatten_perf(l : @layout_types.Layout, buf : StringBuilder) -> Unit {
+  buf.write_string(l.id)
+  buf.write_string(":")
+  buf.write_string(l.x.to_string())
+  buf.write_string(",")
+  buf.write_string(l.y.to_string())
+  buf.write_string(",")
+  buf.write_string(l.width.to_string())
+  buf.write_string(",")
+  buf.write_string(l.height.to_string())
+  buf.write_string(";")
+  for c in l.children {
+    recon_flatten_perf(c, buf)
+  }
+}
+
+///|
+fn recon_sig_perf(l : @layout_types.Layout) -> String {
+  let buf = StringBuilder::new()
+  recon_flatten_perf(l, buf)
+  buf.to_string()
+}
+
+///|
 fn perf_block(w : Double, h : Double) -> @style.Style {
   @style.Style::{
     ..@style.Style::default(),
@@ -44,28 +68,31 @@ fn perf_stack(
 }
 
 ///|
-test "perf(block): changing the LAST block still recomputes the whole stack (cache unused)" {
+test "perf(block): changing the LAST block reuses every preceding block via block-flow memoization" {
   @dispatch.setup()
   let n = 12
   let tree1 = LayoutTree::from_node(
     perf_stack(@types.Block, n, -1, 40.0), 200.0, 2000.0,
   )
-  let _ = tree1.compute_incremental()
+  @block.clear_block_flow_cache()
+  let _ = tree1.compute_incremental() // populate the block-flow cache
   // Change the last block. It has no following siblings, so the dirty set is
-  // just it — ideally every preceding block is reused. It is not: in-flow block
-  // children bypass the per-uid cache, so only the root is "computed" and the
-  // whole subtree recomputes inside block flow without cache reads.
+  // just it — every preceding block is unchanged and reused from the block-flow
+  // cache (compute_with_collapse is skipped for the 11 clean children).
   let dirty = tree1.flow_dirty_uids([n])
   inspect(dirty.length(), content="1")
   let tree2 = LayoutTree::reconcile_from(
     tree1, perf_stack(@types.Block, n, n - 1, 80.0), dirty, 200.0, 2000.0,
   )
-  let stats = CacheStats::new()
-  let _ = tree2.compute_with_stats(stats)
-  inspect(
-    "hits=\{stats.cache_hits} misses=\{stats.cache_misses}",
-    content="hits=0 misses=1",
-  )
+  @block.reset_block_flow_cache_hits()
+  let incr = tree2.compute_incremental()
+  // The 11 unchanged blocks (uids 1..11) are served from the block-flow cache.
+  inspect(@block.block_flow_cache_hit_count(), content="11")
+  // Correctness: incremental result is byte-identical to a full recompute.
+  let full = LayoutTree::from_node(
+    perf_stack(@types.Block, n, n - 1, 80.0), 200.0, 2000.0,
+  ).compute_incremental()
+  inspect(recon_sig_perf(incr) == recon_sig_perf(full), content="true")
 }
 
 ///|
@@ -95,9 +122,8 @@ fn perf_flex_group(
 /// is served whole from the per-uid cache (the "high-subtree short-circuit").
 /// Two flex groups A then B stacked in a block column; change deep inside B.
 /// A precedes B so its absolute position is unchanged — A's entire subtree is a
-/// single cache hit, no descent. This is the reuse the dynamic path relies on
-/// (no-op / paint-only / disjoint-subtree re-renders); the block-flow case above
-/// gets none of it.
+/// single cache hit, no descent. This is the BFC short-circuit (complementary to
+/// the block-flow memoization above, which covers in-flow block children).
 test "perf: an unchanged, unmoved BFC subtree is reused whole (high-subtree short-circuit)" {
   @dispatch.setup()
   // Root column (uid 0). Group A uids 1..5 (base 1), Group B uids 10..14.
@@ -121,4 +147,83 @@ test "perf: an unchanged, unmoved BFC subtree is reused whole (high-subtree shor
   let _ = tree2.compute_with_stats(stats)
   // A's subtree is reused without descending into it: at least one cache hit.
   inspect(stats.cache_hits > 0, content="true")
+}
+
+///|
+/// Adversarial guard: a constraint change (the viewport / available width) must
+/// NOT reuse a stale block-flow cache entry — the cache key includes the
+/// constraint, so a width change recomputes even "clean" children, and the
+/// result still equals a full recompute at the new width.
+test "perf(block): a width change invalidates the block-flow cache (no stale reuse)" {
+  @dispatch.setup()
+  let n = 6
+  // Percent-width children so the available width actually changes their box.
+  let mk = fn(vw : Double) {
+    let children : Array[@node.Node] = []
+    for i = 0; i < n; i = i + 1 {
+      let s = @style.Style::{
+        ..@style.Style::default(),
+        width: @types.Percent(0.5),
+        height: @types.Length(40.0),
+      }
+      children.push(@node.Node::with_uid("b" + i.to_string(), i + 1, s, []))
+    }
+    let root = @style.Style::{
+      ..@style.Style::default(),
+      width: @types.Length(vw),
+      height: @types.Length(1000.0),
+    }
+    @node.Node::with_uid("root", 0, root, children)
+  }
+  let tree1 = LayoutTree::from_node(mk(400.0), 400.0, 1000.0)
+  @block.clear_block_flow_cache()
+  let _ = tree1.compute_incremental()
+  // Re-render with the root widened (its own width style changed -> root in the
+  // dirty set). The children are structurally unchanged ("clean") but the
+  // constraint handed to them differs, so the block-flow cache key misses and
+  // each percent-width child is recomputed at the new available width.
+  let tree2 = LayoutTree::reconcile_from(tree1, mk(800.0), [0], 800.0, 1000.0)
+  @block.reset_block_flow_cache_hits()
+  let incr = tree2.compute_incremental()
+  inspect(@block.block_flow_cache_hit_count(), content="0")
+  let full = LayoutTree::from_node(mk(800.0), 800.0, 1000.0).compute_incremental()
+  inspect(recon_sig_perf(incr) == recon_sig_perf(full), content="true")
+}
+
+///|
+/// Nested block subtrees: a change deep in one branch reuses the sibling
+/// branch's whole subtree through the memoized in-flow path, and the result is
+/// byte-identical to a full recompute.
+test "perf(block): nested block subtrees reuse the unchanged sibling branch" {
+  @dispatch.setup()
+  // root(0) -> [groupA(1) -> [a0(2), a1(3)], groupB(4) -> [b0(5), b1(6)]]
+  let mk = fn(b1_h : Double) {
+    let col = fn(id, uid, kids) {
+      let s = @style.Style::{ ..perf_block(200.0, 0.0), height: @types.Auto }
+      @node.Node::with_uid(id, uid, s, kids)
+    }
+    @node.Node::with_uid("root", 0, perf_block(200.0, 600.0), [
+      col("groupA", 1, [
+        @node.Node::with_uid("a0", 2, perf_block(100.0, 30.0), []),
+        @node.Node::with_uid("a1", 3, perf_block(100.0, 30.0), []),
+      ]),
+      col("groupB", 4, [
+        @node.Node::with_uid("b0", 5, perf_block(100.0, 30.0), []),
+        @node.Node::with_uid("b1", 6, perf_block(100.0, b1_h), []),
+      ]),
+    ])
+  }
+  let tree1 = LayoutTree::from_node(mk(30.0), 200.0, 600.0)
+  @block.clear_block_flow_cache()
+  let _ = tree1.compute_incremental()
+  // Change b1 (uid 6). groupA (uid 1) precedes groupB and is entirely unchanged.
+  let dirty = tree1.flow_dirty_uids([6])
+  let tree2 = LayoutTree::reconcile_from(tree1, mk(50.0), dirty, 200.0, 600.0)
+  @block.reset_block_flow_cache_hits()
+  let incr = tree2.compute_incremental()
+  // groupA's whole subtree is reused at the top in-flow level (1 hit for the
+  // group; its descendants don't re-enter the block loop).
+  inspect(@block.block_flow_cache_hit_count() > 0, content="true")
+  let full = LayoutTree::from_node(mk(50.0), 200.0, 600.0).compute_incremental()
+  inspect(recon_sig_perf(incr) == recon_sig_perf(full), content="true")
 }

--- a/layout/tree/incremental_perf_wbtest.mbt
+++ b/layout/tree/incremental_perf_wbtest.mbt
@@ -1,0 +1,124 @@
+///|
+/// Characterization of incremental-reflow cache effectiveness (item 3): when a
+/// late element in a stack changes, how much preceding work is actually reused.
+/// Whitebox so they can read `CacheStats`. These pin the *current* behavior and
+/// the exact bottleneck driving the layout-engine perf lever (see
+/// docs/incremental-reflow-design.md) — they are characterization tests, not a
+/// target: when the block-flow cache lands they update to show reuse.
+///
+/// Finding: the per-uid layout cache (`try_cache_by_uid`) is only consulted for
+/// children dispatched through the cache-aware callback — i.e. flex / grid /
+/// table / inline-block BFC roots (block.mbt:5609). Ordinary in-flow block
+/// children are laid out by `compute_with_collapse` directly (block.mbt:5623),
+/// which never reads the cache, so a `display:block` stack recomputes in full
+/// regardless of how little changed. A flex stack, by contrast, reuses the
+/// cache for unchanged children.
+
+///|
+fn perf_block(w : Double, h : Double) -> @style.Style {
+  @style.Style::{
+    ..@style.Style::default(),
+    width: @types.Length(w),
+    height: @types.Length(h),
+  }
+}
+
+///|
+/// `n` fixed-size children under a root with `display`. Root uid 0; child #i
+/// uid i+1; child `changed_idx` gets height `tweak`.
+fn perf_stack(
+  display : @types.Display,
+  n : Int,
+  changed_idx : Int,
+  tweak : Double,
+) -> @node.Node {
+  let children : Array[@node.Node] = []
+  for i = 0; i < n; i = i + 1 {
+    let h = if i == changed_idx { tweak } else { 40.0 }
+    children.push(@node.Node::with_uid("b" + i.to_string(), i + 1, perf_block(
+      100.0, h,
+    ), []))
+  }
+  let root_style = @style.Style::{ ..perf_block(200.0, 2000.0), display, }
+  @node.Node::with_uid("root", 0, root_style, children)
+}
+
+///|
+test "perf(block): changing the LAST block still recomputes the whole stack (cache unused)" {
+  @dispatch.setup()
+  let n = 12
+  let tree1 = LayoutTree::from_node(
+    perf_stack(@types.Block, n, -1, 40.0), 200.0, 2000.0,
+  )
+  let _ = tree1.compute_incremental()
+  // Change the last block. It has no following siblings, so the dirty set is
+  // just it — ideally every preceding block is reused. It is not: in-flow block
+  // children bypass the per-uid cache, so only the root is "computed" and the
+  // whole subtree recomputes inside block flow without cache reads.
+  let dirty = tree1.flow_dirty_uids([n])
+  inspect(dirty.length(), content="1")
+  let tree2 = LayoutTree::reconcile_from(
+    tree1, perf_stack(@types.Block, n, n - 1, 80.0), dirty, 200.0, 2000.0,
+  )
+  let stats = CacheStats::new()
+  let _ = tree2.compute_with_stats(stats)
+  inspect(
+    "hits=\{stats.cache_hits} misses=\{stats.cache_misses}",
+    content="hits=0 misses=1",
+  )
+}
+
+///|
+/// A flex container (its own BFC) of `n` fixed items; the item at `changed_idx`
+/// gets height `tweak`. uids are assigned from `base` (container = base, items
+/// base+1..). Used as a reusable subtree under a parent root.
+fn perf_flex_group(
+  base : Int,
+  tag : String,
+  n : Int,
+  changed_idx : Int,
+  tweak : Double,
+) -> @node.Node {
+  let items : Array[@node.Node] = []
+  for i = 0; i < n; i = i + 1 {
+    let h = if i == changed_idx { tweak } else { 40.0 }
+    items.push(@node.Node::with_uid(
+      tag + "i" + i.to_string(), base + 1 + i, perf_block(30.0, h), [],
+    ))
+  }
+  let style = @style.Style::{ ..perf_block(200.0, 60.0), display: @types.Flex }
+  @node.Node::with_uid(tag, base, style, items)
+}
+
+///|
+/// The one reuse that works today: an unchanged BFC subtree that does not move
+/// is served whole from the per-uid cache (the "high-subtree short-circuit").
+/// Two flex groups A then B stacked in a block column; change deep inside B.
+/// A precedes B so its absolute position is unchanged — A's entire subtree is a
+/// single cache hit, no descent. This is the reuse the dynamic path relies on
+/// (no-op / paint-only / disjoint-subtree re-renders); the block-flow case above
+/// gets none of it.
+test "perf: an unchanged, unmoved BFC subtree is reused whole (high-subtree short-circuit)" {
+  @dispatch.setup()
+  // Root column (uid 0). Group A uids 1..5 (base 1), Group B uids 10..14.
+  let mk = fn(b_tweak : Double) {
+    let root_style = @style.Style::{
+      ..perf_block(200.0, 200.0),
+      display: @types.Block,
+    }
+    @node.Node::with_uid("root", 0, root_style, [
+      perf_flex_group(1, "A", 4, -1, 40.0),
+      perf_flex_group(10, "B", 4, 0, b_tweak),
+    ])
+  }
+  let tree1 = LayoutTree::from_node(mk(40.0), 200.0, 200.0)
+  let _ = tree1.compute_incremental()
+  // Change item B0's height. B follows A and is the last child, so nothing that
+  // precedes shifts; only B's subtree is dirty.
+  let dirty = tree1.flow_dirty_uids([11]) // B's first item uid = 10+1
+  let tree2 = LayoutTree::reconcile_from(tree1, mk(80.0), dirty, 200.0, 200.0)
+  let stats = CacheStats::new()
+  let _ = tree2.compute_with_stats(stats)
+  // A's subtree is reused without descending into it: at least one cache hit.
+  inspect(stats.cache_hits > 0, content="true")
+}

--- a/layout/tree/layout_node.mbt
+++ b/layout/tree/layout_node.mbt
@@ -61,6 +61,7 @@ pub struct LayoutNode {
   children : Array[LayoutNode]
   mut measure : @layout_types.MeasureFunc?
   text : String?
+  src : String?
   // Dirty bits
   mut dirty : Bool
   mut children_dirty : Bool
@@ -93,6 +94,7 @@ pub fn LayoutNode::new(
     children,
     measure: None,
     text: None,
+    src: None,
     dirty: true, // Initially dirty
     children_dirty: false,
     cached_layout: None,
@@ -116,6 +118,7 @@ pub fn LayoutNode::leaf(id : String, style : @style.Style) -> LayoutNode {
     children: [],
     measure: None,
     text: None,
+    src: None,
     dirty: true,
     children_dirty: false,
     cached_layout: None,
@@ -143,6 +146,7 @@ pub fn LayoutNode::with_measure(
     children: [],
     measure: Some(measure),
     text: None,
+    src: None,
     dirty: true,
     children_dirty: false,
     cached_layout: None,
@@ -209,6 +213,7 @@ pub fn LayoutNode::to_node(self : LayoutNode) -> @node.Node {
     children,
     self.measure,
     self.text,
+    src=self.src,
   )
 }
 
@@ -223,6 +228,7 @@ pub fn LayoutNode::from_node(node : @node.Node) -> LayoutNode {
     children,
     measure: node.measure,
     text: node.text,
+    src: node.src,
     dirty: true,
     children_dirty: false,
     cached_layout: None,

--- a/layout/tree/moon.pkg
+++ b/layout/tree/moon.pkg
@@ -9,4 +9,5 @@ import {
 }
 
 import {
+  "mizchi/crater-layout/block",
 } for "wbtest"

--- a/layout/tree/pkg.generated.mbti
+++ b/layout/tree/pkg.generated.mbti
@@ -89,6 +89,7 @@ pub struct LayoutNode {
   children : Array[LayoutNode]
   mut measure : @crater-core.MeasureFunc?
   text : String?
+  src : String?
   mut dirty : Bool
   mut children_dirty : Bool
   mut cached_layout : LayoutCache?
@@ -231,4 +232,3 @@ pub fn ResourceRegistry::next_resource_id(Self) -> ResourceId
 // Type aliases
 
 // Traits
-

--- a/moon.mod
+++ b/moon.mod
@@ -1,14 +1,14 @@
 name = "mizchi/crater"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
   "mizchi/css@0.7.3",
-  "mizchi/crater-dom@0.18.0",
-  "mizchi/crater-layout@0.18.0",
-  "mizchi/crater-webvitals@0.18.0",
-  "mizchi/crater-painter@0.18.0",
-  "mizchi/crater-renderer@0.18.0",
+  "mizchi/crater-dom@0.18.1",
+  "mizchi/crater-layout@0.18.1",
+  "mizchi/crater-webvitals@0.18.1",
+  "mizchi/crater-painter@0.18.1",
+  "mizchi/crater-renderer@0.18.1",
 }
 
 readme = "README.mbt.md"

--- a/moon.mod
+++ b/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-webvitals@0.18.0",

--- a/network/moon.mod
+++ b/network/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/crater-network"
 
-version = "0.18.0"
+version = "0.18.1"
 
 repository = "https://github.com/mizchi/crater"
 

--- a/painter/moon.mod
+++ b/painter/moon.mod
@@ -1,11 +1,11 @@
 name = "mizchi/crater-painter"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
   "mizchi/css@0.7.3",
-  "mizchi/crater-core@0.18.0",
-  "mizchi/crater-terminal-protocol@0.18.0",
+  "mizchi/crater-core@0.18.1",
+  "mizchi/crater-terminal-protocol@0.18.1",
   "mizchi/font@0.7.3",
   "mizchi/svg@0.2.1",
   "mizchi/x@0.3.0",

--- a/painter/moon.mod
+++ b/painter/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-painter"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-terminal-protocol@0.18.0",
   "mizchi/font@0.7.3",

--- a/painter/paint/raster/paint_raster_test.mbt
+++ b/painter/paint/raster/paint_raster_test.mbt
@@ -655,7 +655,7 @@ test "framebuffer crop extracts sub-rectangle" {
   inspect(c.width, content="2")
   inspect(c.height, content="2")
   // y=1 row is [4,5,6,7], y=2 row is [8,9,10,11]; columns [1,3) -> 5,6 / 9,10
-  inspect(c.pixels, content="[5, 6, 9, 10]")
+  debug_inspect(c.pixels, content="[5, 6, 9, 10]")
 }
 
 ///|
@@ -668,7 +668,7 @@ test "framebuffer crop clamps a rect that overflows the edges" {
   let c = fb.crop(3, 2, 5, 5)
   inspect(c.width, content="1")
   inspect(c.height, content="1")
-  inspect(c.pixels, content="[11]")
+  debug_inspect(c.pixels, content="[11]")
 }
 
 ///|
@@ -681,7 +681,7 @@ test "framebuffer crop clamps negative origin (padding underflow)" {
   let c = fb.crop(-2, -1, 3, 2)
   inspect(c.width, content="1")
   inspect(c.height, content="1")
-  inspect(c.pixels, content="[0]")
+  debug_inspect(c.pixels, content="[0]")
 }
 
 ///|
@@ -690,5 +690,5 @@ test "framebuffer crop fully outside yields empty" {
   let c = fb.crop(10, 10, 2, 2)
   inspect(c.width, content="0")
   inspect(c.height, content="0")
-  inspect(c.pixels, content="[]")
+  debug_inspect(c.pixels, content="[]")
 }

--- a/renderer/gfx_bridge/gfx_bridge_test.mbt
+++ b/renderer/gfx_bridge/gfx_bridge_test.mbt
@@ -60,7 +60,7 @@ test "collect_paint_commands lowers background fills in paint order" {
   let commands = collect_paint_commands(frame, tree)
   // root + opaque child only; transparent and zero-area nodes are skipped.
   inspect(commands.length(), content="2")
-  inspect(
+  debug_inspect(
     commands.map(fn(c) { c.dst_regions[0].index_count }),
     content="[6, 6]",
   )
@@ -117,7 +117,7 @@ test "replaced images are lowered when an image resolver is supplied" {
   }
   let commands = collect_paint_commands(frame, img_node, resolve_image=resolve)
   inspect(commands.length(), content="1")
-  inspect(commands[0].src_image_ids, content="[42]")
+  debug_inspect(commands[0].src_image_ids, content="[42]")
 }
 
 ///|
@@ -170,8 +170,8 @@ test "node opacity dims the emitted fill and propagates to children" {
   let commands = collect_paint_commands(frame, parent)
   // parent + child fills, both dimmed by the parent's 0.5 group opacity
   inspect(commands.length(), content="2")
-  inspect(commands[0].uniform_dwords, content="[0, 0, 0, 127]")
-  inspect(commands[1].uniform_dwords, content="[0, 0, 0, 127]")
+  debug_inspect(commands[0].uniform_dwords, content="[0, 0, 0, 127]")
+  debug_inspect(commands[1].uniform_dwords, content="[0, 0, 0, 127]")
 }
 
 ///|
@@ -203,8 +203,8 @@ test "box shadow is lowered as a fill before the background" {
   // shadow fill, then background fill
   inspect(commands.length(), content="2")
   // shadow is grey and painted first
-  inspect(commands[0].uniform_dwords, content="[170, 170, 170, 255]")
-  inspect(commands[1].uniform_dwords, content="[0, 0, 0, 255]")
+  debug_inspect(commands[0].uniform_dwords, content="[170, 170, 170, 255]")
+  debug_inspect(commands[1].uniform_dwords, content="[0, 0, 0, 255]")
 }
 
 ///|
@@ -230,7 +230,7 @@ test "border radius lowers the background as a rounded fill" {
   let commands = collect_paint_commands(frame, node)
   inspect(commands.length(), content="1")
   // rounded: shape uniforms appended after the colour
-  inspect(
+  debug_inspect(
     commands[0].uniform_dwords,
     content=(
       #|[0, 0, 0, 255, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 8, 8]

--- a/renderer/gfx_bridge/gfx_software_integration_test.mbt
+++ b/renderer/gfx_bridge/gfx_software_integration_test.mbt
@@ -33,10 +33,10 @@ test "paint tree renders to pixels via the software backend" {
   let driver = @gfx_software.SoftwareDriver::new(4, 4)
   render_paint_tree(driver, root)
   // background pixel (corner) stays white
-  inspect(driver.pixel_at(0, 0), content="(255, 255, 255, 255)")
+  debug_inspect(driver.pixel_at(0, 0), content="(255, 255, 255, 255)")
   // the red box covers the inner 2x2 region
-  inspect(driver.pixel_at(1, 1), content="(255, 0, 0, 255)")
-  inspect(driver.pixel_at(2, 2), content="(255, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(1, 1), content="(255, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(2, 2), content="(255, 0, 0, 255)")
   // just outside the box is still white
-  inspect(driver.pixel_at(3, 3), content="(255, 255, 255, 255)")
+  debug_inspect(driver.pixel_at(3, 3), content="(255, 255, 255, 255)")
 }

--- a/renderer/gfx_frame/gfx_frame_test.mbt
+++ b/renderer/gfx_frame/gfx_frame_test.mbt
@@ -20,7 +20,7 @@ test "to_gfx_color normalizes 0..255 channels into 0..1" {
 
 ///|
 test "color_to_uniform_dwords packs 0..255 channels" {
-  inspect(
+  debug_inspect(
     color_to_uniform_dwords(to_gfx_color(@types.Color::rgba(255, 128, 0, 1.0))),
     content="[255, 128, 0, 255]",
   )
@@ -32,11 +32,11 @@ test "ndc_rect_fill_vertices maps the full viewport onto the NDC square" {
     0.0, 0.0, 100.0, 50.0, 100.0, 50.0,
   )
   // top-left -> (-1, 1), bottom-right -> (1, -1)
-  inspect(
+  debug_inspect(
     vertices,
     content="[-1, 1, 0, 0, 1, 1, 1, 0, 1, -1, 1, 1, -1, -1, 0, 1]",
   )
-  inspect(indices, content="[0, 1, 2, 2, 3, 0]")
+  debug_inspect(indices, content="[0, 1, 2, 2, 3, 0]")
 }
 
 ///|
@@ -55,7 +55,7 @@ test "append_rect_fill maps a pixel box to an NDC quad" {
     ),
   )
   inspect(commands.length(), content="1")
-  inspect(
+  debug_inspect(
     commands[0].vertex_data,
     content=(
       #|[-0.8, 0.8, 0, 0, -0.4, 0.8, 1, 0, -0.4, 0.4, 1, 1, -0.8, 0.4, 0, 1]
@@ -127,7 +127,7 @@ test "with_opacity scales the emitted color alpha" {
     ),
   )
   // opaque black -> alpha 255 * 0.5 = 127
-  inspect(commands[0].uniform_dwords, content="[0, 0, 0, 127]")
+  debug_inspect(commands[0].uniform_dwords, content="[0, 0, 0, 127]")
   // opacity multiplies: 0.5 * 0.5 = 0.25 -> alpha 63
   let dimmer = frame.with_opacity(0.5)
   let c2 = []
@@ -142,7 +142,7 @@ test "with_opacity scales the emitted color alpha" {
       color=to_gfx_color(@types.Color::rgb(0, 0, 0)),
     ),
   )
-  inspect(c2[0].uniform_dwords, content="[0, 0, 0, 63]")
+  debug_inspect(c2[0].uniform_dwords, content="[0, 0, 0, 63]")
 }
 
 ///|
@@ -165,7 +165,7 @@ test "append_rounded_rect_fill packs corner radii into the uniforms" {
     radius_bl=(1.0, 1.0),
   )
   // [r, g, b, a, rx_tl, ry_tl, rx_tr, ry_tr, rx_br, ry_br, rx_bl, ry_bl, x, y, w, h]
-  inspect(
+  debug_inspect(
     commands[0].uniform_dwords,
     content="[0, 0, 0, 255, 4, 4, 3, 2, 2, 2, 1, 1, 0, 0, 8, 8]",
   )

--- a/renderer/gfx_image/gfx_image_test.mbt
+++ b/renderer/gfx_image/gfx_image_test.mbt
@@ -20,9 +20,9 @@ test "append_image_quad emits a textured quad referencing the image id" {
   )
   inspect(commands.length(), content="1")
   // textured: the source image id is referenced
-  inspect(commands[0].src_image_ids, content="[7]")
+  debug_inspect(commands[0].src_image_ids, content="[7]")
   // uv spans the unit square
-  inspect(
+  debug_inspect(
     commands[0].vertex_data,
     content="[-1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, -1, 0, 0, 1]",
   )

--- a/renderer/gfx_software/gfx_software.mbt
+++ b/renderer/gfx_software/gfx_software.mbt
@@ -530,7 +530,7 @@ pub impl @gfx.GraphicsDriver for SoftwareDriver with fn begin(self, pass) {
 }
 
 ///|
-pub impl @gfx.GraphicsDriver for SoftwareDriver with fn end(self, _present) {
+pub impl @gfx.GraphicsDriver for SoftwareDriver with fn end(_self, _present) {
 
 }
 

--- a/renderer/gfx_software/gfx_software_test.mbt
+++ b/renderer/gfx_software/gfx_software_test.mbt
@@ -30,8 +30,8 @@ test "software driver clears then rasterizes a full-frame quad" {
   @gfx.GraphicsDriver::draw_triangles(driver, command)
   @gfx.GraphicsDriver::end(driver, false)
   // every pixel is now red
-  inspect(driver.pixel_at(0, 0), content="(255, 0, 0, 255)")
-  inspect(driver.pixel_at(3, 3), content="(255, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(0, 0), content="(255, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(3, 3), content="(255, 0, 0, 255)")
 }
 
 ///|
@@ -65,11 +65,11 @@ test "software driver fills only the covered sub-rectangle" {
   @gfx.GraphicsDriver::draw_triangles(driver, command)
   @gfx.GraphicsDriver::end(driver, false)
   // covered
-  inspect(driver.pixel_at(0, 0), content="(0, 255, 0, 255)")
-  inspect(driver.pixel_at(1, 1), content="(0, 255, 0, 255)")
+  debug_inspect(driver.pixel_at(0, 0), content="(0, 255, 0, 255)")
+  debug_inspect(driver.pixel_at(1, 1), content="(0, 255, 0, 255)")
   // outside the 2x2 box -> still the clear color
-  inspect(driver.pixel_at(2, 2), content="(0, 0, 0, 255)")
-  inspect(driver.pixel_at(3, 0), content="(0, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(2, 2), content="(0, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(3, 0), content="(0, 0, 0, 255)")
 }
 
 ///|
@@ -82,7 +82,7 @@ test "read_pixels returns the requested RGBA region" {
   )
   @gfx.GraphicsDriver::end(driver, false)
   let pixels = @gfx.GraphicsDriver::read_pixels(driver, 0, 0, 2, 2)
-  inspect(
+  debug_inspect(
     pixels,
     content="Some([0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255])",
   )
@@ -119,10 +119,10 @@ test "draw is scissored to the command's destination region" {
   @gfx.GraphicsDriver::draw_triangles(driver, command)
   @gfx.GraphicsDriver::end(driver, false)
   // left columns red, right columns remain the clear color
-  inspect(driver.pixel_at(0, 0), content="(255, 0, 0, 255)")
-  inspect(driver.pixel_at(1, 3), content="(255, 0, 0, 255)")
-  inspect(driver.pixel_at(2, 0), content="(0, 0, 0, 255)")
-  inspect(driver.pixel_at(3, 3), content="(0, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(0, 0), content="(255, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(1, 3), content="(255, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(2, 0), content="(0, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(3, 3), content="(0, 0, 0, 255)")
 }
 
 ///|
@@ -155,11 +155,11 @@ test "rounded-rect uniforms carve the corners" {
   @gfx.GraphicsDriver::draw_triangles(driver, command)
   @gfx.GraphicsDriver::end(driver, false)
   // the top-left corner pixel is carved away (still the clear color)
-  inspect(driver.pixel_at(0, 0), content="(255, 255, 255, 255)")
+  debug_inspect(driver.pixel_at(0, 0), content="(255, 255, 255, 255)")
   // the center is filled
-  inspect(driver.pixel_at(4, 4), content="(0, 0, 0, 255)")
+  debug_inspect(driver.pixel_at(4, 4), content="(0, 0, 0, 255)")
   // an edge midpoint is filled (not a corner)
-  inspect(
+  debug_inspect(
     driver.pixel_at(0, 4),
     content=(
       #|(0, 0, 0, 245)

--- a/renderer/gfx_text/atlas_test.mbt
+++ b/renderer/gfx_text/atlas_test.mbt
@@ -34,7 +34,10 @@ test "build_glyph_atlas packs inked glyphs into an alpha strip" {
   inspect(atlas.height, content="2")
   // row-major alpha: g0 occupies columns 0..1, g1 columns 2..3.
   // row 0: [255,255, 127,255]; row 1: [255,255, 0,255]
-  inspect(atlas.coverage, content="[255, 255, 127, 255, 255, 255, 0, 255]")
+  debug_inspect(
+    atlas.coverage,
+    content="[255, 255, 127, 255, 255, 255, 0, 255]",
+  )
   // g1's uv rect starts halfway across the atlas
   inspect(atlas.entries[1].u0, content="0.5")
   inspect(atlas.entries[1].u1, content="1")
@@ -57,7 +60,7 @@ test "atlas_to_commands emits textured quads sampling the atlas" {
   )
   inspect(commands.length(), content="1")
   // textured: references the atlas image id
-  inspect(commands[0].src_image_ids, content="[9]")
+  debug_inspect(commands[0].src_image_ids, content="[9]")
   // uv of the single glyph spans the whole atlas
   inspect(atlas.entries[0].u0, content="0")
   inspect(atlas.entries[0].u1, content="1")

--- a/renderer/gfx_text/bitmap_font.mbt
+++ b/renderer/gfx_text/bitmap_font.mbt
@@ -18,7 +18,7 @@
 /// their uppercase form.
 fn glyph_rows(ch : Char) -> Array[String]? {
   let c = if ch >= 'a' && ch <= 'z' {
-    Char::from_int(ch.to_int() - 32)
+    (ch.to_int() - 32).unsafe_to_char()
   } else {
     ch
   }

--- a/renderer/gfx_text/gfx_text_test.mbt
+++ b/renderer/gfx_text/gfx_text_test.mbt
@@ -42,12 +42,29 @@ test "glyph_placements_to_commands emits one quad per inked glyph" {
   let commands = glyph_placements_to_commands(frame, placements, color)
   inspect(commands.length(), content="2")
   // each glyph is a single quad
-  inspect(commands.map(fn(c) { c.indices.length() }), content="[6, 6]")
+  debug_inspect(commands.map(fn(c) { c.indices.length() }), content="[6, 6]")
   // the ink box position folds in the bitmap offset (10+1, 0+2)
-  inspect(
+  debug_inspect(
     commands[1].vertex_data,
     content=(
-      #|[-0.78, 0.96, 0, 0, -0.6599999999999999, 0.96, 1, 0, -0.6599999999999999, 0.8, 1, 1, -0.78, 0.8, 0, 1]
+      #|[
+      #|  -0.78,
+      #|  0.96,
+      #|  0,
+      #|  0,
+      #|  -0.6599999999999999,
+      #|  0.96,
+      #|  1,
+      #|  0,
+      #|  -0.6599999999999999,
+      #|  0.8,
+      #|  1,
+      #|  1,
+      #|  -0.78,
+      #|  0.8,
+      #|  0,
+      #|  1,
+      #|]
     ),
   )
 }

--- a/renderer/gfx_vrt/gfx_vrt_test.mbt
+++ b/renderer/gfx_vrt/gfx_vrt_test.mbt
@@ -32,9 +32,9 @@ test "render_paint_tree_to_image produces the expected pixels" {
     [solid("box", 2.0, 2.0, 4.0, 4.0, @types.Color::rgb(0, 0, 0), [])],
   )
   let image = render_paint_tree_to_image(root, 8, 8)
-  inspect(image.pixel_at(0, 0), content="(255, 255, 255, 255)")
-  inspect(image.pixel_at(3, 3), content="(0, 0, 0, 255)")
-  inspect(image.pixel_at(7, 7), content="(255, 255, 255, 255)")
+  debug_inspect(image.pixel_at(0, 0), content="(255, 255, 255, 255)")
+  debug_inspect(image.pixel_at(3, 3), content="(0, 0, 0, 255)")
+  debug_inspect(image.pixel_at(7, 7), content="(255, 255, 255, 255)")
 }
 
 ///|
@@ -76,7 +76,7 @@ test "render_html_to_image rasterizes a styled box through the VRT pipeline" {
   inspect(image.width, content="8")
   inspect(image.height, content="8")
   // the red box paints the top-left pixel
-  inspect(image.pixel_at(0, 0), content="(255, 0, 0, 255)")
+  debug_inspect(image.pixel_at(0, 0), content="(255, 0, 0, 255)")
 }
 
 ///|

--- a/renderer/moon.mod
+++ b/renderer/moon.mod
@@ -4,7 +4,7 @@ version = "0.18.0"
 
 import {
   "mizchi/crater-core@0.18.0",
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
   "mizchi/crater-painter@0.18.0",

--- a/renderer/moon.mod
+++ b/renderer/moon.mod
@@ -1,13 +1,13 @@
 name = "mizchi/crater-renderer"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-core@0.18.0",
+  "mizchi/crater-core@0.18.1",
   "mizchi/css@0.7.3",
-  "mizchi/crater-dom@0.18.0",
-  "mizchi/crater-layout@0.18.0",
-  "mizchi/crater-painter@0.18.0",
+  "mizchi/crater-dom@0.18.1",
+  "mizchi/crater-layout@0.18.1",
+  "mizchi/crater-painter@0.18.1",
   "mizchi/gfx@0.1.0",
   "mizchi/svg@0.2.1",
   "moonbitlang/async@0.19.0",

--- a/renderer/renderer/dom_id_render_test.mbt
+++ b/renderer/renderer/dom_id_render_test.mbt
@@ -29,7 +29,7 @@ test "dom_id is threaded onto the render node and hidden from the cascade" {
   let root = @renderer.render_to_node(html, @renderer.RenderContext::default())
   let div = find_render_node_by_id(root, "div").unwrap()
   // The DomTree id reaches the render node...
-  inspect(div.dom_id, content="Some(7)")
+  debug_inspect(div.dom_id, content="Some(7)")
   // ...but the cascade never saw the attribute, so the rule did not match
   // (still the default color, not red).
   inspect(div.style.color.to_rgba_string() == "rgb(255, 0, 0)", content="false")
@@ -40,5 +40,5 @@ test "dom_id is None on the static parse path (no internal attribute)" {
   let html = "<div>plain</div>"
   let root = @renderer.render_to_node(html, @renderer.RenderContext::default())
   let div = find_render_node_by_id(root, "div").unwrap()
-  inspect(div.dom_id, content="None")
+  debug_inspect(div.dom_id, content="None")
 }

--- a/renderer/renderer/generated_content.mbt
+++ b/renderer/renderer/generated_content.mbt
@@ -825,7 +825,7 @@ fn pseudo_base_style_from_host(host_style : @style.Style) -> @style.Style {
 }
 
 ///|
-fn resolve_pseudo_spec(
+fn _resolve_pseudo_spec(
   selector_elem : @css.Element,
   host_style : @style.Style,
   stylesheets : Array[@css.Stylesheet],

--- a/renderer/renderer/measurement_record.mbt
+++ b/renderer/renderer/measurement_record.mbt
@@ -233,7 +233,7 @@ pub fn deserialize_text_metrics_recording(
     while i < len && unit_at(i) != stop {
       i = i + 1
     }
-    let s = data[start:i].to_string()
+    let s = data[start:i].to_owned()
     i = i + 1 // consume stop
     s
   }
@@ -243,7 +243,7 @@ pub fn deserialize_text_metrics_recording(
     let mh = @string.parse_double(read_until(sp)) catch { _ => 0.0 }
     let xh = @string.parse_double(read_until(sp)) catch { _ => 0.0 }
     let key_len = @string.parse_int(read_until(colon)) catch { _ => 0 }
-    let key = data[i:i + key_len].to_string()
+    let key = data[i:i + key_len].to_owned()
     i = i + key_len
     result.push({
       key,
@@ -382,7 +382,7 @@ pub fn deserialize_image_intrinsic_recording(
     while i < len && unit_at(i) != stop {
       i = i + 1
     }
-    let s = data[start:i].to_string()
+    let s = data[start:i].to_owned()
     i = i + 1
     s
   }
@@ -391,7 +391,7 @@ pub fn deserialize_image_intrinsic_recording(
     let w = @string.parse_double(read_until(sp)) catch { _ => 0.0 }
     let h = @string.parse_double(read_until(sp)) catch { _ => 0.0 }
     let src_len = @string.parse_int(read_until(colon)) catch { _ => 0 }
-    let src = data[i:i + src_len].to_string()
+    let src = data[i:i + src_len].to_owned()
     i = i + src_len
     result.push({ src, has_size: has, width: w, height: h })
   }

--- a/renderer/renderer/render_root.mbt
+++ b/renderer/renderer/render_root.mbt
@@ -110,7 +110,7 @@ fn select_render_root(
 ///|
 fn resolve_root_available_width(
   viewport_width : Double,
-  root_margin : @types.Rect[Double],
+  _root_margin : @types.Rect[Double],
   doc_root_style : @style.Style?,
 ) -> Double {
   // The available width is the root's containing block (the initial containing

--- a/renderer/renderer/shadow_style_test.mbt
+++ b/renderer/renderer/shadow_style_test.mbt
@@ -80,7 +80,7 @@ test "compute_shadow_tree_styles threads inheritance across the boundary" {
   )
 
   // Host, wrapper, and leaf are all styled.
-  inspect(styles.size(), content="3")
+  inspect(styles.length(), content="3")
 
   // font-size: 20px on .wrap inherits into its leaf child.
   let wrap_style = styles.get(wrap.to_int()).unwrap()
@@ -121,7 +121,7 @@ test "compute_slotted_styles applies ::slotted rules to assigned light nodes" {
   )
 
   // Both light children are slotted, so both receive an entry.
-  inspect(styles.size(), content="2")
+  inspect(styles.length(), content="2")
 
   // Only .tag matches ::slotted(.tag): its color differs from the plain node's.
   let tagged_style = styles.get(tagged.to_int()).unwrap()

--- a/renderer/vrt/pkg.generated.mbti
+++ b/renderer/vrt/pkg.generated.mbti
@@ -60,20 +60,20 @@ pub(all) struct ComputedStyleEntry {
   z_index : String
   color : String
   background_color : String
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 pub(all) struct CssMutation {
   selector : String
   property : String
   action : CssMutationAction
-} derive(Eq, @debug.Debug)
+} derive(Eq, Debug)
 pub fn CssMutation::is_paint_only(Self) -> Bool
 pub impl Show for CssMutation
 
 pub(all) enum CssMutationAction {
   Remove
   Override(String)
-} derive(Eq, @debug.Debug)
+} derive(Eq, Debug)
 pub impl Show for CssMutationAction
 
 pub(all) struct LayoutBox {
@@ -83,7 +83,7 @@ pub(all) struct LayoutBox {
   y : Double
   width : Double
   height : Double
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 
 pub(all) struct PreparedVrtPage {
   doc : @html.Document
@@ -132,4 +132,3 @@ pub impl Show for RenderVariantResult
 // Type aliases
 
 // Traits
-

--- a/renderer/vrt/render_session_test.mbt
+++ b/renderer/vrt/render_session_test.mbt
@@ -178,10 +178,22 @@ test "computed style index matches the resolved style" {
   }
   let node = @renderer.render_to_node(html, ctx)
   let card = computed_style_by_id(node, "#card").unwrap()
-  inspect(
+  debug_inspect(
     card,
     content=(
-      #|{id: div#card, index: 1, display: flex, position: relative, visibility: visible, font_size: 20px, font_family: serif, opacity: 0.5, z_index: 7, color: rgb(255, 0, 0), background_color: rgb(0, 255, 0)}
+      #|{
+      #|  id: "div#card",
+      #|  index: 1,
+      #|  display: "flex",
+      #|  position: "relative",
+      #|  visibility: "visible",
+      #|  font_size: "20px",
+      #|  font_family: "serif",
+      #|  opacity: "0.5",
+      #|  z_index: "7",
+      #|  color: "rgb(255, 0, 0)",
+      #|  background_color: "rgb(0, 255, 0)",
+      #|}
     ),
   )
 }

--- a/renderer/vrt/top.mbt
+++ b/renderer/vrt/top.mbt
@@ -496,7 +496,7 @@ pub fn RenderSession::branch_reusing_layout_diff(
 /// box geometry — i.e. whether a branch carrying only such mutations can reuse
 /// the base layout.
 pub fn CssMutation::is_paint_only(self : CssMutation) -> Bool {
-  not(@dom.is_layout_property(self.property.to_lower()))
+  !@dom.is_layout_property(self.property.to_lower())
 }
 
 ///|
@@ -538,7 +538,7 @@ pub(all) struct LayoutBox {
   y : Double
   width : Double
   height : Double
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 fn collect_layout_boxes_into(
@@ -696,7 +696,7 @@ pub(all) struct ComputedStyleEntry {
   z_index : String
   color : String
   background_color : String
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 fn collect_computed_styles_into(

--- a/runtime/moon.mod
+++ b/runtime/moon.mod
@@ -1,9 +1,9 @@
 name = "mizchi/crater-browser-runtime"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-dom@0.18.0",
+  "mizchi/crater-dom@0.18.1",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/runtime/moon.pkg
+++ b/runtime/moon.pkg
@@ -12,6 +12,7 @@ options(
     "js_runtime_quickjs_dom_ops.mbt": [ "js" ],
     "js_runtime_quickjs_ffi.mbt": [ "js" ],
     "js_runtime_wasm.mbt": [ "wasm", "wasm-gc" ],
+    "dom_ops_wbtest.mbt": [ "js" ],
     "scheduler_integration_js.mbt": [ "js", "native" ],
     "scheduler_integration_stub.mbt": [ "wasm", "wasm-gc" ],
   },

--- a/scripts/ci/drop-v8-members.sh
+++ b/scripts/ci/drop-v8-members.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Remove the mizchi/v8-pulling workspace members from a moon.work so that a
+# `moon` invocation over the workspace never resolves `mizchi/v8` — and thus
+# never runs its `postadd` hook, which `git clone`s denoland/rusty_v8 at
+# dependency-resolution time. That clone is the wrong thing to pay for in
+# JS/wasm-only jobs (vrt-bench, benchmarks): it is slow, flakes on transient
+# network, and is hard-blocked (403) in the Claude-Code-on-the-web sandbox,
+# where it aborts resolution for the *whole* workspace even for a v8-unrelated
+# `--target js` build. See crater #312.
+#
+# `mizchi/v8` enters the graph through exactly two members:
+#   - ./browser/native  (direct dep on mizchi/v8)
+#   - ./testing         (dep on crater-browser-native -> mizchi/v8)
+# Dropping those two removes V8 from the dependency graph entirely.
+#
+# This edits moon.work IN PLACE (no restore) — intended for ephemeral CI
+# runners and for callers that manage their own backup (see
+# scripts/moon-test-no-v8.sh). It is idempotent: re-running drops nothing more.
+#
+# Usage:
+#   bash scripts/ci/drop-v8-members.sh                # edits ./moon.work
+#   bash scripts/ci/drop-v8-members.sh path/to/moon.work
+set -euo pipefail
+
+work="${1:-moon.work}"
+if [[ ! -f "$work" ]]; then
+  echo "error: $work not found" >&2
+  exit 1
+fi
+
+# The two members that transitively pull mizchi/v8. Keep this list in sync with
+# the dependency graph (a new direct consumer of mizchi/v8 must be added here).
+v8_member_re='^[[:space:]]*"\./(browser/native|testing)",[[:space:]]*$'
+
+before="$(grep -cE "$v8_member_re" "$work" || true)"
+if [[ "$before" -eq 0 ]]; then
+  echo "[drop-v8-members] no V8-pulling members present in $work (already trimmed)" >&2
+  exit 0
+fi
+
+tmp="$(mktemp)"
+grep -vE "$v8_member_re" "$work" >"$tmp"
+mv "$tmp" "$work"
+echo "[drop-v8-members] dropped $before V8-pulling member(s) from $work" >&2

--- a/scripts/moon-test-no-v8.sh
+++ b/scripts/moon-test-no-v8.sh
@@ -37,8 +37,9 @@ cp "$work" "$backup"
 restore() { cp "$backup" "$work"; rm -f "$backup"; }
 trap restore EXIT
 
-# Remove the V8-pulling members. Matches lines like `  "./browser/native",`.
-grep -vE '^[[:space:]]*"\./(browser/native|testing)",[[:space:]]*$' "$backup" > "$work"
+# Remove the V8-pulling members (./browser/native, ./testing) for the duration
+# of this run. Shared with the CI dropper so the member list lives in one place.
+bash "$repo_root/scripts/ci/drop-v8-members.sh" "$work"
 
 # Belt-and-suspenders: if a V8-adjacent prebuild still runs, degrade instead of
 # failing (browser/scripts/mizchi-v8-consumer-prebuild.mjs honors this).

--- a/terminal_image_cache/moon.mod
+++ b/terminal_image_cache/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/crater-terminal-image-cache"
 
-version = "0.18.0"
+version = "0.18.1"
 
 repository = "https://github.com/mizchi/crater"
 

--- a/terminal_protocol/moon.mod
+++ b/terminal_protocol/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/crater-terminal-protocol"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
   "mizchi/tui-terminal-protocol@0.1.2",

--- a/testing/e2e/native_v8/moon.pkg
+++ b/testing/e2e/native_v8/moon.pkg
@@ -6,7 +6,7 @@ import {
   "mizchi/crater-dom/dom",
 }
 
-warnings = "-text_segment_excceed"
+warnings = "-text_segment_excceed-unused_package"
 
 supported_targets = "+native"
 

--- a/testing/moon.mod
+++ b/testing/moon.mod
@@ -7,7 +7,7 @@ import {
   "mizchi/crater-browser@0.18.0",
   "mizchi/crater-browser-native@0.18.0",
   "mizchi/crater-browser-runtime@0.18.0",
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-dom@0.18.0",
   "mizchi/crater-layout@0.18.0",
 }

--- a/testing/moon.mod
+++ b/testing/moon.mod
@@ -1,15 +1,15 @@
 name = "mizchi/crater-testing"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-core@0.18.0",
-  "mizchi/crater-browser@0.18.0",
-  "mizchi/crater-browser-native@0.18.0",
-  "mizchi/crater-browser-runtime@0.18.0",
+  "mizchi/crater-core@0.18.1",
+  "mizchi/crater-browser@0.18.1",
+  "mizchi/crater-browser-native@0.18.1",
+  "mizchi/crater-browser-runtime@0.18.1",
   "mizchi/css@0.7.3",
-  "mizchi/crater-dom@0.18.0",
-  "mizchi/crater-layout@0.18.0",
+  "mizchi/crater-dom@0.18.1",
+  "mizchi/crater-layout@0.18.1",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/tools/moon.mod
+++ b/tools/moon.mod
@@ -1,9 +1,9 @@
 name = "mizchi/crater-tools"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-webdriver-bidi@0.18.0",
+  "mizchi/crater-webdriver-bidi@0.18.1",
   "mizchi/js@0.10.13",
 }
 

--- a/wasm/moon.mod
+++ b/wasm/moon.mod
@@ -1,9 +1,9 @@
 name = "mizchi/crater-wasm"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
-  "mizchi/crater-js@0.18.0",
+  "mizchi/crater-js@0.18.1",
 }
 
 readme = "README.md"

--- a/webdriver/moon.mod
+++ b/webdriver/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webdriver-bidi"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-core@0.18.0",
   "mizchi/crater-network@0.18.0",
   "mizchi/font@0.7.3",

--- a/webdriver/moon.mod
+++ b/webdriver/moon.mod
@@ -1,20 +1,20 @@
 name = "mizchi/crater-webdriver-bidi"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
   "mizchi/css@0.7.3",
-  "mizchi/crater-core@0.18.0",
-  "mizchi/crater-network@0.18.0",
+  "mizchi/crater-core@0.18.1",
+  "mizchi/crater-network@0.18.1",
   "mizchi/font@0.7.3",
   "mizchi/svg@0.2.1",
-  "mizchi/crater-dom@0.18.0",
-  "mizchi/crater-layout@0.18.0",
-  "mizchi/crater-painter@0.18.0",
-  "mizchi/crater-renderer@0.18.0",
-  "mizchi/crater-browser@0.18.0",
-  "mizchi/crater-browser-http@0.18.0",
-  "mizchi/crater-browser-helpers@0.18.0",
+  "mizchi/crater-dom@0.18.1",
+  "mizchi/crater-layout@0.18.1",
+  "mizchi/crater-painter@0.18.1",
+  "mizchi/crater-renderer@0.18.1",
+  "mizchi/crater-browser@0.18.1",
+  "mizchi/crater-browser-http@0.18.1",
+  "mizchi/crater-browser-helpers@0.18.1",
   "mizchi/webdriver@0.2.6",
   "mizchi/js@0.10.13",
   "moonbitlang/async@0.19.0",

--- a/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
+++ b/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
@@ -920,11 +920,11 @@ fn paint_node_matches_selector(
   }
   if sel.has_prefix("#") {
     // `#main` matches a node whose id is `<tag>#main`.
-    return id.has_suffix("#" + sel.substring(start=1))
+    return id.has_suffix("#" + sel[1:].to_owned())
   }
   if sel.has_prefix(".") {
     // `.card` matches a node whose id is `<tag>.card`.
-    return id.has_suffix("." + sel.substring(start=1))
+    return id.has_suffix("." + sel[1:].to_owned())
   }
   false
 }

--- a/webvitals/moon.mod
+++ b/webvitals/moon.mod
@@ -1,10 +1,10 @@
 name = "mizchi/crater-webvitals"
 
-version = "0.18.0"
+version = "0.18.1"
 
 import {
   "mizchi/css@0.7.3",
-  "mizchi/crater-core@0.18.0",
+  "mizchi/crater-core@0.18.1",
 }
 
 readme = "README.md"

--- a/webvitals/moon.mod
+++ b/webvitals/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-webvitals"
 version = "0.18.0"
 
 import {
-  "mizchi/css@0.7.0",
+  "mizchi/css@0.7.3",
   "mizchi/crater-core@0.18.0",
 }
 


### PR DESCRIPTION
## Summary
- use `Style::layout_eq` to seed only layout-relevant incremental reflow changes
- expand seeds through `flow_dirty_uids` instead of marking every uid dirty
- preserve render-node `src` on `LayoutNode` so src changes can invalidate layout inputs
- bump `mizchi/css` to 0.7.3

## Validation
- `moon test --target js browser/shell/incremental_reflow_wbtest.mbt`
- `moon test --target js layout/tree/incremental_reconcile_test.mbt`
- `moon test --target js layout/tree/layout_tree_test.mbt`
- `moon check --target js`

Refs #319