### PR TITLE
chore(nix): add reproducible dev/CI toolchain flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# direnv: auto-load the reproducible Crater dev environment.
+# Requires nix-direnv (https://github.com/nix-community/nix-direnv).
+# Run `direnv allow` once after editing this file.
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ uv.lock
 # MoonBit generated files (tracked for publishing)
 # *.generated.mbti
 
+# Nix / direnv
+.direnv/
+result
+result-*
+
 # Generated render results
 render-results/
 

--- a/docs/nix-environment.md
+++ b/docs/nix-environment.md
@@ -1,0 +1,69 @@
+# Reproducible dev/CI environment (Nix)
+
+`flake.nix` provides a reproducible toolchain for Crater so local development
+and CI converge on the same versions. This document is the **maintenance
+contract**: what is pinned, where, and how to keep it from drifting.
+
+## Quick start
+
+```bash
+nix develop          # enter the dev shell (or: direnv allow, with nix-direnv)
+just check           # everything on PATH: moon, pkf, just, node, pnpm, pkl, ...
+```
+
+First entry: run `nix flake lock` once to generate `flake.lock` (see below).
+
+## What is pinned, and how
+
+| Tool | Pinned by | Where the version lives |
+|---|---|---|
+| nixpkgs (just, nodejs_24, pkl, wasm-tools, sqlite, git, curl, make) | `flake.lock` narHash | `flake.lock` (generate with `nix flake lock`) |
+| `pkf` (pkfire) | fixed-output hash | `pkfVersion` + `pkfAssets.<system>.hash` in `flake.nix` |
+| pnpm | corepack | `packageManager` in `package.json` |
+| MoonBit (`moon`) | installer + **version assertion** | `moonbitVersion` in `flake.nix` |
+
+### Why MoonBit is special
+
+MoonBit is not in nixpkgs, and upstream does **not** currently serve pinned
+per-version binary tarballs: `https://cli.moonbitlang.com/binaries/<version>/…`
+returns `403`, only `latest` resolves. So the dev shell installs MoonBit via the
+official installer and then **asserts** the resulting `moon version` equals
+`moonbitVersion`, warning loudly on drift rather than floating silently. If/when
+upstream publishes stable per-version URLs, promote MoonBit to a real
+fixed-output derivation like `pkf`.
+
+## flake.lock
+
+`flake.lock` is intentionally **not committed yet** — the flake was authored in
+an environment without `nix`, so the nixpkgs narHash could not be generated.
+To finish pinning:
+
+```bash
+nix flake lock      # writes flake.lock
+git add flake.lock
+```
+
+After that, the nixpkgs-sourced tools are byte-reproducible.
+
+## Adding a platform for `pkf`
+
+Only `x86_64-linux` has a verified hash; other systems use `lib.fakeHash`. To
+fill one in, run `nix build .#pkf` on that system — Nix prints the real hash —
+and paste it into `pkfAssets.<system>.hash` in `flake.nix`.
+
+## Keeping pins in sync (the 保守 / maintenance part)
+
+When you bump a tool, update **both** the flake and the existing CI source of
+truth so they cannot drift apart:
+
+| If you change… | also update… |
+|---|---|
+| `moonbitVersion` (flake) | `.github/actions/setup-crater/action.yml` (`moonbit-version`) |
+| `pkfVersion` + hash (flake) | `.github/workflows/ci.yml` (`PKFIRE_TAG`) |
+| `nodejs_24` (flake) | `setup-crater/action.yml` (`node-version`) |
+| `wasm-tools` (flake) | `setup-crater/action.yml` (`wasm-tools-version`) |
+| pnpm (`package.json`) | nothing — corepack reads it in both places |
+
+CI itself is unchanged: jobs still use the curl-based installers in
+`setup-crater`. The flake is an additive, opt-in local-reproduction layer; wiring
+CI to run *inside* `nix develop` is a possible follow-up, not done here.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,128 @@
+{
+  description = "Crater MoonBit browser engine — reproducible dev/CI toolchain";
+
+  # NOTE: flake.lock is NOT committed yet because this flake was authored in an
+  # environment without `nix`. Run `nix flake lock` once on a machine with Nix
+  # to pin nixpkgs (and thereby every nixpkgs-sourced tool below) by narHash.
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      # Toolchain pins. Keep these in sync with:
+      #   - .github/actions/setup-crater/action.yml  (node/just/wasm-tools)
+      #   - .github/workflows/ci.yml                 (PKFIRE_TAG)
+      #   - package.json                             (packageManager / pnpm)
+      moonbitVersion = "0.1.20260618"; # expected `moon version`; see shellHook
+      pkfVersion = "0.12.3";
+
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+
+      # pkfire ships per-platform static tarballs as GitHub release assets.
+      # Hashes are flat-file SRI of `pkf-<asset>.tar.gz`. Only the assets we have
+      # verified are filled in; the rest use lib.fakeHash so `nix build` prints
+      # the real hash on first use (standard FOD bootstrap).
+      pkfAssets = {
+        "x86_64-linux" = {
+          asset = "pkf-linux-amd64";
+          # verified 2026-06-30 against pkfire@0.12.3 release
+          hash = "sha256-AjeiXgYsVoGqjQrrVH9g454hRF1ACOd4ZryoJUPGN3M=";
+        };
+        "aarch64-linux" = { asset = "pkf-linux-arm64"; hash = nixpkgs.lib.fakeHash; };
+        "x86_64-darwin" = { asset = "pkf-darwin-amd64"; hash = nixpkgs.lib.fakeHash; };
+        "aarch64-darwin" = { asset = "pkf-darwin-arm64"; hash = nixpkgs.lib.fakeHash; };
+      };
+
+      mkPkf = pkgs: system:
+        let a = pkfAssets.${system};
+        in pkgs.stdenvNoCC.mkDerivation {
+          pname = "pkf";
+          version = pkfVersion;
+          src = pkgs.fetchurl {
+            url = "https://github.com/mizchi/pkfire/releases/download/pkfire@${pkfVersion}/${a.asset}.tar.gz";
+            inherit (a) hash;
+          };
+          sourceRoot = ".";
+          nativeBuildInputs = nixpkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 pkf "$out/bin/pkf"
+            runHook postInstall
+          '';
+          meta.description = "pkfire CI gate runner (release binary ${pkfVersion})";
+        };
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          pkf = mkPkf pkgs system;
+          # Libraries the prebuilt MoonBit ELF binaries need at runtime.
+          # Harmless on macOS; required on NixOS (alongside nix-ld) and used to
+          # extend LD_LIBRARY_PATH so the installer-fetched `moon` can run.
+          moonRuntimeLibs = nixpkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.stdenv.cc.cc.lib
+            pkgs.zlib
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              # --- pinned via flake.lock (nixpkgs) ---
+              pkgs.just
+              pkgs.nodejs_24 # bundles corepack -> honours package.json pnpm pin
+              pkgs.pkl
+              pkgs.wasm-tools
+              pkgs.sqlite # libsqlite3 for native-deps builds
+              pkgs.git
+              pkgs.curl
+              pkgs.cacert
+              pkgs.gnumake
+              # --- pinned via FOD (release asset) ---
+              pkf
+            ] ++ moonRuntimeLibs;
+
+            env = {
+              MOONBIT_EXPECTED_VERSION = moonbitVersion;
+              LD_LIBRARY_PATH = nixpkgs.lib.makeLibraryPath moonRuntimeLibs;
+            };
+
+            shellHook = ''
+              set -u
+              # pnpm: honour the package.json `packageManager` pin via corepack
+              export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+              corepack enable >/dev/null 2>&1 || true
+
+              # MoonBit is not in nixpkgs and upstream does not currently serve
+              # pinned per-version binary tarballs (the dated /binaries/<ver>/
+              # path 403s; only `latest` resolves). So we install via the
+              # official installer and ASSERT the resulting version, failing
+              # loudly on drift instead of silently floating.
+              export PATH="$HOME/.moon/bin:$PATH"
+              installed="$(moon version 2>/dev/null | awk 'NR==1{print $2}')"
+              if [ "$installed" != "$MOONBIT_EXPECTED_VERSION" ]; then
+                echo "crater: installing MoonBit (have '$installed', want '$MOONBIT_EXPECTED_VERSION')" >&2
+                if MOONBIT_INSTALL_VERSION="$MOONBIT_EXPECTED_VERSION" \
+                     curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash >&2; then :; else
+                  echo "crater: pinned install failed; falling back to latest" >&2
+                  curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash >&2 || true
+                fi
+                installed="$(moon version 2>/dev/null | awk 'NR==1{print $2}')"
+                if [ "$installed" != "$MOONBIT_EXPECTED_VERSION" ]; then
+                  echo "crater: WARNING MoonBit is '$installed', expected '$MOONBIT_EXPECTED_VERSION' (upstream may no longer publish the pinned build)" >&2
+                fi
+              fi
+
+              echo "crater devshell: moon=$installed pkf=$(pkf --version 2>/dev/null) node=$(node --version) just=$(just --version)" >&2
+              set +u
+            '';
+          };
+        });
+
+      packages = forAllSystems (system:
+        let pkgs = import nixpkgs { inherit system; };
+        in { pkf = mkPkf pkgs system; });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -91,9 +91,15 @@
 
             shellHook = ''
               set -u
