### PR TITLE
chore(spec): align pkfire workflow + spec tests with pkfire 0.12.3

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -30,11 +30,12 @@ workflowTests {
     changed { "flaker.toml" }
     direct { check.checkFlaker.name }
     tasks {
-      check.checkFlaker.name
-      check.checkMbti.name
       check.checkMoon.name
-      check.checkTaskfile.name
       check.checkTs.name
+      check.checkFlaker.name
+      check.checkDeadModules.name
+      check.checkTaskfile.name
+      check.checkMbti.name
       spec.specCheck.name
       spec.specLint.name
       check.check.name
@@ -54,34 +55,34 @@ workflowTests {
     name = "wpt dom fixture change runs dom and visual gates"
     changed { "wpt/dom/nodes/Document-createElement.html" }
     direct {
-      visual.testWptVrt.name
       wpt.testWptDom.name
+      visual.testWptVrt.name
     }
     tasks {
-      visual.testVrt.name
-      visual.testWptVrt.name
-      visual.testVisual.name
       wpt.testWptCss.name
       wpt.testWptDom.name
       wpt.testWptWebdriver.name
       wpt.testWpt.name
+      visual.testVrt.name
+      visual.testWptVrt.name
+      visual.testVisual.name
     }
   }
   new {
     name = "wpt webdriver fixture change runs webdriver and visual gates"
     changed { "wpt/webdriver/tests/bidi/session/status/status.py" }
     direct {
-      visual.testWptVrt.name
       wpt.testWptWebdriver.name
+      visual.testWptVrt.name
     }
     tasks {
-      visual.testVrt.name
-      visual.testWptVrt.name
-      visual.testVisual.name
       wpt.testWptCss.name
       wpt.testWptDom.name
       wpt.testWptWebdriver.name
       wpt.testWpt.name
+      visual.testVrt.name
+      visual.testWptVrt.name
+      visual.testVisual.name
     }
   }
   new {
@@ -94,20 +95,21 @@ workflowTests {
       spec.specTest.name
     }
     tasks {
-      check.checkFlaker.name
-      check.checkMbti.name
       check.checkMoon.name
-      check.checkTaskfile.name
       check.checkTs.name
+      check.checkFlaker.name
+      check.checkDeadModules.name
+      check.checkTaskfile.name
+      check.checkMbti.name
       spec.specCheck.name
       spec.specLint.name
       check.check.name
       spec.specDocs.name
       spec.specTest.name
       spec.spec.name
-      test.buildJsPackage.name
       test.testMoon.name
       test.testVitest.name
+      test.buildJsPackage.name
       test.testWasm.name
       test.testNode.name
       test.test.name

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -84,9 +84,9 @@ tests {
       [graphTaskPath(test.buildJsPackage.name, "visibility")] = "internal"
     }
     expectStdoutContains {
-      "\"outputs\": ["
+      "\"outputs\":["
       "\"js/dist/**\""
-      "\"deps\": ["
+      "\"deps\":["
       "\"build-js-package\","
       "\"test-wasm\""
     }
@@ -240,7 +240,7 @@ tests {
     workdir = ".."
     cmd = "pkf affected --check"
     expectStdoutContains {
-      "workflow test(s) passed"
+      "workflow tests passed"
     }
   }
   new {
@@ -251,7 +251,7 @@ tests {
     specRef { "task.diagnostics" }
     workdir = ".."
     cmd =
-      "bash -lc 'set -euo pipefail; json=$(pkf lint --json); printf \"%s\" \"$json\" | grep -Fq \"\\\"findings\\\": []\"'"
+      "bash -lc 'set -euo pipefail; json=$(pkf lint --json); printf \"%s\" \"$json\" | grep -Eq \"\\\"findings\\\":[[:space:]]*[[]]\"'"
   }
   new {
     name = "ci_dead_module_detection_guard"


### PR DESCRIPTION
pkfire 0.12.3 (the MoonBit rewrite) changed two observable behaviors that the pinned task contracts hadn't caught up to. This realigns `Taskfile.pkl` and `specs/tasks.Test.pkl` so the gates pass again.

## What changed

**1. `check` gate + affected ordering**
- The `check` gate now pulls in `check-dead-modules`.
- affected-plan / direct ordering is now **dependency order** (not alphabetical) and is compared order-sensitively.
- Reordered the `Taskfile.pkl` `workflowTests` `direct`/`tasks` listings to the computed order and added `check-dead-modules` to the check-gate scenarios.
- `pkf affected --check` now passes **7/7** (was 4/7 failing).

**2. Compact JSON + message wording**
- `pkf graph --json` / `pkf lint --json` now emit **compact JSON** (no space after `:`).
- `pkf affected --check` prints **"all N workflow tests passed"**.
- Updated the pkspec `expectStdoutContains` assertions: `"deps":[` / `"outputs":[`, `"workflow tests passed"`, and a whitespace-tolerant grep for an empty `"findings"` array (matches compact + pretty, rejects non-empty).

## Verification

Verified locally with pkf 0.12.3:
- `pkf affected --check` → 7/7
- `pkf lint --json` → `{"findings":[]}`
- the findings regex matches both compact and pretty output while rejecting non-empty

The `pkspec-run` assertions (`expectStdoutJsonPath`) are structurally consistent with 0.12.3's graph JSON but were **not** executed locally — no pkspec binary is published or installed in this environment.

## Scope

Touches only `Taskfile.pkl` and `specs/tasks.Test.pkl`; no engine/runtime code. Independent of the nix toolchain flake (#322).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgmgHovSTV6mEzFYNLy959)_