### PR TITLE
perf(renderer): share inherited CSS var map instead of cloning per element (#316)

### DIFF
--- a/renderer/renderer/style_resolve.mbt
+++ b/renderer/renderer/style_resolve.mbt
@@ -15,12 +15,74 @@ fn is_root_selector(selector : @css.CompoundSelector) -> Bool {
 
 ///|
 fn clone_string_map(source : Map[String, String]) -> Map[String, String] {
-  let cloned : Map[String, String] = {}
-  for entry in source {
-    let (key, value) = entry
-    cloned[key] = value
+  // Native copy pre-sizes the target, avoiding the incremental grow/rehash
+  // churn of inserting entries one-by-one.
+  source.copy()
+}
+
+///|
+/// True when this element writes into the inherited custom-property map, so the
+/// map must be cloned before mutation. When false, the element inherits the
+/// parent's vars unchanged and the map can be shared read-only — avoiding an
+/// O(vars) clone per element, the dominant style-resolution cost on var-heavy
+/// pages. Conservative: any `--` declaration, a `color-scheme` declaration, or
+/// a not-yet-seeded color-scheme key forces the clone. Mirrors exactly the
+/// write conditions of collect_cascaded_custom_properties /
+/// collect_inline_custom_properties / seed_effective_color_scheme_for_direct_style.
+fn element_contributes_css_vars(
+  cascaded : @css.CascadedValues?,
+  inline_css : String?,
+  css_vars : Map[String, String],
+) -> Bool {
+  // Root / first element still needs the color-scheme seed written.
+  if css_vars.get(renderer_effective_color_scheme_key) is None {
+    return true
   }
-  cloned
+  match cascaded {
+    Some(cv) => {
+      let mut contributes = false
+      cv.each(fn(prop, _decl) {
+        if prop.has_prefix("--") || prop == "color-scheme" {
+          contributes = true
+        }
+      })
+      if contributes {
+        return true
+      }
+    }
+    None => ()
+  }
+  match inline_css {
+    Some(css) =>
+      for declaration in parse_inline_declarations_cached(css) {
+        let (prop, _value) = declaration
+        if prop.has_prefix("--") || prop.to_lower() == "color-scheme" {
+          return true
+        }
+      }
+    None => ()
+  }
+  false
+}
+
+///|
+/// Build the element's effective custom-property map. Shares the inherited map
+/// read-only when the element contributes nothing (the common case), else
+/// clones and folds in the element's own custom properties + color-scheme seed.
+fn compute_element_css_vars(
+  cascaded : @css.CascadedValues?,
+  inline_css : String?,
+  css_vars : Map[String, String],
+) -> Map[String, String] {
+  if element_contributes_css_vars(cascaded, inline_css, css_vars) {
+    let vars = css_vars.copy()
+    collect_cascaded_custom_properties(cascaded, vars)
+    collect_inline_custom_properties(inline_css, vars)
+    seed_effective_color_scheme_for_direct_style(cascaded, inline_css, vars)
+    vars
+  } else {
+    css_vars
+  }
 }
 
 ///|
@@ -714,11 +776,8 @@ fn apply_cascaded_to_style(
   parent_style : @style.Style?,
   css_vars : Map[String, String],
 ) -> @style.Style {
-  let element_css_vars = clone_string_map(css_vars)
-  collect_cascaded_custom_properties(cascaded, element_css_vars)
-  collect_inline_custom_properties(inline_css, element_css_vars)
-  seed_effective_color_scheme_for_direct_style(
-    cascaded, inline_css, element_css_vars,
+  let element_css_vars = compute_element_css_vars(
+    cascaded, inline_css, css_vars,
   )
   let mut author_line_height_present = false
   match cascaded {
@@ -1253,13 +1312,7 @@ fn compute_element_css_vars_indexed(
   } else {
     None
   }
-  let element_css_vars = clone_string_map(css_vars)
-  collect_cascaded_custom_properties(cascaded, element_css_vars)
-  collect_inline_custom_properties(inline_css, element_css_vars)
-  seed_effective_color_scheme_for_direct_style(
-    cascaded, inline_css, element_css_vars,
-  )
-  element_css_vars
+  compute_element_css_vars(cascaded, inline_css, css_vars)
 }
 
 ///|


### PR DESCRIPTION
## Context

Re-profiling the MDN grid fixture (see [#316 comment](https://github.com/mizchi/crater/issues/316#issuecomment-4876405428)) showed the render bottleneck has moved: **style resolution ~50%**, block layout ~20%, inline-flow only ~7%. Within style resolution, `clone_string_map` of the inherited custom-property map was **~13% of total render time** — every one of ~1339 elements deep-copied the full inherited `css_vars` map even when it defined no custom properties (O(nodes × vars)).

## Change

- `apply_cascaded_to_style` and `compute_element_css_vars_indexed` now build the element's var map via a new `compute_element_css_vars`, which **shares the parent map read-only** unless the element actually contributes — a `--` declaration, a `color-scheme` declaration, or an unseeded root. The predicate mirrors exactly the write conditions of the three existing `collect_*` / `seed_*` mutators, so the shared map is never mutated (the downstream var-resolution sinks only read it).
- `clone_string_map` now uses the native `Map::copy()` (pre-sized) instead of inserting entries one-by-one, removing grow/rehash churn on the paths that do still clone (e.g. pseudo-element vars).

## Results (MDN grid fixture, conformance runtime, best-of-3)

| | before | after |
|---|---|---|
| full render | 4152 ms | **3310 ms** (~20% faster) |
| output | 289471 bytes | **byte-identical** (verified `diff`) |

## Regression testing

- Rendered output is **byte-for-byte identical** before/after on the MDN fixture.
- `renderer` package: 10/10.
- Full no-v8 workspace suite: **3599/3608**. The 9 failures are **pre-existing** — browser JS-runtime slot-assignment / mutation-record / sixel-image tests, confirmed identical with and without this change (they don't touch CSS custom-property resolution).

Validated in-sandbox via `just test-no-v8` (now possible after #312).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgmgHovSTV6mEzFYNLy959)_