-              # pnpm: honour the package.json `packageManager` pin via corepack
+              # pnpm: honour the package.json `packageManager` pin via corepack.
+              # Corepack lives in the read-only /nix/store, so `corepack enable`
+              # cannot write shims next to its own binary; point it at a writable
+              # dir that we prepend to PATH instead.
               export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-              corepack enable >/dev/null 2>&1 || true
+              corepack_shims="$HOME/.cache/crater/corepack-shims"
+              mkdir -p "$corepack_shims"
+              export PATH="$corepack_shims:$PATH"
+              corepack enable --install-directory "$corepack_shims" pnpm npm >/dev/null 2>&1 || true
 
               # MoonBit is not in nixpkgs and upstream does not currently serve
               # pinned per-version binary tarballs (the dated /binaries/<ver>/
@@ -104,8 +110,8 @@
               installed="$(moon version 2>/dev/null | awk 'NR==1{print $2}')"
               if [ "$installed" != "$MOONBIT_EXPECTED_VERSION" ]; then
                 echo "crater: installing MoonBit (have '$installed', want '$MOONBIT_EXPECTED_VERSION')" >&2
-                if MOONBIT_INSTALL_VERSION="$MOONBIT_EXPECTED_VERSION" \
-                     curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash >&2; then :; else
+                if curl -fsSL https://cli.moonbitlang.com/install/unix.sh \
+                     | MOONBIT_INSTALL_VERSION="$MOONBIT_EXPECTED_VERSION" bash >&2; then :; else
                   echo "crater: pinned install failed; falling back to latest" >&2
                   curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash >&2 || true
                 fi


