### PR TITLE
spec(dom): approve compat.web-components-shadow-selectors (#155)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,6 @@ pkf run spec-check                                          # contract が壊れ
 
 | scenario id | 概要 | link | 状態 |
 |---|---|---|---|
-| `compat.web-components-shadow-selectors` | `:host` 複合 / `::slotted` / `:host-context` | #155 (umbrella) → #285 / #286 | 両経路 landed: スタイリング #285 (PR #288–#293, scenario `compat.shadow-static-styling` approved) — shadow-scoped マッチ→cascade→`compute_composed_shadow_styles`。DOM query #286 (scenario `compat.shadow-query-selector` approved) — `shadow_query_selector` が compound/combinator + `:host()`/`:host-context()` をシャドウスコープで解決。slot 割当 API (assignedNodes/Elements/assignedSlot) も landed |
 | `compat.web-components-element-internals` | closed shadow / declarative SD / form-associated | #156 | crater 内部 |
 | `compat.browser-shell-form-controls` | select popup / blur change / IME / caret | #159 | crater 内部 |
 | `compat.native-form-control-appearance` | select / button native appearance 方針 | #160 | 方針判断含む |

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -444,10 +444,10 @@ scenarios {
     id = "compat.web-components-shadow-selectors"
     name = "Shadow DOM selector surface is complete"
     description =
-      "Implement remaining shadow-aware selectors: :host compound selectors, ::slotted, :host-context. Source: TODO Next (P1) and browser/TODO.md."
+      "Implement remaining shadow-aware selectors: :host compound selectors, ::slotted, :host-context. Source: TODO Next (P1) and browser/TODO.md. See GitHub issue #155."
     tags { "dom"; "shadow"; "selectors"; "todo:next" }
     severity = "major"
-    reviewStatus = "draft"
+    reviewStatus = "approved"
     contributes { "goal.dom-compat" }
   }
   new {

--- a/specs/tasks.Test.pkl
+++ b/specs/tasks.Test.pkl
@@ -854,4 +854,14 @@ tests {
     cmd =
       "bash -lc 'set -e; grep -Fq -- \"pub fn DomTree::shadow_query_selector_all\" dom/dom/shadow_query_selector.mbt; grep -Fq -- \"pub fn DomTree::shadow_query_selector(\" dom/dom/shadow_query_selector.mbt; grep -Fq -- \"shadow_query_selector handles compounds, combinators, and :host scoping\" dom/dom/shadow_query_selector_test.mbt; grep -Fq -- \"shadow_query_selector does not cross into nested shadow roots\" dom/dom/shadow_query_selector_test.mbt; grep -Fq -- \"shadow_query_selector rejects non-shadow-root scope and invalid selector\" dom/dom/shadow_query_selector_test.mbt'"
   }
+  new {
+    name = "shadow_selector_surface_matches_host_slotted_host_context"
+    description =
+      "The remaining shadow-aware selectors are complete: DomTree::matches_shadow_scoped resolves :host (incl. :host() compounds), :host-context(<compound>), and ::slotted(<compound>) through the mizchi/css matcher, verified by the matches_shadow_scoped tests (#155)."
+    tags { "dom"; "shadow"; "selectors"; "issue:155"; "todo:next" }
+    specRef { "compat.web-components-shadow-selectors" }
+    workdir = ".."
+    cmd =
+      "bash -lc 'set -e; grep -Fq -- \"pub fn DomTree::matches_shadow_scoped(\" dom/dom/shadow_query.mbt; grep -Fq -- \"matches_shadow_scoped resolves :host and descendants\" dom/dom/shadow_query_test.mbt; grep -Fq -- \":host-context(.page)\" dom/dom/shadow_query_test.mbt; grep -Fq -- \"matches_shadow_scoped resolves ::slotted\" dom/dom/shadow_query_test.mbt'"
+  }
 }


### PR DESCRIPTION
## Why

The `compat.web-components-shadow-selectors` scenario (#155) was still `draft`, but its selector surface is already implemented and tested — `:host` (incl. `:host()` compounds), `:host-context(<compound>)`, and `::slotted(<compound>)` resolve through the `mizchi/css` matcher, integrated in crater via `DomTree::matches_shadow_scoped`.

Verified in-sandbox: `dom/dom` 50/50, `renderer/renderer` 398/398, including:
- `matches_shadow_scoped resolves :host and descendants` (with a `:host-context(.page)` assertion)
- `matches_shadow_scoped resolves ::slotted`

The sibling scenarios `compat.shadow-static-styling` (#285) and `compat.shadow-query-selector` (#286) are already `approved`; this closes the umbrella selector-surface scenario.

## Change (pkspec reification, per CLAUDE.md)

- **`specs/tasks.Test.pkl`** — new implementing test `shadow_selector_surface_matches_host_slotted_host_context` with `specRef { "compat.web-components-shadow-selectors" }` and a grep-based wiring `cmd` asserting the matcher + the two `matches_shadow_scoped` tests (all four greps verified locally).
- **`specs/crater.pkl`** — flip `reviewStatus` `draft → approved`; add the `#155` backlink to the description.
- **`TODO.md`** — drop the now-approved row from the "Next (P1)" table.

No product code changes. `pkf run spec-check` / `spec-test` validate the link in CI (the `pkspec` binary isn't available in the authoring sandbox).

Closes #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgmgHovSTV6mEzFYNLy959)_