### PR TITLE
fix(renderer): default tables to content-box box-sizing (#281)

### DIFF
--- a/renderer/renderer/style_resolve.mbt
+++ b/renderer/renderer/style_resolve.mbt
@@ -560,9 +560,12 @@ fn get_ua_default_style(tag : String) -> @style.Style {
     // Table elements
     "table" =>
       {
+        // Tables default to `box-sizing: content-box` like every other element
+        // (there is no UA rule making them border-box). An explicit `width` is
+        // therefore the content-box width, and border/padding — including the
+        // legacy `<table border>` presentational hint — are added outside it.
         ..default_style,
         display: @types.Table,
-        box_sizing: @types.BorderBox,
         border_spacing: 2.0,
       }
     "tr" => { ..default_style, display: @types.TableRow }

--- a/renderer/renderer/table_attributes_render_test.mbt
+++ b/renderer/renderer/table_attributes_render_test.mbt
@@ -305,3 +305,34 @@ test "table_border_fixed_layout_width_matches_browser_281" {
     None => fail("table layout box not found")
   }
 }
+
+///|
+/// Issue #281: tables default to `box-sizing: content-box`, so when the columns
+/// fit inside the specified `width` the used table box is the content width plus
+/// the border added *outside* it. Here `width: 500px` + a `border="10"` table
+/// border gives 500 + 2*10 = 520 (previously the table incorrectly defaulted to
+/// border-box and stayed 500, eating the border into the content).
+test "table_explicit_width_is_content_box_281" {
+  let html =
+    #|<!DOCTYPE HTML>
+    #|<style>table { border-spacing: 0 }</style>
+    #|<table border="10" style="width: 500px"><tr><td>x</td></tr></table>
+  let layout = @renderer.render(html, @renderer.RenderContext::default())
+  fn find_table(l : @layout_types.Layout) -> @layout_types.Layout? {
+    if l.id.has_prefix("table") {
+      return Some(l)
+    }
+    for c in l.children {
+      match find_table(c) {
+        Some(found) => return Some(found)
+        None => ()
+      }
+    }
+    None
+  }
+
+  match find_table(layout) {
+    Some(table) => inspect(table.width, content="520")
+    None => fail("table layout box not found")
+  }
+}


### PR DESCRIPTION
## Root cause

The `<table>` UA default in `get_ua_default_style` forced `box_sizing: BorderBox`. That's not a real UA rule — tables default to `content-box` like every other element. So an explicit `width` on a table was treated as the *border-box* width, and the table's border (including the legacy `<table border>` presentational hint) ate into the content instead of being added outside it.

Repro (`<table border="10" style="width:500px">`): crater laid the table out at **500px** wide; Chromium reports **520** (issue #281: "browser=610, crater=500, diff = the HTML-border box"). Notably the border already affected *height* (auto-height adds border at layout time) but not *width*, which is what made this half-wired.

## Fix

Remove the `box_sizing: BorderBox` override so tables inherit the content-box default. The existing `adjust_for_box_sizing` pass then adds border+padding *outside* the specified width, matching Chromium.

- Auto / borderless tables: unaffected (border+padding = 0 ⇒ content-box ≡ border-box).
- Explicit `box-sizing: border-box`: still honored.

## Verification (conformance render + `moon test`)

| case | before | after |
|---|---|---|
| `<table border="10" width:500>` | 500 | **520** |
| `<table style="border:10px; width:500">` | 500 | **520** |
| `<table style="border:10px; width:500; box-sizing:border-box">` | 500 | 500 |
| `<div style="border:10px; width:500">` | 520 | 520 |

- Added render regression test `table_explicit_width_is_content_box_281` (asserts 520).
- `renderer/renderer` **399/399**, `layout/table` **29/29**.
- Full no-v8 workspace suite: **3600 passed / 9 failed** — the 9 are pre-existing browser JS-runtime slot/sixel failures, unchanged with/without this change.
- The existing `table_border_fixed_layout_width_matches_browser_281` (fixed-layout column-overflow → 610) is orthogonal and still passes.

The CI `wpt-css` gate is a **pass-floor** (`passed >= baseline`, `failed <= baseline`), so this can only improve or hold `css-values`; the noted residual calc-table failures are column-distribution, separate from this box-sizing fix.

Closes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgmgHovSTV6mEzFYNLy959)_