### PR DESCRIPTION
## Summary

Adds a Nix flake dev shell so local development and CI can converge on the same toolchain versions. **Additive and opt-in** — CI's existing curl-based installers in `setup-crater` are untouched.

```bash
nix develop      # or: direnv allow (with nix-direnv)
just check       # moon, pkf, just, node, pnpm, pkl, wasm-tools all on PATH
```

## What is pinned, and how

| Tool | Pin mechanism | Status |
|---|---|---|
| just, nodejs_24, pkl, wasm-tools, sqlite, git, curl, make | `flake.lock` narHash (nixpkgs) | needs one `nix flake lock` run |
| `pkf` (pkfire 0.12.3) | fixed-output derivation | hash **verified** for `x86_64-linux`; other systems use `lib.fakeHash` (standard `nix build`-reveals-hash flow) |
| pnpm | corepack ← `package.json` `packageManager` | works in dev & CI |
| MoonBit (`moon`) | installer + **version assertion** | pinned-by-hash not currently possible (see below) |

## Two caveats worth a reviewer's eye

1. **`flake.lock` is intentionally not committed yet.** This was authored in an environment without `nix`, so the nixpkgs narHash couldn't be generated or the flake evaluated. Running `nix flake lock` once on a machine with nix finishes the pinning and is the first real validation of the flake. `docs/nix-environment.md` documents this.

2. **MoonBit can't be hash-pinned today.** It isn't in nixpkgs, and upstream no longer serves pinned per-version binary tarballs — `https://cli.moonbitlang.com/binaries/0.1.20260618/…` returns `403`; only `latest` resolves (both verified). So the shell installs MoonBit via the official installer pinned to `moonbitVersion` and **asserts** the resulting `moon version`, warning loudly on drift instead of floating silently. If upstream publishes stable per-version URLs, MoonBit can be promoted to a real fixed-output derivation like `pkf`.

## Files

- `flake.nix` — dev shell + `pkf` FOD + `packages.pkf`.
- `.envrc` — `use flake` for nix-direnv.
- `docs/nix-environment.md` — the maintenance contract: what's pinned where, and a sync table so flake pins can't drift from `setup-crater/action.yml`, `ci.yml`, and `package.json`.
- `.gitignore` — `.direnv/`, `result*`.

## Not in this PR

Wiring CI to run *inside* `nix develop` (so local and CI are byte-identical) is a deliberate follow-up, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgmgHovSTV6mEzFYNLy959)_