### PR TITLE
perf(reflow): profile-driven render wins + incremental scoped cascade (off by default)

### DIFF
--- a/benchmarks/cascade_reuse_profile/main.mbt
+++ b/benchmarks/cascade_reuse_profile/main.mbt
@@ -1,0 +1,72 @@
+///|
+/// A/B harness for incremental (scoped) cascade — Phase 1. Measures the renderer
+/// hot path the shell uses on a reflow (`build_render_root_node`): full cascade
+/// vs. cascade-reuse (prior styles reused for unchanged subtrees). See
+/// docs/incremental-cascade-design.md.
+
+///|
+/// A reuse-safe stylesheet (only class/tag/descendant selectors) with `rules`
+/// class rules, inlined as a <style> block so the whole page is one document.
+fn build_page(blocks : Int, rules : Int) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string("<!DOCTYPE html><html><head><style>")
+  buf.write_string("body{margin:0}.row .cell{margin:2px}")
+  for i = 0; i < rules; i = i + 1 {
+    buf.write_string(".c")
+    buf.write_string(i.to_string())
+    buf.write_string("{padding:")
+    buf.write_string((i % 12).to_string())
+    buf.write_string("px;border:1px solid #ddd;background:#eef;color:#123}")
+  }
+  buf.write_string("</style></head><body><main-shell>")
+  for i = 0; i < blocks; i = i + 1 {
+    let c = i % rules
+    buf.write_string("<section class=\"box c")
+    buf.write_string(c.to_string())
+    buf.write_string("\"><div class=\"row c")
+    buf.write_string(((c + 1) % rules).to_string())
+    buf.write_string("\"><span class=\"cell\">Item ")
+    buf.write_string(i.to_string())
+    buf.write_string("</span></div><p class=\"body\">para</p></section>")
+  }
+  buf.write_string("</main-shell></body></html>")
+  buf.to_string()
+}
+
+///|
+fn main {
+  let iters = 300
+  let html = build_page(90, 60)
+  let ctx = {
+    ..@renderer.RenderContext::default(),
+    viewport_width: 800.0,
+    viewport_height: 600.0,
+  }
+  let doc = @html.parse_document(html)
+  let prepared = @renderer.prepare_render_document(doc, ctx, [])
+
+  // Prime the prior-style maps from one reuse pass over the document.
+  @renderer.cascade_reuse_begin(Map::new(), Map::new())
+  let _ = @renderer.build_render_root_node(doc, ctx, prepared)
+  let (prior_styles, prior_sigs, _) = @renderer.cascade_reuse_end()
+
+  // Sanity: how many elements a reuse pass reuses (an unchanged re-render).
+  @renderer.cascade_reuse_begin(prior_styles, prior_sigs)
+  let _ = @renderer.build_render_root_node(doc, ctx, prepared)
+  let (_, _, reused) = @renderer.cascade_reuse_end()
+
+  let mode = "reuse"
+  let mut acc = 0
+  for i = 0; i < iters; i = i + 1 {
+    if mode == "reuse" {
+      @renderer.cascade_reuse_begin(prior_styles, prior_sigs)
+      let node = @renderer.build_render_root_node(doc, ctx, prepared)
+      let _ = @renderer.cascade_reuse_end()
+      acc = acc + node.children.length()
+    } else {
+      let node = @renderer.build_render_root_node(doc, ctx, prepared)
+      acc = acc + node.children.length()
+    }
+  }
+  println("mode=\{mode} iters=\{iters} reused_per_pass=\{reused} acc=\{acc}")
+}

--- a/benchmarks/cascade_reuse_profile/moon.pkg
+++ b/benchmarks/cascade_reuse_profile/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "mizchi/crater-renderer/renderer",
+  "mizchi/crater-dom/html",
+  "mizchi/crater-core/node",
+}
+
+supported_targets = "native"
+
+options(
+  "is-main": true,
+)

--- a/benchmarks/paint_raster_profile/main.mbt
+++ b/benchmarks/paint_raster_profile/main.mbt
@@ -1,0 +1,73 @@
+///|
+/// Native profiling / A-B harness for the software-raster -> RGBA base64 encode
+/// scenario (the BiDi captureScreenshot path). Renders a heavy page once, then
+/// repeatedly rasterizes the paint tree and base64-encodes the framebuffer.
+
+///|
+fn build_css(rules : Int) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string("body{margin:0;font-family:sans-serif}")
+  buf.write_string("section{display:block;padding:8px}")
+  buf.write_string(".row{display:flex;gap:8px}")
+  for i = 0; i < rules; i = i + 1 {
+    buf.write_string(".c")
+    buf.write_string(i.to_string())
+    buf.write_string("{padding:")
+    buf.write_string((i % 12).to_string())
+    buf.write_string("px;border:1px solid #ddd;background:#f")
+    buf.write_string((i % 10).to_string())
+    buf.write_string("f8ff;color:#1")
+    buf.write_string((i % 10).to_string())
+    buf.write_string("2}")
+  }
+  buf.to_string()
+}
+
+///|
+fn build_html(blocks : Int, rules : Int) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string("<!DOCTYPE html><html><body><main-shell>")
+  for i = 0; i < blocks; i = i + 1 {
+    let c = i % rules
+    buf.write_string("<section class=\"card c")
+    buf.write_string(c.to_string())
+    buf.write_string("\"><div class=\"row c")
+    buf.write_string(((c + 1) % rules).to_string())
+    buf.write_string("\"><span class=\"cell\">Item ")
+    buf.write_string(i.to_string())
+    buf.write_string(
+      "</span></div><p class=\"body\">Synthetic paragraph.</p></section>",
+    )
+  }
+  buf.write_string("</main-shell></body></html>")
+  buf.to_string()
+}
+
+///|
+fn main {
+  let width = 800
+  let height = 600
+  let iters = 150
+  let css = [build_css(60)]
+  let html = build_html(90, 60)
+  let ctx = {
+    ..@renderer.RenderContext::default(),
+    viewport_width: width.to_double(),
+    viewport_height: height.to_double(),
+  }
+  let (node, layout) = @renderer.render_to_node_and_layout_with_external_css(
+    html, ctx, css,
+  )
+  let paint : @paint_model.PaintNode = @paint_render.from_node_and_layout(
+    node, layout,
+  )
+  let mut acc = 0
+  for i = 0; i < iters; i = i + 1 {
+    let fb = @raster.Framebuffer::new(width, height)
+    let palette = @raster.DynamicPalette::new()
+    @raster.render_paint_node_to_framebuffer(paint, fb, palette)
+    let encoded = @raster.framebuffer_to_rgba_base64(fb, palette)
+    acc = acc + encoded.length()
+  }
+  println("rasterized \{iters}x \{width}x\{height} acc=\{acc}")
+}

--- a/benchmarks/paint_raster_profile/moon.pkg
+++ b/benchmarks/paint_raster_profile/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "mizchi/crater-renderer/renderer",
+  "mizchi/crater-core",
+  "mizchi/crater-core/node",
+  "mizchi/crater-painter/paint/render_bridge" @paint_render,
+  "mizchi/crater-painter/paint/model" @paint_model,
+  "mizchi/crater-painter/paint/raster",
+}
+
+supported_targets = "native"
+
+options(
+  "is-main": true,
+)

--- a/benchmarks/render_profile/main.mbt
+++ b/benchmarks/render_profile/main.mbt
@@ -1,0 +1,80 @@
+///|
+/// Build a stylesheet with `rules` class rules plus a handful of descendant /
+/// tag rules, so the selector-matching side of the cascade has real work.
+fn build_css(rules : Int) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string("body{margin:0;font-family:sans-serif}")
+  buf.write_string("section{display:block;padding:8px}")
+  buf.write_string(".row{display:flex;gap:8px}")
+  buf.write_string(".row > .cell{flex:1;padding:4px}")
+  buf.write_string("main-shell vrt-target .card p{line-height:1.5}")
+  for i = 0; i < rules; i = i + 1 {
+    buf.write_string(".c")
+    buf.write_string(i.to_string())
+    buf.write_string("{padding:")
+    buf.write_string((i % 12).to_string())
+    buf.write_string("px;margin:")
+    buf.write_string((i % 7).to_string())
+    buf.write_string("px;border:1px solid #ddd;background:#f")
+    buf.write_string((i % 10).to_string())
+    buf.write_string("f8ff;color:#1")
+    buf.write_string((i % 10).to_string())
+    buf.write_string("2}")
+  }
+  buf.to_string()
+}
+
+///|
+/// Build a page of `blocks` cards, each a small nested subtree carrying a mix
+/// of classes so many selectors partially match. Mirrors the shape of the
+/// component_vrt "m" fixture (noise blocks around a component subtree).
+fn build_html(blocks : Int, rules : Int) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string("<!DOCTYPE html><html><body><main-shell>")
+  for i = 0; i < blocks; i = i + 1 {
+    let c = i % rules
+    buf.write_string("<section class=\"card c")
+    buf.write_string(c.to_string())
+    buf.write_string("\"><div class=\"row c")
+    buf.write_string(((c + 1) % rules).to_string())
+    buf.write_string("\"><span class=\"cell c")
+    buf.write_string(((c + 2) % rules).to_string())
+    buf.write_string("\">Item ")
+    buf.write_string(i.to_string())
+    buf.write_string("</span><span class=\"cell c")
+    buf.write_string(((c + 3) % rules).to_string())
+    buf.write_string("\">detail text for row that wraps</span></div>")
+    buf.write_string("<p class=\"body c")
+    buf.write_string(((c + 4) % rules).to_string())
+    buf.write_string(
+      "\">Synthetic paragraph content for layout work.</p></section>",
+    )
+  }
+  buf.write_string("</main-shell></body></html>")
+  buf.to_string()
+}
+
+///|
+fn main {
+  let rules = 60
+  let blocks = 120
+  let iters = 200
+  let css = [build_css(rules)]
+  let html = build_html(blocks, rules)
+  let ctx = {
+    ..@renderer.RenderContext::default(),
+    viewport_width: 800.0,
+    viewport_height: 600.0,
+  }
+  // Warm up (parse + first layout) outside the checksum so the profile is
+  // dominated by steady-state renders.
+  let mut acc = 0
+  for i = 0; i < iters; i = i + 1 {
+    let (node, layout) = @renderer.render_to_node_and_layout_with_external_css(
+      html, ctx, css,
+    )
+    // Keep the results live so the optimizer can't drop the render.
+    acc = acc + node.children.length() + layout.children.length()
+  }
+  println("rendered \{iters}x blocks=\{blocks} rules=\{rules} acc=\{acc}")
+}

--- a/benchmarks/render_profile/moon.pkg
+++ b/benchmarks/render_profile/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "mizchi/crater-renderer/renderer",
+  "mizchi/crater-core",
+  "mizchi/crater-core/node",
+}
+
+supported_targets = "native"
+
+options(
+  "is-main": true,
+)

--- a/browser/shell/cascade_reuse_wbtest.mbt
+++ b/browser/shell/cascade_reuse_wbtest.mbt
@@ -1,0 +1,105 @@
+///|
+/// Incremental (scoped) cascade — Phase 1 equivalence + engagement tests.
+///
+/// Correctness is a pure render property: with cascade reuse ON, rendering v2
+/// after v1 (so unchanged subtrees reuse prior computed styles) must be
+/// byte-identical to a full from-scratch render of v2. The engagement assertions
+/// (`cascade_reuse_last_count`) guard against a silently-disabled fast path
+/// reading as a pass. See docs/incremental-cascade-design.md.
+
+///|
+/// Render `v2` on a full-rebuild browser; render `v2` on a reuse browser that
+/// first rendered `v1` (populating the prior-style maps). Returns
+/// (incremental == full, reused-count-on-the-v2-render).
+fn cascade_reuse_equiv(v1 : String, v2 : String) -> (Bool, Int) {
+  let full = Browser::new(400, 300)
+  full.set_html_content(v2)
+  full.parsed_doc = Some(@html.parse_document(v2))
+  let want = full.render_text_full_page()
+
+  // Reuse: render v1 (records prior styles), then re-render v2.
+  let incr = Browser::new(400, 300)
+  incr.set_cascade_reuse(true)
+  incr.set_html_content(v1)
+  incr.parsed_doc = Some(@html.parse_document(v1))
+  let _ = incr.render_text_full_page()
+  incr.set_html_content(v2)
+  incr.clear_render_cache()
+  incr.parsed_doc = Some(@html.parse_document(v2))
+  let got = incr.render_text_full_page()
+  (got == want, incr.cascade_reuse_last_count())
+}
+
+///|
+/// A reuse-safe stylesheet (only class / tag / descendant selectors) wrapping a
+/// two-column structure. `t1` / `t2` are the two cells' text.
+fn cascade_reuse_page(t1 : String, t2 : String, extra_css : String) -> String {
+  "<html><head><style>" +
+  ".box{color:#112233;padding:4px}.row .cell{margin:2px;color:#334455}" +
+  extra_css +
+  "</style></head><body>" +
+  "<div class=\"row\"><div class=\"box\"><span class=\"cell\">" +
+  t1 +
+  "</span></div><div class=\"box\"><span class=\"cell\">" +
+  t2 +
+  "</span></div></div></body></html>"
+}
+
+///|
+test "cascade reuse: a text-only change matches a full rebuild and engages" {
+  let v1 = cascade_reuse_page("a", "b", "")
+  let v2 = cascade_reuse_page("aaa changed", "b", "")
+  let (equal, reused) = cascade_reuse_equiv(v1, v2)
+  // Byte-identical to a full rebuild.
+  inspect(equal, content="true")
+  // The fast path actually engaged: unchanged subtrees reused prior styles.
+  inspect(reused > 0, content="true")
+}
+
+///|
+test "cascade reuse: a :empty rule disables reuse but still matches" {
+  // `:empty` makes a text edit able to flip a match, so the guard must fall back
+  // to a full cascade. Output still matches; reuse must not have engaged.
+  let v1 = cascade_reuse_page("a", "b", ".box:empty{color:#ff0000}")
+  let v2 = cascade_reuse_page("aaa changed", "b", ".box:empty{color:#ff0000}")
+  let (equal, reused) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+  inspect(reused, content="0")
+}
+
+///|
+test "cascade reuse: a class change re-cascades and matches a full rebuild" {
+  // The mutated element's class changes (its style must be recomputed); the
+  // unchanged sibling may still reuse. Output must match a full rebuild.
+  let v1 = cascade_reuse_page("a", "b", ".hot{color:#00ff00;padding:20px}")
+  let v2 = "<html><head><style>.box{color:#112233;padding:4px}.row .cell{margin:2px;color:#334455}.hot{color:#00ff00;padding:20px}</style></head><body>" +
+    "<div class=\"row\"><div class=\"box hot\"><span class=\"cell\">a</span></div><div class=\"box\"><span class=\"cell\">b</span></div></div></body></html>"
+  let (equal, _) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+}
+
+///|
+test "cascade reuse: an unchanged re-render matches and reuses everything" {
+  let v = cascade_reuse_page("hello", "world", "")
+  let (equal, reused) = cascade_reuse_equiv(v, v)
+  inspect(equal, content="true")
+  inspect(reused > 0, content="true")
+}
+
+///|
+test "cascade reuse: an ancestor class change invalidates descendants (combinator)" {
+  // `.active .cell` is a descendant dependency: adding `active` to the ancestor
+  // must recompute the .cell descendants' style, even though the .cell elements'
+  // own inputs are unchanged. The ancestor-clean chain must catch this — reusing
+  // the .cell styles here would be a stale-style bug. Output must match a full
+  // rebuild.
+  let css = ".active .cell{color:#ff0000;padding:9px}"
+  let v1 = "<html><head><style>.box{color:#112233;padding:4px}.row .cell{margin:2px}" +
+    css +
+    "</style></head><body><div class=\"row\"><div class=\"box\"><span class=\"cell\">a</span></div></div></body></html>"
+  let v2 = "<html><head><style>.box{color:#112233;padding:4px}.row .cell{margin:2px}" +
+    css +
+    "</style></head><body><div class=\"row active\"><div class=\"box\"><span class=\"cell\">a</span></div></div></body></html>"
+  let (equal, _) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+}

--- a/browser/shell/cascade_reuse_wbtest.mbt
+++ b/browser/shell/cascade_reuse_wbtest.mbt
@@ -57,14 +57,44 @@ test "cascade reuse: a text-only change matches a full rebuild and engages" {
 }
 
 ///|
-test "cascade reuse: a :empty rule disables reuse but still matches" {
-  // `:empty` makes a text edit able to flip a match, so the guard must fall back
-  // to a full cascade. Output still matches; reuse must not have engaged.
+test "cascade reuse: a :empty sheet reuses on a non-empty text edit (Phase 4)" {
+  // Phase 4 makes `:empty` reuse-safe via the child-structure summary. Both
+  // versions keep the `.box` non-empty, so its emptiness is unchanged: reuse
+  // engages and matches a full rebuild.
   let v1 = cascade_reuse_page("a", "b", ".box:empty{color:#ff0000}")
   let v2 = cascade_reuse_page("aaa changed", "b", ".box:empty{color:#ff0000}")
   let (equal, reused) = cascade_reuse_equiv(v1, v2)
   inspect(equal, content="true")
-  inspect(reused, content="0")
+  inspect(reused > 0, content="true")
+}
+
+///|
+test "cascade reuse: an empty -> filled transition invalidates :empty" {
+  // Filling a previously-empty element flips its `:empty` match. The child
+  // summary in its signature changes (no children -> a text child), so it
+  // recomputes; reusing its empty-state style would be a stale-style bug.
+  let v1 = "<html><head><style>.slot{color:#111111}.slot:empty{color:#ff0000;padding:9px}</style></head><body>" +
+    "<div class=\"slot\"></div></body></html>"
+  let v2 = "<html><head><style>.slot{color:#111111}.slot:empty{color:#ff0000;padding:9px}</style></head><body>" +
+    "<div class=\"slot\">now filled</div></body></html>"
+  let (equal, _) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+}
+
+///|
+test "cascade reuse: appending a child invalidates :last-child (positional-from-end)" {
+  // `.list .item:last-child` — appending an item makes the old last item no
+  // longer `:last-child`. The parent's child summary changes, dirtying the whole
+  // list via the ancestor chain, so the old last item recomputes. Match full.
+  let css = ".item{color:#111111}.list .item:last-child{color:#ff0000;padding:5px}"
+  let v1 = "<html><head><style>" +
+    css +
+    "</style></head><body><div class=\"list\"><div class=\"item\">a</div><div class=\"item\">b</div></div></body></html>"
+  let v2 = "<html><head><style>" +
+    css +
+    "</style></head><body><div class=\"list\"><div class=\"item\">a</div><div class=\"item\">b</div><div class=\"item\">c</div></div></body></html>"
+  let (equal, _) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
 }
 
 ///|

--- a/browser/shell/cascade_reuse_wbtest.mbt
+++ b/browser/shell/cascade_reuse_wbtest.mbt
@@ -136,6 +136,41 @@ test "cascade reuse: a calc() plus is not mistaken for an unsafe selector" {
 }
 
 ///|
+/// A page with a `.list .item:first-child` rule. `prepend` inserts an extra
+/// leading item; `t` is appended to the first original item's text.
+fn cascade_reuse_first_child_page(prepend : Bool, t : String) -> String {
+  let extra = if prepend { "<div class=\"item\">new</div>" } else { "" }
+  "<html><head><style>.item{color:#111111}.list .item:first-child{color:#ff0000;padding:8px}</style></head><body>" +
+  "<div class=\"list\">" +
+  extra +
+  "<div class=\"item\">a" +
+  t +
+  "</div><div class=\"item\">b</div></div></body></html>"
+}
+
+///|
+test "cascade reuse: :first-child survives a prepend (positional-from-start)" {
+  // Prepending a sibling makes the old first child no longer `:first-child`. Its
+  // owner_id (child index) shifts, so it recomputes; reusing its red style would
+  // be a stale-style bug. Output must match a full rebuild.
+  let v1 = cascade_reuse_first_child_page(false, "")
+  let v2 = cascade_reuse_first_child_page(true, "")
+  let (equal, _) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+}
+
+///|
+test "cascade reuse: a :first-child sheet still reuses on a text edit" {
+  // `:first-child` is now reuse-safe; a text edit keeps positions and inputs
+  // stable, so reuse engages and matches full.
+  let v1 = cascade_reuse_first_child_page(false, "")
+  let v2 = cascade_reuse_first_child_page(false, "xxx")
+  let (equal, reused) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+  inspect(reused > 0, content="true")
+}
+
+///|
 test "cascade reuse: an ancestor class change invalidates descendants (combinator)" {
   // `.active .cell` is a descendant dependency: adding `active` to the ancestor
   // must recompute the .cell descendants' style, even though the .cell elements'

--- a/browser/shell/cascade_reuse_wbtest.mbt
+++ b/browser/shell/cascade_reuse_wbtest.mbt
@@ -87,6 +87,55 @@ test "cascade reuse: an unchanged re-render matches and reuses everything" {
 }
 
 ///|
+/// A page with an adjacent-sibling rule `.a + .b`. `c1`/`c2` are the two
+/// siblings' classes, `t` the second sibling's text.
+fn cascade_reuse_sibling_page(c1 : String, c2 : String, t : String) -> String {
+  "<html><head><style>.b{color:#111111}.a + .b{color:#ff0000;padding:7px}</style></head><body>" +
+  "<div class=\"row\"><span class=\"" +
+  c1 +
+  "\">x</span><span class=\"" +
+  c2 +
+  "\">" +
+  t +
+  "</span></div></body></html>"
+}
+
+///|
+test "cascade reuse: a preceding-sibling change invalidates an adjacent match" {
+  // `.a + .b` — changing the FIRST sibling's class must recompute `.b` even
+  // though `.b`'s own inputs are unchanged. The preceding-sibling gate must catch
+  // it; reusing `.b`'s style would be a stale-style bug. Output must match full.
+  let v1 = cascade_reuse_sibling_page("a", "b", "y")
+  let v2 = cascade_reuse_sibling_page("z", "b", "y") // .a -> .z: .b no longer adjacent to .a
+  let (equal, _) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+}
+
+///|
+test "cascade reuse: a sibling-combinator sheet still reuses on a text edit" {
+  // With `+` in the sheet the preceding-sibling gate is active, but a text-only
+  // edit keeps every sibling clean, so reuse still engages and matches full.
+  let v1 = cascade_reuse_sibling_page("a", "b", "y")
+  let v2 = cascade_reuse_sibling_page("a", "b", "yyy changed")
+  let (equal, reused) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+  inspect(reused > 0, content="true")
+}
+
+///|
+test "cascade reuse: a calc() plus is not mistaken for an unsafe selector" {
+  // `calc(... + ...)` in a value must not disable reuse (Phase 1 wrongly did):
+  // it only trips the conservative sibling gate. A text edit still reuses.
+  let v1 = cascade_reuse_page("a", "b", ".box{width:calc(100px + 2px)}")
+  let v2 = cascade_reuse_page(
+    "aaa changed", "b", ".box{width:calc(100px + 2px)}",
+  )
+  let (equal, reused) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+  inspect(reused > 0, content="true")
+}
+
+///|
 test "cascade reuse: an ancestor class change invalidates descendants (combinator)" {
   // `.active .cell` is a descendant dependency: adding `active` to the ancestor
   // must recompute the .cell descendants' style, even though the .cell elements'

--- a/browser/shell/incremental_reflow.mbt
+++ b/browser/shell/incremental_reflow.mbt
@@ -10,6 +10,25 @@ pub fn Browser::set_incremental_reflow(self : Browser, enabled : Bool) -> Unit {
 }
 
 ///|
+/// Enable incremental (scoped) cascade — Phase 1, **off by default**. When on, a
+/// reflow whose stylesheet is reuse-safe (no sibling/positional/:has/:empty
+/// selectors) reuses prior computed styles for subtrees whose inputs are
+/// unchanged, skipping the O(n) re-cascade. Correctness is a pure render
+/// property, validated on the js target (incremental == full per mutation kind).
+/// See docs/incremental-cascade-design.md.
+pub fn Browser::set_cascade_reuse(self : Browser, enabled : Bool) -> Unit {
+  self.enable_cascade_reuse = enabled
+}
+
+///|
+/// The number of elements that reused a prior computed style on the last render
+/// (0 when reuse was off, the stylesheet was not reuse-safe, or the CSS changed).
+/// Lets a test assert the fast path actually engaged.
+pub fn Browser::cascade_reuse_last_count(self : Browser) -> Int {
+  self.cascade_reuse_last_count
+}
+
+///|
 /// A deterministic geometry signature of the current render's layout boxes —
 /// `id:x,y,w,h` per box in document order — for VRT-style comparison of the
 /// dynamic reflow path. Forces a render so the layout tree reflects the current

--- a/browser/shell/moon.pkg
+++ b/browser/shell/moon.pkg
@@ -2,8 +2,8 @@ import {
   "moonbitlang/core/json",
   "moonbitlang/async/io",
   "mizchi/crater-renderer/renderer",
-  "mizchi/crater-renderer/vrt" @vrt,
-  "mizchi/crater-core/node" @node,
+  "mizchi/crater-renderer/vrt",
+  "mizchi/crater-core/node",
   "mizchi/crater-layout/tree" @layout_tree,
   "mizchi/crater-dom/html",
   "mizchi/crater-browser-helpers" @browser_helpers,
@@ -29,12 +29,12 @@ import {
   "mizchi/crater-painter/terminal/sixel",
   "mizchi/crater-terminal-image-cache" @terminal_image_cache,
   "mizchi/crater-painter/paint/raster",
+  "mizchi/css/style",
 }
 
 import {
   "moonbitlang/async",
   "mizchi/crater-dom/css/responsive",
-  "mizchi/css/style" @style,
 } for "wbtest"
 
 warnings = "-unused_package"

--- a/browser/shell/pkg.generated.mbti
+++ b/browser/shell/pkg.generated.mbti
@@ -19,6 +19,7 @@ type Browser
 pub async fn Browser::activate_at(Self, Int, Int) -> Bool raise @crater-browser-http.HttpError
 pub async fn Browser::activate_focused_link(Self) -> Bool raise @crater-browser-http.HttpError
 pub async fn Browser::activate_link_at(Self, Int, Int) -> Bool raise @crater-browser-http.HttpError
+pub fn Browser::cascade_reuse_last_count(Self) -> Int
 pub fn Browser::cookie_jar(Self) -> @cookie_jar.CookieJar
 pub fn Browser::debug_layout(Self) -> Unit
 pub fn Browser::enter_hint_mode(Self) -> Unit
@@ -54,6 +55,7 @@ pub fn Browser::render_text_full_page(Self) -> String
 pub fn Browser::run_event_loop(Self, max_iterations? : Int) -> Bool
 pub fn Browser::scroll_down(Self, Int) -> Unit
 pub fn Browser::scroll_up(Self, Int) -> Unit
+pub fn Browser::set_cascade_reuse(Self, Bool) -> Unit
 pub fn Browser::set_dark_mode(Self, Bool) -> Unit
 pub fn Browser::set_enable_cookies(Self, Bool) -> Unit
 pub fn Browser::set_enable_js(Self, Bool) -> Unit

--- a/browser/shell/render_cache.mbt
+++ b/browser/shell/render_cache.mbt
@@ -65,7 +65,83 @@ fn Browser::render_node_from_document(
   dark : Bool,
 ) -> @layout.Node {
   let prepared = self.prepare_render_document_for_context(doc, ctx, dark)
+  // Incremental (scoped) cascade — Phase 1, off by default. Only when the
+  // stylesheet is reuse-safe do we run a reuse pass; prior styles are reused
+  // only when the CSS signature is unchanged (a CSS edit resets the maps).
+  if self.enable_cascade_reuse {
+    let css_texts = self.cascade_reuse_css_texts()
+    if css_texts.length() > 0 && @renderer.css_allows_cascade_reuse(css_texts) {
+      let css_sig = css_texts.join("\u{01}")
+      let use_prior = self.cascade_reuse_prev_css_sig == Some(css_sig)
+      @renderer.cascade_reuse_begin(
+        if use_prior {
+          self.cascade_reuse_prior_styles
+        } else {
+          {}
+        },
+        if use_prior {
+          self.cascade_reuse_prior_sigs
+        } else {
+          {}
+        },
+      )
+      let node = @renderer.build_render_root_node(doc, ctx, prepared)
+      let (styles, sigs, reused) = @renderer.cascade_reuse_end()
+      self.cascade_reuse_prior_styles = styles
+      self.cascade_reuse_prior_sigs = sigs
+      self.cascade_reuse_prev_css_sig = Some(css_sig)
+      self.cascade_reuse_last_count = reused
+      return node
+    }
+  }
   @renderer.build_render_root_node(doc, ctx, prepared)
+}
+
+///|
+/// The CSS texts that drive the cascade: external stylesheets plus any inline
+/// `<style>` blocks in the current document. Used both to gate cascade reuse
+/// (reuse-safe selectors only) and to signature the stylesheet so a CSS edit
+/// invalidates the reused styles. Body text is deliberately excluded so a
+/// text-only mutation keeps the same signature.
+fn Browser::cascade_reuse_css_texts(self : Browser) -> Array[String] {
+  let texts : Array[String] = []
+  for css in self.external_css {
+    texts.push(css)
+  }
+  extract_style_blocks(self.html_content, texts)
+  texts
+}
+
+///|
+/// Append the inner text of each `<style>…</style>` block in `html` to `out`.
+/// A simple scan, case-insensitive on the tag name and tolerant of attributes
+/// on the open tag. Anything unparsed just means no reuse (conservative).
+fn extract_style_blocks(html : String, out : Array[String]) -> Unit {
+  let lower = html.to_lower()
+  let n = lower.length()
+  let mut base = 0
+  while base < n {
+    match lower.substring(start=base).find("<style") {
+      Some(rel_open) => {
+        let open = base + rel_open
+        match lower.substring(start=open).find(">") {
+          Some(rel_gt) => {
+            let gt = open + rel_gt
+            match lower.substring(start=gt).find("</style") {
+              Some(rel_close) => {
+                let close = gt + rel_close
+                out.push(html.substring(start=gt + 1, end=close))
+                base = close + 1
+              }
+              None => break
+            }
+          }
+          None => break
+        }
+      }
+      None => break
+    }
+  }
 }
 
 ///|

--- a/browser/shell/render_cache.mbt
+++ b/browser/shell/render_cache.mbt
@@ -84,6 +84,7 @@ fn Browser::render_node_from_document(
         } else {
           {}
         },
+        uses_sibling=@renderer.css_uses_sibling_combinator(css_texts),
       )
       let node = @renderer.build_render_root_node(doc, ctx, prepared)
       let (styles, sigs, reused) = @renderer.cascade_reuse_end()

--- a/browser/shell/render_cache.mbt
+++ b/browser/shell/render_cache.mbt
@@ -85,6 +85,7 @@ fn Browser::render_node_from_document(
           {}
         },
         uses_sibling=@renderer.css_uses_sibling_combinator(css_texts),
+        uses_child_structure=@renderer.css_uses_child_structure(css_texts),
       )
       let node = @renderer.build_render_root_node(doc, ctx, prepared)
       let (styles, sigs, reused) = @renderer.cascade_reuse_end()

--- a/browser/shell/state.mbt
+++ b/browser/shell/state.mbt
@@ -162,6 +162,17 @@ struct Browser {
   /// see docs/incremental-reflow-design.md). `set_incremental_reflow(false)`
   /// opts back into a full rebuild every render.
   mut enable_incremental_reflow : Bool
+  /// Incremental (scoped) cascade — Phase 1, **off by default**. When on, a
+  /// reflow whose stylesheet is reuse-safe reuses prior computed styles for
+  /// unchanged subtrees instead of re-cascading. See
+  /// docs/incremental-cascade-design.md. The prior maps are keyed by the
+  /// renderer's `owner_id`; `cascade_reuse_prev_css_sig` invalidates them on a
+  /// stylesheet edit.
+  mut enable_cascade_reuse : Bool
+  mut cascade_reuse_prior_styles : Map[String, @style.Style]
+  mut cascade_reuse_prior_sigs : Map[String, String]
+  mut cascade_reuse_prev_css_sig : String?
+  mut cascade_reuse_last_count : Int
   /// Previous TUI buffer for diff rendering
   mut prev_buffer : @tui.CharBuffer?
   /// Last render key (for diff invalidation)
@@ -263,6 +274,11 @@ pub fn Browser::new(
     incremental_prev_tree: None,
     incremental_prev_node: None,
     enable_incremental_reflow: true,
+    enable_cascade_reuse: false,
+    cascade_reuse_prior_styles: {},
+    cascade_reuse_prior_sigs: {},
+    cascade_reuse_prev_css_sig: None,
+    cascade_reuse_last_count: 0,
     prev_buffer: None,
     last_render_key: "",
     last_color_scheme_dark: false,

--- a/docs/incremental-cascade-design.md
+++ b/docs/incremental-cascade-design.md
@@ -1,0 +1,197 @@
+# Design: incremental (scoped) cascade for the dynamic-rendering path
+
+Status: **proposal / design phase.** This is the explicitly-deferred next lever
+named in `docs/incremental-reflow-design.md` ("Risks / open questions → *Cascade
+still O(n)* … a later phase could scope cascade with the mutation set + selector
+dependencies"; "The remaining ceiling is the **cascade**"). Layout is already
+incremental and default-on; this document designs making the **style cascade**
+incremental too.
+
+## Where the cost is now (measured)
+
+After the incremental-layout work landed, a dynamic re-render on a `domOps`
+batch does, per `browser/shell/render_cache.mbt`:
+
+1. `prepare_render_document_for_context` — CSS parse + selector indexing.
+   **Cached** across reflows (keyed on dark mode).
+2. `render_node_from_document` → `@renderer.build_render_root_node(doc, ctx,
+   prepared)` — **the full per-element cascade, re-run every reflow.**
+3. `build_dynamic_layout_tree` — **incremental**: stable uids, `reconcile_from`,
+   `Style::layout_eq` dirty seed, block-flow memoization. Only dirty subtrees
+   recompute.
+
+Profiling the native reflow path (paint-only recolor branch that reuses layout,
+`benchmarks/reflow_profile`, 20 iters under callgrind) shows the split starkly:
+
+| phase | inclusive Ir | note |
+|---|---|---|
+| `build_render_root_node` (cascade) | ~everything | `StyleBuilder::build` runs O(n) per reflow |
+| `from_node_and_layout` (paint rebuild) | 0.17% | local, negligible |
+| `diff_trees` (paint diff) | 0.16% | local, negligible |
+
+~59% of the reflow is memory-management churn (`moonbit_drop_object`,
+`ref_child_slot_at`, `ref_child_count`, malloc/free) — the allocate-then-drop of
+a fresh styled `Node` tree — and almost all of the remaining app work is the
+cascade itself (`mizchi/css` `StyleBuilder`, selector matching). So **cascade is
+now the reflow ceiling**, exactly as the reflow design predicted.
+
+The single most common dynamic mutation — a UI framework updating text
+(`textContent` / `CharacterData`) — currently pays this full O(n) cascade even
+though it changes **zero** computed styles (barring `:empty`/`:blank`; see
+below).
+
+## The correctness invariant (unchanged, and it's the whole difficulty)
+
+A mutation on node *X* can change the *computed* style of a **different** node
+*Y* through a selector combinator. The `mizchi/css` matcher supports the full
+range that makes this true — confirmed in-tree:
+
+- `:has()` (relational — an ancestor/anywhere dependency),
+- `:nth-child` / `:nth-of-type` / `:first-child` / `:last-child`,
+- next-sibling (`+`) and subsequent-sibling (`~`) combinators,
+- `:empty` / `:blank` (depend on **child/text presence**, so even a text or
+  child-list mutation can flip a match).
+
+Today's reflow is correct **because the cascade stays full** and the dirty seed
+is computed by diffing the freshly-cascaded computed `@style.Style`
+(`node_layout_inputs_equal` in `incremental_reflow.mbt`), which already reflects
+every combinator. Any cascade-scoping must preserve this: **the set of nodes we
+re-cascade (or skip) must be a provable superset of the nodes whose computed
+style could change.** Under-cascading = silently stale styles. This is the same
+failure mode the reflow doc flags for the mutation queue ("*not* a safe
+substitute for the style diff").
+
+## Design principle: stylesheet-derived guards, conservative fallback
+
+Rather than a full Blink-style invalidation-set engine up front, exploit a cheap
+fact: **what a mutation *can* invalidate is bounded by what the stylesheet's
+selectors actually reference.** Precompute, once per prepared stylesheet (cached
+alongside `PreparedRenderDocument`), a small set of guard flags / maps:
+
+- `uses_empty_or_blank : Bool` — any selector contains `:empty`/`:blank`.
+- `uses_sibling_combinator : Bool` — any `+` or `~`.
+- `uses_nth_or_position : Bool` — any `:nth-*`/`:first/last-child`/`:only-*`.
+- `uses_has : Bool` — any `:has()`.
+- `classes_in_selectors : Set[String]`, `attrs_in_selectors : Set[String]`,
+  `ids_in_selectors : Set[String]` — the class / attribute / id names any
+  selector keys on (including inside `:has()` / combinators).
+
+These are derived from the already-parsed, already-indexed selector set, so the
+computation is one pass over the stylesheet at prepare time — amortized to ~0 per
+reflow (the prepared doc is cached). When any guard can't be reasoned about,
+**fall back to the current full cascade** — correctness never depends on the
+optimization firing.
+
+## Phasing (value / risk ordered)
+
+### Phase 1 — whole-batch cascade *skip* for provably-inert mutations (recommended first)
+
+Target the dominant case: a `domOps` batch that only changes **text**
+(`CharacterData`) and touches **no** class/attribute/structure that any selector
+depends on.
+
+A text-only batch changes zero computed styles **iff** the stylesheet does not
+use `:empty`/`:blank` (a text edit can flip `:empty`; a combinator can then
+propagate it). So:
+
+```
+batch_is_cascade_inert(batch, guards) =
+  every record is CharacterData
+  && not guards.uses_empty_or_blank
+  && (no record adds/removes a node — pure text edits, not childList)
+```
+
+When inert, **skip `build_render_root_node` entirely.** Reuse the prior
+cascaded node tree (`incremental_prev_node`) and patch only the changed text onto
+the corresponding nodes (matched by `dom_id` → uid, the identity plumbing phase A
+already provides). Feed the patched tree to the existing `reconcile_from`; the
+`Style::layout_eq` seed will (correctly) flag only the text-changed nodes, and
+block-flow memoization reuses everything else — the layout path is unchanged.
+
+- **Win:** removes the entire O(n) cascade for the most frequent mutation kind.
+  Given cascade ≈ the whole reflow today, a text-only reflow should drop toward
+  the cost of re-laying-out the one changed text subtree — a several-fold reflow
+  speedup on framework-driven text churn.
+- **Risk:** low and *bounded by a single guard flag*. If the sheet uses
+  `:empty`/`:blank`, or the batch isn't pure-text, fall back to full cascade.
+- **Cost:** shell plumbing + a text-patch over the reused node tree. No change to
+  `mizchi/css`.
+
+### Phase 2 — class/attribute invalidation scoping
+
+For an attribute/class edit on element *E*: if the changed name is **not** in
+`classes_in_selectors` / `attrs_in_selectors`, no selector matches on it →
+computed styles are unchanged everywhere → skip cascade (same reuse path as
+Phase 1). If it *is* referenced, re-cascade a **scope**: *E*'s subtree, plus
+combinator-reachable neighbours when `uses_sibling_combinator` /
+`uses_nth_or_position` / `uses_has` are set (else just *E*'s subtree). Everything
+outside the scope reuses prior computed styles.
+
+- **Win:** covers class-toggle theming / state changes without a full cascade.
+- **Risk:** medium — the "scope" must be a correct superset. The guard flags let
+  us widen conservatively (e.g. any `:has()` in the sheet ⇒ scope widens to the
+  document ⇒ effectively Phase-1-only for that sheet, still correct).
+
+### Phase 3 — full descendant/sibling/:has invalidation sets (Blink-style)
+
+Precompute per-feature invalidation sets from selectors and apply them per
+mutation. Largest win on complex apps, largest engineering + correctness
+surface. **Likely not worth it** relative to Phase 1+2 for crater's targets;
+list it for completeness and defer.
+
+## Where it hooks
+
+- Guard computation: alongside `prepare_render_document*` (cache on the prepared
+  doc), in `renderer` or `browser/shell/render_cache.mbt`.
+- Skip/scope decision + node-tree reuse: `Browser::render_node_from_document`
+  (`render_cache.mbt`) and `Browser::build_dynamic_layout_tree`
+  (`incremental_reflow.mbt`), which already hold `incremental_prev_node` and the
+  uid registry.
+- The DomTree mutation queue (`dom/dom/mutation.mbt`,
+  `MutationRecord::affects_layout`) supplies the per-record classification the
+  batch predicate consumes — as a *refinement on top of* the correct guard, never
+  a replacement (per the reflow doc's warning).
+
+## Validation (js target, no V8)
+
+Reuse the existing equivalence harness pattern: incremental result must be
+**byte-identical** to a full from-scratch recompute, per mutation kind
+(`browser/shell/incremental_reflow_wbtest.mbt`, `renderer/vrt`
+`RenderSession::branch_*`). Add:
+
+1. A "cascade skipped" counter (like `block_flow_cache_hit_count`) so a test can
+   assert the fast path actually engaged — otherwise a silently-disabled skip
+   looks like a pass.
+2. Golden equality per kind: text-only, text-only **with** a `:empty` rule
+   present (must fall back and still match), class toggle referenced vs
+   unreferenced by a selector, sibling-combinator case, `:has()` case, append /
+   remove / move.
+3. A fuzz-ish mutation sequence asserting incremental == full throughout.
+
+## Risks / open questions
+
+- **`:empty`/`:blank` + text/childList** — handled by `uses_empty_or_blank`
+  (fall back). This is the one non-obvious text-mutation hazard; the guard makes
+  it safe.
+- **`:has()`** — a relational dependency that can reach anywhere; `uses_has`
+  forces conservative widening (document scope) in Phase 2.
+- **Generated / anonymous boxes** — no `dom_id`; reuse must keep them attached to
+  their owning element's reused subtree (the reflow doc's deterministic-uid note
+  applies).
+- **Shadow DOM / slots** — `sync_render_state`'s shadow path should fall back to
+  full cascade until covered, matching the reflow phase-2 stance.
+- **CSS custom properties / `var()`** — a `--x` change on `:root` can affect any
+  consumer; treat a custom-property mutation as non-inert (fall back) unless a
+  dependency map is added later.
+
+## Recommended scope for the first change
+
+**Phase 1 only**, as one landable step: guard computation + text-only inert-batch
+detection + prior-node-tree reuse with text patching, gated behind the existing
+`enable_incremental_reflow` flag and the guard fallback, with the js-target
+equivalence tests above (including the "skip actually engaged" counter and the
+`:empty` fallback case). Defer Phases 2–3 to follow-up PRs.
+
+Per `CLAUDE.md`, this multi-PR workstream should get a `pkspec` scenario
+(`diagnostic.*` / `protocol.*` family) filed from day one so each PR backlinks to
+it; `TODO.md` gets a row under the appropriate priority.

--- a/docs/incremental-cascade-design.md
+++ b/docs/incremental-cascade-design.md
@@ -12,8 +12,28 @@ when every preceding sibling is also clean, so a changed preceding sibling that
 flips an `X + this` match correctly recomputes `this`. This also removes the
 Phase-1 false-positive where a `calc(a + b)` value disabled reuse. It stays off
 by default pending a native-V8 dynamic round-trip sign-off (same bar incremental
-layout held). Phase 3 (full descendant/`:has`/positional-from-end/`:empty`
-invalidation) remains future work.
+layout held).
+
+**Phase 3** relaxes the guard to allow **positional-from-start** selectors
+(`:first-child`, `:nth-child(...)`): a sibling inserted *before* an element
+shifts its `owner_id` (child index) so it recomputes, while one inserted *after*
+leaves its from-start position — and its key — unchanged, so reuse stays correct
+without new machinery. The remaining unsafe set (positional-from-**end** / only
+/ of-type, `:has`, `:empty`/`:blank`, `:focus-within`, pseudo-elements) needs
+per-feature invalidation (a subtree-clean pass for `:has`, a child-presence
+signature for `:empty`, a parent-child-list gate for from-end/of-type) and is
+deferred to Phase 4.
+
+**Flag-on readiness.** Correctness is covered offline on the js target
+(`browser/shell/cascade_reuse_wbtest.mbt` — text edit, `:empty` fallback, class
+change, ancestor-combinator invalidation, sibling-combinator invalidation,
+`calc()` non-disable, `:first-child` prepend invalidation) and the win is
+measured (−14.7%). The remaining gate before `set_cascade_reuse` goes default-on
+is the **native-V8 dynamic round-trip**: `testing/e2e/native_v8`
+"E2E: cascade reuse matches a full rebuild on the dynamic JS path" enables the
+flag on the real script-driven mutation path and asserts equivalence to a full
+rebuild — the same sign-off incremental layout used. (That suite is V8-gated, so
+it runs in the native-V8 CI job / a V8 environment, not the no-v8 sandbox.)
 
 This is the explicitly-deferred next lever
 named in `docs/incremental-reflow-design.md` ("Risks / open questions → *Cascade

--- a/docs/incremental-cascade-design.md
+++ b/docs/incremental-cascade-design.md
@@ -1,6 +1,15 @@
 # Design: incremental (scoped) cascade for the dynamic-rendering path
 
-Status: **proposal / design phase.** This is the explicitly-deferred next lever
+Status: **Phase 1 landed (off by default).** The scoped-cascade reuse of Phase 1
+below is implemented (`renderer/renderer/cascade_reuse.mbt`, wired in
+`browser/shell`, `set_cascade_reuse`), js-equivalence-tested, and measured:
+`benchmarks/cascade_reuse_profile` A/B on the renderer reflow path (90 blocks,
+~360 elements, ~80% clean) shows the cascade drop from **2.57s → 2.19s (−14.7%)**
+median wall-clock. It stays off by default pending a native-V8 dynamic
+round-trip sign-off (same bar incremental layout held). Phases 2–3 remain
+future work.
+
+This is the explicitly-deferred next lever
 named in `docs/incremental-reflow-design.md` ("Risks / open questions → *Cascade
 still O(n)* … a later phase could scope cascade with the mutation set + selector
 dependencies"; "The remaining ceiling is the **cascade**"). Layout is already

--- a/docs/incremental-cascade-design.md
+++ b/docs/incremental-cascade-design.md
@@ -18,11 +18,17 @@ layout held).
 (`:first-child`, `:nth-child(...)`): a sibling inserted *before* an element
 shifts its `owner_id` (child index) so it recomputes, while one inserted *after*
 leaves its from-start position — and its key — unchanged, so reuse stays correct
-without new machinery. The remaining unsafe set (positional-from-**end** / only
-/ of-type, `:has`, `:empty`/`:blank`, `:focus-within`, pseudo-elements) needs
-per-feature invalidation (a subtree-clean pass for `:has`, a child-presence
-signature for `:empty`, a parent-child-list gate for from-end/of-type) and is
-deferred to Phase 4.
+without new machinery. **Phase 4** adds `:empty`/`:blank` and positional-from-**end** / only / of-type
+(`:last-child`, `:only-child`, `:nth-last-*`, `*-of-type`) via one mechanism: a
+**child-structure summary** appended to an element's signature
+(`css_uses_child_structure`). It captures the two things those selectors read —
+(a) the element's own emptiness/blankness (`:empty`/`:blank`), and (b), through
+the *parent's* summary reaching children via the ancestor-clean chain, the
+child list a from-end/of-type match depends on (count, order, tags). A
+non-whitespace text edit keeps the same summary shape, so text-edit reuse is
+preserved. Only **`:has`** (arbitrary-depth descendant dependency — needs a
+subtree-clean pre-pass), **`:focus-within`** (descendant focus state), and
+**pseudo-elements** remain disqualified.
 
 **Flag-on readiness.** Correctness is covered offline on the js target
 (`browser/shell/cascade_reuse_wbtest.mbt` — text edit, `:empty` fallback, class

--- a/docs/incremental-cascade-design.md
+++ b/docs/incremental-cascade-design.md
@@ -1,13 +1,19 @@
 # Design: incremental (scoped) cascade for the dynamic-rendering path
 
-Status: **Phase 1 landed (off by default).** The scoped-cascade reuse of Phase 1
-below is implemented (`renderer/renderer/cascade_reuse.mbt`, wired in
-`browser/shell`, `set_cascade_reuse`), js-equivalence-tested, and measured:
+Status: **Phases 1 & 2 landed (off by default).** The scoped-cascade reuse is
+implemented (`renderer/renderer/cascade_reuse.mbt`, wired in `browser/shell`,
+`set_cascade_reuse`), js-equivalence-tested, and measured:
 `benchmarks/cascade_reuse_profile` A/B on the renderer reflow path (90 blocks,
 ~360 elements, ~80% clean) shows the cascade drop from **2.57s → 2.19s (−14.7%)**
-median wall-clock. It stays off by default pending a native-V8 dynamic
-round-trip sign-off (same bar incremental layout held). Phases 2–3 remain
-future work.
+median wall-clock. **Phase 2** extends the reuse-safe set to **sibling
+combinators (`+`/`~`)** via a preceding-sibling-clean gate
+(`css_uses_sibling_combinator`) — an element under a `+`/`~` sheet may only reuse
+when every preceding sibling is also clean, so a changed preceding sibling that
+flips an `X + this` match correctly recomputes `this`. This also removes the
+Phase-1 false-positive where a `calc(a + b)` value disabled reuse. It stays off
+by default pending a native-V8 dynamic round-trip sign-off (same bar incremental
+layout held). Phase 3 (full descendant/`:has`/positional-from-end/`:empty`
+invalidation) remains future work.
 
 This is the explicitly-deferred next lever
 named in `docs/incremental-reflow-design.md` ("Risks / open questions → *Cascade

--- a/docs/incremental-cascade-design.md
+++ b/docs/incremental-cascade-design.md
@@ -195,3 +195,96 @@ equivalence tests above (including the "skip actually engaged" counter and the
 Per `CLAUDE.md`, this multi-PR workstream should get a `pkspec` scenario
 (`diagnostic.*` / `protocol.*` family) filed from day one so each PR backlinks to
 it; `TODO.md` gets a row under the appropriate priority.
+
+## Implementation plan — as scoped against the current code
+
+Tracing the shell reflow path pins down the exact mechanism and its one real
+hazard, so Phase 1 can be built without guesswork.
+
+### Reflow flow today (where the cascade actually runs)
+
+`Browser::render_text` / `render_text_full_page` (`browser/shell/text_renderer.mbt`):
+
+1. If `render_node` **and** `layout_tree` are cached → reuse (no rebuild). This is
+   the no-op re-render short-circuit.
+2. Otherwise (a mutation called `clear_render_cache`, dropping both):
+   - `render_node_from_document(doc)` → `@renderer.build_render_root_node` — **the
+     full O(n) cascade**;
+   - `build_dynamic_layout_tree(n)` (`incremental_reflow.mbt`) → stabilizes uids,
+     reconciles against `incremental_prev_node`, incremental layout.
+
+So the cascade to skip is step 2's `build_render_root_node`, and the reuse source
+is `incremental_prev_node` (the prior styled tree, already retained).
+
+### Landed identity infrastructure (Phase A — usable now)
+
+`Node` already carries `mut uid` (stabilized across rebuilds via
+`@node.stabilize_uids` + `UidRegistry`) and `mut dom_id : Int?`. So a prior
+computed `@style.Style` can be keyed by stabilized `uid` and matched on the next
+rebuild.
+
+### The mechanism (and the hazard that picks it)
+
+Reusing `incremental_prev_node` **wholesale** is wrong: its text nodes hold the
+*old* text, and render trees contain generated / anonymous / inline-split nodes
+with no 1:1 mapping back to DOM text, so "patch the new text in" is not a safe
+local edit.
+
+Therefore the safe mechanism is: **rebuild the node-tree structure from the
+current document (cheap — element→node, text→text node, generated content handled
+by the existing builder), but for each element reuse its prior computed
+`@style.Style` (keyed by stabilized uid) instead of re-running selector matching +
+`StyleBuilder`, whenever that element's cascade result is provably unchanged.**
+
+An element's cascade result is provably unchanged when:
+
+- the stylesheet is guard-clean for the mutation class (for a pure-text edit:
+  `not uses_empty_or_blank`), **and**
+- the element's own cascade inputs (tag, id, class list, matched attributes,
+  inline `style`) are unchanged vs the prior render, **and**
+- its inherited context (parent's reused computed style) is unchanged.
+
+Per-element input comparison is cheap string compares vs the expensive selector
+match it replaces — a net win. New / input-changed elements fall back to a normal
+per-element cascade; the whole optimization degrades to today's full cascade when
+nothing qualifies.
+
+### Concrete pieces
+
+1. **Guard** (`renderer` or `browser/shell`): `css_uses_empty_or_blank(sheets,
+   inline_style_blocks) -> Bool`, a conservative substring scan for `:empty` /
+   `:blank` over the stylesheet text (`self.external_css` + `<style>` blocks in
+   `html_content`). Over-conservative (a literal match forces fallback) = always
+   safe. Cache on the prepared document.
+2. **Prior inputs** to compare against: keep the prior `@html.Document` (or a
+   per-`dom_id` signature of tag/id/class/attr/inline) beside
+   `incremental_prev_node`.
+3. **Style-reusing node build**: a `build_render_root_node` variant taking a
+   `Map[uid, @style.Style]` (prior styles) + the prior-input signature; it builds
+   structure from the current doc and, per element, reuses the prior style when
+   inputs match and the guard holds, else cascades that element.
+4. **Shell wiring**: in step 2 above, when the flag is on, the guard holds, and
+   `incremental_prev_node` exists, take the style-reusing build instead of the
+   full cascade; feed the result to `build_dynamic_layout_tree` unchanged.
+5. **Skip-engaged counter**: `cascade_reused_uid_count()` (mirroring
+   `block_flow_cache_hit_count`) so a test asserts the fast path fired — a
+   silently-disabled skip must not read as a pass.
+
+### Validation boundary
+
+The js-target equivalence harness (`incremental_reflow_wbtest.mbt`) drives reflow
+via `set_html_content` through the **same** `render_node_from_document` →
+`build_dynamic_layout_tree` flow the V8 dynamic path uses, so incremental-with-skip
+== full-rebuild is checkable in-sandbox, no V8: add per-kind goldens (pure-text
+reuse; pure-text **with** a `:empty` rule present → must fall back and still
+match; class/attr change → element re-cascades; append/remove/move) plus the
+counter assertion. The native-V8 dynamic round-trip stays the final real-env
+sign-off (as for incremental layout), but correctness is a pure render property
+the js harness already exercises.
+
+### Why this is staged as its own PR, not folded into a perf sweep
+
+It touches the **core render path** and its failure mode is a *silent* stale-style
+render, so it needs its own focused change + the equivalence goldens above before
+default-on — the same bar (and off-by-default flag `enable_incremental_reflow`
+gating) the incremental-layout work held itself to.

--- a/painter/paint/raster/framebuffer_encode.mbt
+++ b/painter/paint/raster/framebuffer_encode.mbt
@@ -49,14 +49,53 @@ fn framebuffer_to_rgba_base64_js(
   palette_g : Array[Int],
   palette_b : Array[Int],
 ) -> String {
-  let rgba : Array[Int] = []
-  for idx in pixels {
-    rgba.push(palette_r[idx])
-    rgba.push(palette_g[idx])
-    rgba.push(palette_b[idx])
-    rgba.push(255)
+  // Fuse the RGBA expansion into the base64 loop instead of materializing an
+  // ~n*4-int RGBA buffer first: that intermediate was pure memory-bandwidth
+  // cost for a full-viewport screenshot (the BiDi captureScreenshot path).
+  // RGBA is 4 bytes/pixel and base64 groups 3 bytes, and lcm(4,3)=12 bytes =
+  // 3 pixels = 4 base64 quads, so whole groups of 3 pixels land exactly on a
+  // base64 group boundary with no carry. Keep the plain (incrementally grown)
+  // StringBuilder — eagerly presizing it to the multi-MB output measured slower
+  // (worse cache/paging) than incremental growth.
+  let n = pixels.length()
+  let out = StringBuilder::new()
+  let full = n / 3
+  for g = 0; g < full; g = g + 1 {
+    let i = g * 3
+    let p0 = pixels[i]
+    let p1 = pixels[i + 1]
+    let p2 = pixels[i + 2]
+    let r0 = palette_r[p0]
+    let g0 = palette_g[p0]
+    let b0 = palette_b[p0]
+    let r1 = palette_r[p1]
+    let g1 = palette_g[p1]
+    let b1 = palette_b[p1]
+    let r2 = palette_r[p2]
+    let g2 = palette_g[p2]
+    let b2 = palette_b[p2]
+    // Bytes r0 g0 b0 | 255 r1 g1 | b1 255 r2 | g2 b2 255 -> four base64 quads.
+    write_base64_quad(out, r0, g0, b0, 0)
+    write_base64_quad(out, 255, r1, g1, 0)
+    write_base64_quad(out, b1, 255, r2, 0)
+    write_base64_quad(out, g2, b2, 255, 0)
   }
-  encode_bytes_base64(rgba)
+  // Tail: the last n % 3 pixels (0, 1 or 2) form up to 8 RGBA bytes. `full * 3`
+  // pixels is `full * 12` bytes (a multiple of 3), so the stream splits cleanly
+  // here; encode the remainder on its own (it carries the base64 padding).
+  let rem = n - full * 3
+  if rem > 0 {
+    let tail : Array[Int] = []
+    for k = full * 3; k < n; k = k + 1 {
+      let p = pixels[k]
+      tail.push(palette_r[p])
+      tail.push(palette_g[p])
+      tail.push(palette_b[p])
+      tail.push(255)
+    }
+    out.write_string(encode_bytes_base64(tail))
+  }
+  out.to_string()
 }
 
 ///|

--- a/painter/paint/raster/framebuffer_encode_wbtest.mbt
+++ b/painter/paint/raster/framebuffer_encode_wbtest.mbt
@@ -1,0 +1,31 @@
+///|
+/// The non-JS `framebuffer_to_rgba_base64_js` fuses RGBA expansion into the
+/// base64 loop (encoding 3 pixels / 12 bytes at a time). Prove it stays byte-
+/// identical to the straightforward "expand to an RGBA array, then encode"
+/// reference for every pixel-count remainder (n % 3 in {0, 1, 2}), including the
+/// tail path. JS uses a separate Buffer-based extern, so guard this to non-JS.
+#cfg(not(target="js"))
+test "fused framebuffer base64 matches rgba-expansion reference" {
+  let palette_r = [10, 20, 30, 255, 0]
+  let palette_g = [40, 50, 60, 255, 0]
+  let palette_b = [70, 80, 90, 255, 0]
+  let palette_len = palette_r.length()
+  for n = 1; n <= 12; n = n + 1 {
+    let pixels : Array[Int] = []
+    for i = 0; i < n; i = i + 1 {
+      pixels.push(i % palette_len)
+    }
+    let fused = framebuffer_to_rgba_base64_js(
+      pixels, palette_r, palette_g, palette_b,
+    )
+    let rgba : Array[Int] = []
+    for idx in pixels {
+      rgba.push(palette_r[idx])
+      rgba.push(palette_g[idx])
+      rgba.push(palette_b[idx])
+      rgba.push(255)
+    }
+    let reference = encode_bytes_base64(rgba)
+    assert_eq(fused, reference)
+  }
+}

--- a/renderer/renderer/cascade_reuse.mbt
+++ b/renderer/renderer/cascade_reuse.mbt
@@ -1,25 +1,30 @@
 ///|
-// Incremental (scoped) cascade — Phase 1. See docs/incremental-cascade-design.md.
+// Incremental (scoped) cascade — Phases 1 & 2. See
+// docs/incremental-cascade-design.md.
 //
 // A dynamic re-render rebuilds the styled node tree from the mutated document
 // and re-runs the full O(n) cascade even when almost nothing changed. When the
 // shell installs a prior-style map (via `cascade_reuse_begin`) for a reflow
-// whose stylesheet is *reuse-safe* (no sibling/positional/:has/:empty selectors
-// — `css_allows_cascade_reuse`), this lets an element whose own cascade inputs
-// are unchanged **and** whose whole ancestor chain is unchanged reuse its prior
-// computed style instead of re-running selector matching + StyleBuilder.
+// whose stylesheet is *reuse-safe* (`css_allows_cascade_reuse`), this lets an
+// element whose own cascade inputs are unchanged reuse its prior computed style
+// instead of re-running selector matching + StyleBuilder.
 //
 // Correctness (proved inductively):
 //   - key: `owner_id`, the structural path already threaded through the build
 //     (matches the anonymous-node uid scheme), so a stable position ⇒ stable key;
 //   - a node is *clean* iff the stylesheet is reuse-safe, its input signature is
-//     unchanged, and its parent is clean (root is the base case). The clean
-//     chain means every ancestor's inputs are unchanged, so descendant/child
-//     combinators and inherited context (style + css vars) are all unchanged;
-//   - reuse-safe excludes exactly the selectors whose match can flip without a
-//     change in the element's own inputs or its ancestors' inputs: sibling
-//     (`+`/`~`), positional (`:nth`/`:first`/`:last`/`:only`), `:has`,
-//     `:empty`/`:blank`, `:focus-within`.
+//     unchanged, its parent is clean (root is the base case), and — when the
+//     sheet uses a sibling combinator (Phase 2) — every preceding sibling is
+//     clean. The ancestor chain makes descendant/child combinators and inherited
+//     context (style + css vars) safe; the preceding-sibling gate makes `+`/`~`
+//     safe (a changed preceding sibling flips an `X + this` / `X ~ this` match);
+//   - reuse-safe (`css_allows_cascade_reuse`) still excludes the selectors whose
+//     match can flip without a change captured by the owner_id / ancestor /
+//     preceding-sibling model: positional-from-end / only / of-type (a sibling
+//     appended after an element flips its match without changing its key), `:has`
+//     (descendant dependency), `:empty`/`:blank` (child/text presence), and
+//     `:focus-within`. `css_uses_sibling_combinator` flags `+`/`~` so the
+//     preceding-sibling gate turns on;
 //   - the stylesheet itself must be unchanged — the shell only passes a prior
 //     map when the CSS signature matches (a CSS edit resets the map).
 //
@@ -33,6 +38,13 @@ priv struct CascadeReuseCtx {
   new_styles : Map[String, @style.Style]
   new_sigs : Map[String, String]
   clean : Map[String, Bool]
+  // Phase 2: when the stylesheet uses a sibling combinator (`+`/`~`), an
+  // element's match can depend on a preceding sibling, so it may only reuse when
+  // every preceding sibling (same parent) is also clean. `preceding_clean` is the
+  // running AND of the direct children's cleanliness, keyed by parent owner_id;
+  // children are entered left-to-right so it is complete for each next sibling.
+  uses_sibling : Bool
+  preceding_clean : Map[String, Bool]
   mut reused : Int
 }
 
@@ -48,6 +60,7 @@ let cascade_reuse_ctx : Ref[CascadeReuseCtx?] = { val: None }
 pub fn cascade_reuse_begin(
   prior_styles : Map[String, @style.Style],
   prior_sigs : Map[String, String],
+  uses_sibling? : Bool = false,
 ) -> Unit {
   cascade_reuse_ctx.val = Some({
     prior_styles,
@@ -55,6 +68,8 @@ pub fn cascade_reuse_begin(
     new_styles: {},
     new_sigs: {},
     clean: {},
+    uses_sibling,
+    preceding_clean: {},
     reused: 0,
   })
 }
@@ -137,21 +152,49 @@ fn cascade_reuse_try(owner_id : String, elem : @html.Element) -> @style.Style? {
     Some(ctx) => {
       let sig = cascade_reuse_sig(elem)
       ctx.new_sigs[owner_id] = sig
-      let parent_clean = match cascade_reuse_parent_key(owner_id) {
+      let parent = cascade_reuse_parent_key(owner_id)
+      let parent_clean = match parent {
         None => true // root: no parent constraint
         Some(pk) => ctx.clean.get(pk) is Some(true)
       }
-      if parent_clean && ctx.prior_sigs.get(owner_id) is Some(prior_sig) {
-        if prior_sig == sig {
-          match ctx.prior_styles.get(owner_id) {
-            Some(style) => {
-              ctx.clean[owner_id] = true
-              ctx.new_styles[owner_id] = style
-              ctx.reused += 1
-              return Some(style)
-            }
-            None => ()
+      // Own inputs unchanged and a prior style exists to reuse.
+      let self_clean = match ctx.prior_sigs.get(owner_id) {
+        Some(prior_sig) =>
+          prior_sig == sig && ctx.prior_styles.get(owner_id) is Some(_)
+        None => false
+      }
+      // Sibling gate (Phase 2): with `+`/`~` in the sheet, this element may only
+      // reuse if every preceding sibling is clean (a changed preceding sibling
+      // can flip an `X + this` / `X ~ this` match).
+      let preceding_ok = if ctx.uses_sibling {
+        match parent {
+          None => true
+          Some(pk) => not(ctx.preceding_clean.get(pk) is Some(false))
+        }
+      } else {
+        true
+      }
+      let is_clean = self_clean && parent_clean && preceding_ok
+      // Fold this element into its parent's running preceding-clean AND.
+      match parent {
+        Some(pk) => {
+          let prev = match ctx.preceding_clean.get(pk) {
+            Some(v) => v
+            None => true
           }
+          ctx.preceding_clean[pk] = prev && is_clean
+        }
+        None => ()
+      }
+      if is_clean {
+        ctx.clean[owner_id] = true
+        match ctx.prior_styles.get(owner_id) {
+          Some(style) => {
+            ctx.new_styles[owner_id] = style
+            ctx.reused += 1
+            return Some(style)
+          }
+          None => ()
         }
       }
       None
@@ -176,9 +219,16 @@ fn cascade_reuse_record(owner_id : String, style : @style.Style) -> Unit {
 /// the disqualifying selector features. A false positive (e.g. `+` inside a
 /// `calc()` value) only disables the optimization — never a correctness risk.
 pub fn css_allows_cascade_reuse(texts : Array[String]) -> Bool {
+  // Sibling combinators (`+`/`~`) are NOT disqualifying — they are handled by the
+  // preceding-sibling gate (see `css_uses_sibling_combinator`). The rest create
+  // dependencies the owner_id/ancestor/sibling model does not capture:
+  // positional-from-end / only / of-type (a sibling appended after an element
+  // flips its match without changing its key), `:has` (descendant dependency),
+  // `:empty`/`:blank` (child/text presence), `:focus-within` (descendant focus),
+  // and pseudo-elements.
   let unsafe_tokens = [
-    "+", "~", ":nth", ":has", ":empty", ":blank", ":first-child", ":last-child",
-    ":only-child", "-of-type", ":focus-within", "::",
+    ":nth", ":has", ":empty", ":blank", ":first-child", ":last-child", ":only-child",
+    "-of-type", ":focus-within", "::",
   ]
   for text in texts {
     for tok in unsafe_tokens {
@@ -188,4 +238,18 @@ pub fn css_allows_cascade_reuse(texts : Array[String]) -> Bool {
     }
   }
   true
+}
+
+///|
+/// Whether any CSS text uses a sibling combinator (`+` or `~`). Conservative: a
+/// substring match (so `calc(a + b)` or `[attr~=v]` also counts) — a false
+/// positive only tightens the preceding-sibling gate, never a correctness risk.
+/// When true, cascade reuse requires every preceding sibling to be clean.
+pub fn css_uses_sibling_combinator(texts : Array[String]) -> Bool {
+  for text in texts {
+    if text.contains("+") || text.contains("~") {
+      return true
+    }
+  }
+  false
 }

--- a/renderer/renderer/cascade_reuse.mbt
+++ b/renderer/renderer/cascade_reuse.mbt
@@ -1,8 +1,11 @@
 ///|
-// Incremental (scoped) cascade — Phases 1–3. See
-// docs/incremental-cascade-design.md. (Phase 2 = sibling combinators via the
-// preceding-sibling gate; Phase 3 = positional-from-start `:first-child` /
-// `:nth-child` via owner_id keying — see `css_allows_cascade_reuse`.)
+// Incremental (scoped) cascade — Phases 1–4. See
+// docs/incremental-cascade-design.md. Beyond the base owner_id + ancestor-clean
+// model: Phase 2 = sibling combinators via the preceding-sibling gate; Phase 3 =
+// positional-from-start `:first-child` / `:nth-child` via owner_id keying;
+// Phase 4 = `:empty`/`:blank` and positional-from-end / only / of-type via the
+// child-structure signature. Only `:has`, `:focus-within` and pseudo-elements
+// remain disqualified (see `css_allows_cascade_reuse`).
 //
 // A dynamic re-render rebuilds the styled node tree from the mutated document
 // and re-runs the full O(n) cascade even when almost nothing changed. When the
@@ -47,6 +50,10 @@ priv struct CascadeReuseCtx {
   // children are entered left-to-right so it is complete for each next sibling.
   uses_sibling : Bool
   preceding_clean : Map[String, Bool]
+  // Phase 4: when the sheet uses `:empty`/`:blank` or a positional-from-end /
+  // only / of-type selector, each element's signature includes a summary of its
+  // direct children (see `cascade_reuse_sig`).
+  uses_child_structure : Bool
   mut reused : Int
 }
 
@@ -63,6 +70,7 @@ pub fn cascade_reuse_begin(
   prior_styles : Map[String, @style.Style],
   prior_sigs : Map[String, String],
   uses_sibling? : Bool = false,
+  uses_child_structure? : Bool = false,
 ) -> Unit {
   cascade_reuse_ctx.val = Some({
     prior_styles,
@@ -72,6 +80,7 @@ pub fn cascade_reuse_begin(
     clean: {},
     uses_sibling,
     preceding_clean: {},
+    uses_child_structure,
     reused: 0,
   })
 }
@@ -99,7 +108,10 @@ pub fn cascade_reuse_end() -> (
 /// keys on (tag, id, class list, inline style, attributes). Two renders with the
 /// same signature at the same `owner_id` and a clean parent compute the same
 /// style. Attributes are serialized in sorted order for stability.
-fn cascade_reuse_sig(elem : @html.Element) -> String {
+fn cascade_reuse_sig(
+  elem : @html.Element,
+  include_child_structure : Bool,
+) -> String {
   let buf = StringBuilder::new()
   buf.write_string(elem.tag)
   buf.write_char('|')
@@ -129,6 +141,32 @@ fn cascade_reuse_sig(elem : @html.Element) -> String {
     }
     buf.write_char(';')
   }
+  // Phase 4: when the sheet uses child-structure-dependent selectors, append a
+  // summary of this element's direct children. It captures the two things those
+  // selectors key on: (a) the element's own emptiness / blankness (`:empty` /
+  // `:blank`), and (b) — through the *parent's* summary, which reaches children
+  // via the ancestor-clean chain — the child list a positional-from-end / only /
+  // of-type match reads (count, order, tags). A non-whitespace text edit that
+  // keeps the same shape (`T`) leaves the summary unchanged, so text-edit reuse
+  // is preserved.
+  if include_child_structure {
+    buf.write_char('|')
+    for child in elem.children {
+      match child {
+        @html.Node::Element(e) => {
+          buf.write_string("E:")
+          buf.write_string(e.tag)
+          buf.write_char(';')
+        }
+        @html.Node::Text(t) =>
+          if t.trim().is_empty() {
+            buf.write_char('W')
+          } else {
+            buf.write_char('T')
+          }
+      }
+    }
+  }
   buf.to_string()
 }
 
@@ -152,7 +190,7 @@ fn cascade_reuse_try(owner_id : String, elem : @html.Element) -> @style.Style? {
   match cascade_reuse_ctx.val {
     None => None
     Some(ctx) => {
-      let sig = cascade_reuse_sig(elem)
+      let sig = cascade_reuse_sig(elem, ctx.uses_child_structure)
       ctx.new_sigs[owner_id] = sig
       let parent = cascade_reuse_parent_key(owner_id)
       let parent_clean = match parent {
@@ -228,16 +266,13 @@ pub fn css_allows_cascade_reuse(texts : Array[String]) -> Bool {
   //     inserted before an element shifts its `owner_id` (child index) so it
   //     recomputes; one inserted after leaves its from-start position (and key)
   //     unchanged, so reuse is correct.
-  // Still disqualifying — dependencies the owner_id/ancestor/sibling model does
-  // not capture: positional-from-*end* / only / of-type (`:last-child`,
-  // `:only-child`, `:nth-last-*`, `*-of-type`) — a sibling appended *after* an
-  // element flips its match without changing its key; `:has` (descendant
-  // dependency); `:empty`/`:blank` (child/text presence); `:focus-within`
-  // (descendant focus); pseudo-elements.
-  let unsafe_tokens = [
-    ":nth-last", ":has", ":empty", ":blank", ":last-child", ":only-child", "-of-type",
-    ":focus-within", "::",
-  ]
+  //   - positional-from-*end* / only / of-type (`:last-child`, `:only-child`,
+  //     `:nth-last-*`, `*-of-type`) and `:empty`/`:blank` — handled by the child
+  //     structure summary (see `css_uses_child_structure` / `cascade_reuse_sig`).
+  // Still disqualifying — dependencies not captured by any of the above: `:has`
+  // (arbitrary-depth descendant dependency, needs a subtree-clean pass),
+  // `:focus-within` (descendant focus state), and pseudo-elements.
+  let unsafe_tokens = [":has", ":focus-within", "::"]
   for text in texts {
     for tok in unsafe_tokens {
       if text.contains(tok) {
@@ -246,6 +281,27 @@ pub fn css_allows_cascade_reuse(texts : Array[String]) -> Bool {
     }
   }
   true
+}
+
+///|
+/// Whether any CSS text uses a selector whose match depends on child structure:
+/// `:empty`/`:blank` (own child/text presence) or positional-from-end / only /
+/// of-type (`:last-child`, `:only-child`, `:nth-last-*`, `*-of-type` — read the
+/// parent's child list). When true, each element's reuse signature includes a
+/// summary of its direct children. Conservative substring scan; a false positive
+/// only tightens reuse.
+pub fn css_uses_child_structure(texts : Array[String]) -> Bool {
+  let tokens = [
+    ":empty", ":blank", ":last-child", ":only-child", ":nth-last", "-of-type",
+  ]
+  for text in texts {
+    for tok in tokens {
+      if text.contains(tok) {
+        return true
+      }
+    }
+  }
+  false
 }
 
 ///|

--- a/renderer/renderer/cascade_reuse.mbt
+++ b/renderer/renderer/cascade_reuse.mbt
@@ -1,6 +1,8 @@
 ///|
-// Incremental (scoped) cascade — Phases 1 & 2. See
-// docs/incremental-cascade-design.md.
+// Incremental (scoped) cascade — Phases 1–3. See
+// docs/incremental-cascade-design.md. (Phase 2 = sibling combinators via the
+// preceding-sibling gate; Phase 3 = positional-from-start `:first-child` /
+// `:nth-child` via owner_id keying — see `css_allows_cascade_reuse`.)
 //
 // A dynamic re-render rebuilds the styled node tree from the mutated document
 // and re-runs the full O(n) cascade even when almost nothing changed. When the
@@ -219,16 +221,22 @@ fn cascade_reuse_record(owner_id : String, style : @style.Style) -> Unit {
 /// the disqualifying selector features. A false positive (e.g. `+` inside a
 /// `calc()` value) only disables the optimization — never a correctness risk.
 pub fn css_allows_cascade_reuse(texts : Array[String]) -> Bool {
-  // Sibling combinators (`+`/`~`) are NOT disqualifying — they are handled by the
-  // preceding-sibling gate (see `css_uses_sibling_combinator`). The rest create
-  // dependencies the owner_id/ancestor/sibling model does not capture:
-  // positional-from-end / only / of-type (a sibling appended after an element
-  // flips its match without changing its key), `:has` (descendant dependency),
-  // `:empty`/`:blank` (child/text presence), `:focus-within` (descendant focus),
-  // and pseudo-elements.
+  // NOT disqualifying:
+  //   - sibling combinators (`+`/`~`) — handled by the preceding-sibling gate
+  //     (`css_uses_sibling_combinator`);
+  //   - `:first-child` / `:nth-child(...)` (from the *start*) — a sibling
+  //     inserted before an element shifts its `owner_id` (child index) so it
+  //     recomputes; one inserted after leaves its from-start position (and key)
+  //     unchanged, so reuse is correct.
+  // Still disqualifying — dependencies the owner_id/ancestor/sibling model does
+  // not capture: positional-from-*end* / only / of-type (`:last-child`,
+  // `:only-child`, `:nth-last-*`, `*-of-type`) — a sibling appended *after* an
+  // element flips its match without changing its key; `:has` (descendant
+  // dependency); `:empty`/`:blank` (child/text presence); `:focus-within`
+  // (descendant focus); pseudo-elements.
   let unsafe_tokens = [
-    ":nth", ":has", ":empty", ":blank", ":first-child", ":last-child", ":only-child",
-    "-of-type", ":focus-within", "::",
+    ":nth-last", ":has", ":empty", ":blank", ":last-child", ":only-child", "-of-type",
+    ":focus-within", "::",
   ]
   for text in texts {
     for tok in unsafe_tokens {

--- a/renderer/renderer/cascade_reuse.mbt
+++ b/renderer/renderer/cascade_reuse.mbt
@@ -1,0 +1,191 @@
+///|
+// Incremental (scoped) cascade — Phase 1. See docs/incremental-cascade-design.md.
+//
+// A dynamic re-render rebuilds the styled node tree from the mutated document
+// and re-runs the full O(n) cascade even when almost nothing changed. When the
+// shell installs a prior-style map (via `cascade_reuse_begin`) for a reflow
+// whose stylesheet is *reuse-safe* (no sibling/positional/:has/:empty selectors
+// — `css_allows_cascade_reuse`), this lets an element whose own cascade inputs
+// are unchanged **and** whose whole ancestor chain is unchanged reuse its prior
+// computed style instead of re-running selector matching + StyleBuilder.
+//
+// Correctness (proved inductively):
+//   - key: `owner_id`, the structural path already threaded through the build
+//     (matches the anonymous-node uid scheme), so a stable position ⇒ stable key;
+//   - a node is *clean* iff the stylesheet is reuse-safe, its input signature is
+//     unchanged, and its parent is clean (root is the base case). The clean
+//     chain means every ancestor's inputs are unchanged, so descendant/child
+//     combinators and inherited context (style + css vars) are all unchanged;
+//   - reuse-safe excludes exactly the selectors whose match can flip without a
+//     change in the element's own inputs or its ancestors' inputs: sibling
+//     (`+`/`~`), positional (`:nth`/`:first`/`:last`/`:only`), `:has`,
+//     `:empty`/`:blank`, `:focus-within`.
+//   - the stylesheet itself must be unchanged — the shell only passes a prior
+//     map when the CSS signature matches (a CSS edit resets the map).
+//
+// Everything degrades to a normal full cascade when a node isn't clean, so a
+// miss is never wrong — only slower.
+
+///|
+priv struct CascadeReuseCtx {
+  prior_styles : Map[String, @style.Style]
+  prior_sigs : Map[String, String]
+  new_styles : Map[String, @style.Style]
+  new_sigs : Map[String, String]
+  clean : Map[String, Bool]
+  mut reused : Int
+}
+
+///|
+let cascade_reuse_ctx : Ref[CascadeReuseCtx?] = { val: None }
+
+///|
+/// Start a cascade-reuse pass. `prior_styles` / `prior_sigs` are keyed by
+/// `owner_id` from the previous render (pass empty maps to record-only, i.e. no
+/// reuse). The build records the new styles + signatures; retrieve them with
+/// `cascade_reuse_end` to seed the next reflow. Only call around a
+/// `build_render_root_node` when the stylesheet is unchanged and reuse-safe.
+pub fn cascade_reuse_begin(
+  prior_styles : Map[String, @style.Style],
+  prior_sigs : Map[String, String],
+) -> Unit {
+  cascade_reuse_ctx.val = Some({
+    prior_styles,
+    prior_sigs,
+    new_styles: {},
+    new_sigs: {},
+    clean: {},
+    reused: 0,
+  })
+}
+
+///|
+/// End the pass: returns (new styles by owner_id, new signatures by owner_id,
+/// reused count) and clears the active context. The maps become the next
+/// reflow's prior maps.
+pub fn cascade_reuse_end() -> (
+  Map[String, @style.Style],
+  Map[String, String],
+  Int,
+) {
+  match cascade_reuse_ctx.val {
+    Some(ctx) => {
+      cascade_reuse_ctx.val = None
+      (ctx.new_styles, ctx.new_sigs, ctx.reused)
+    }
+    None => ({}, {}, 0)
+  }
+}
+
+///|
+/// The cascade-input signature of an element: everything a reuse-safe cascade
+/// keys on (tag, id, class list, inline style, attributes). Two renders with the
+/// same signature at the same `owner_id` and a clean parent compute the same
+/// style. Attributes are serialized in sorted order for stability.
+fn cascade_reuse_sig(elem : @html.Element) -> String {
+  let buf = StringBuilder::new()
+  buf.write_string(elem.tag)
+  buf.write_char('|')
+  match elem.id {
+    Some(id) => buf.write_string(id)
+    None => ()
+  }
+  buf.write_char('|')
+  for c in elem.classes {
+    buf.write_string(c)
+    buf.write_char(' ')
+  }
+  buf.write_char('|')
+  match elem.style {
+    Some(s) => buf.write_string(s)
+    None => ()
+  }
+  buf.write_char('|')
+  let keys = elem.attributes.keys().collect()
+  keys.sort()
+  for k in keys {
+    buf.write_string(k)
+    buf.write_char('=')
+    match elem.attributes.get(k) {
+      Some(v) => buf.write_string(v)
+      None => ()
+    }
+    buf.write_char(';')
+  }
+  buf.to_string()
+}
+
+///|
+/// The `owner_id` of the parent, i.e. the path with the last `/segment` removed.
+/// Returns None for a top-level key (no `/`).
+fn cascade_reuse_parent_key(owner_id : String) -> String? {
+  match owner_id.rev_find("/") {
+    Some(idx) => Some(owner_id.substring(start=0, end=idx))
+    None => None
+  }
+}
+
+///|
+/// If element `elem` at `owner_id` can reuse its prior computed style, return it
+/// (and mark the node clean so its children may reuse too). Records the
+/// signature. Returns None when there is no active reuse pass or the node isn't
+/// clean — the caller then computes the style normally and must call
+/// `cascade_reuse_record` with the result.
+fn cascade_reuse_try(owner_id : String, elem : @html.Element) -> @style.Style? {
+  match cascade_reuse_ctx.val {
+    None => None
+    Some(ctx) => {
+      let sig = cascade_reuse_sig(elem)
+      ctx.new_sigs[owner_id] = sig
+      let parent_clean = match cascade_reuse_parent_key(owner_id) {
+        None => true // root: no parent constraint
+        Some(pk) => ctx.clean.get(pk) is Some(true)
+      }
+      if parent_clean && ctx.prior_sigs.get(owner_id) is Some(prior_sig) {
+        if prior_sig == sig {
+          match ctx.prior_styles.get(owner_id) {
+            Some(style) => {
+              ctx.clean[owner_id] = true
+              ctx.new_styles[owner_id] = style
+              ctx.reused += 1
+              return Some(style)
+            }
+            None => ()
+          }
+        }
+      }
+      None
+    }
+  }
+}
+
+///|
+/// Record a freshly-computed style for `owner_id` (the not-clean path). The
+/// signature was already recorded by `cascade_reuse_try`.
+fn cascade_reuse_record(owner_id : String, style : @style.Style) -> Unit {
+  match cascade_reuse_ctx.val {
+    Some(ctx) => ctx.new_styles[owner_id] = style
+    None => ()
+  }
+}
+
+///|
+/// Whether the given raw CSS texts are safe for scoped cascade reuse: they must
+/// use no selector whose match can flip without a change in an element's own
+/// inputs or its ancestors' inputs. Conservative and cheap: a substring scan for
+/// the disqualifying selector features. A false positive (e.g. `+` inside a
+/// `calc()` value) only disables the optimization — never a correctness risk.
+pub fn css_allows_cascade_reuse(texts : Array[String]) -> Bool {
+  let unsafe_tokens = [
+    "+", "~", ":nth", ":has", ":empty", ":blank", ":first-child", ":last-child",
+    ":only-child", "-of-type", ":focus-within", "::",
+  ]
+  for text in texts {
+    for tok in unsafe_tokens {
+      if text.contains(tok) {
+        return false
+      }
+    }
+  }
+  true
+}

--- a/renderer/renderer/nested_element_node.mbt
+++ b/renderer/renderer/nested_element_node.mbt
@@ -20,15 +20,27 @@ fn element_to_node_with_styles_internal(
       incoming_counters, owner_id,
     )
   }
-  let computed_style = compute_element_style_indexed(
-    selector_elem,
-    elem.style,
-    indexed_stylesheets,
-    false,
-    ctx,
-    parent_style,
-    css_vars,
-  )
+  // Incremental cascade (Phase 1): when a reuse pass is active and this element
+  // is clean (unchanged inputs + clean ancestors under a reuse-safe stylesheet),
+  // reuse its prior computed style instead of re-running the cascade. `owner_id`
+  // is the structural key; downstream adjustments re-run identically for a clean
+  // node. See docs/incremental-cascade-design.md.
+  let computed_style = match cascade_reuse_try(owner_id, elem) {
+    Some(reused) => reused
+    None => {
+      let s = compute_element_style_indexed(
+        selector_elem,
+        elem.style,
+        indexed_stylesheets,
+        false,
+        ctx,
+        parent_style,
+        css_vars,
+      )
+      cascade_reuse_record(owner_id, s)
+      s
+    }
+  }
   viewport_full_node_count.val += 1
   let tag_lower = elem.tag.to_lower()
   let computed_style = apply_element_visibility_attributes(

--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -18,6 +18,10 @@ pub fn apply_css_property_debug(@style.Style, String, String) -> @style.Style
 
 pub fn build_render_root_node(@html.Document, RenderContext, PreparedRenderDocument) -> @node.Node
 
+pub fn cascade_reuse_begin(Map[String, @style.Style], Map[String, String]) -> Unit
+
+pub fn cascade_reuse_end() -> (Map[String, @style.Style], Map[String, String], Int)
+
 pub fn clear_builtin_text_advance_ratio_override_for_test() -> Unit
 
 pub fn clear_image_intrinsic_size_provider() -> Unit
@@ -35,6 +39,8 @@ pub fn compute_shadow_tree_styles(@dom.DomTree, @dom.NodeId, RenderContext, @sty
 pub fn compute_slotted_styles(@dom.DomTree, @dom.NodeId, RenderContext, @style.Style?) -> Map[Int, @style.Style]
 
 pub let crater_dom_id_attr : String
+
+pub fn css_allows_cascade_reuse(Array[String]) -> Bool
 
 pub fn element_to_node(@html.Element, @style.Style?) -> @node.Node
 

--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -18,7 +18,7 @@ pub fn apply_css_property_debug(@style.Style, String, String) -> @style.Style
 
 pub fn build_render_root_node(@html.Document, RenderContext, PreparedRenderDocument) -> @node.Node
 
-pub fn cascade_reuse_begin(Map[String, @style.Style], Map[String, String]) -> Unit
+pub fn cascade_reuse_begin(Map[String, @style.Style], Map[String, String], uses_sibling? : Bool) -> Unit
 
 pub fn cascade_reuse_end() -> (Map[String, @style.Style], Map[String, String], Int)
 
@@ -41,6 +41,8 @@ pub fn compute_slotted_styles(@dom.DomTree, @dom.NodeId, RenderContext, @style.S
 pub let crater_dom_id_attr : String
 
 pub fn css_allows_cascade_reuse(Array[String]) -> Bool
+
+pub fn css_uses_sibling_combinator(Array[String]) -> Bool
 
 pub fn element_to_node(@html.Element, @style.Style?) -> @node.Node
 

--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -18,7 +18,7 @@ pub fn apply_css_property_debug(@style.Style, String, String) -> @style.Style
 
 pub fn build_render_root_node(@html.Document, RenderContext, PreparedRenderDocument) -> @node.Node
 
-pub fn cascade_reuse_begin(Map[String, @style.Style], Map[String, String], uses_sibling? : Bool) -> Unit
+pub fn cascade_reuse_begin(Map[String, @style.Style], Map[String, String], uses_sibling? : Bool, uses_child_structure? : Bool) -> Unit
 
 pub fn cascade_reuse_end() -> (Map[String, @style.Style], Map[String, String], Int)
 
@@ -41,6 +41,8 @@ pub fn compute_slotted_styles(@dom.DomTree, @dom.NodeId, RenderContext, @style.S
 pub let crater_dom_id_attr : String
 
 pub fn css_allows_cascade_reuse(Array[String]) -> Bool
+
+pub fn css_uses_child_structure(Array[String]) -> Bool
 
 pub fn css_uses_sibling_combinator(Array[String]) -> Bool
 

--- a/renderer/renderer/style_resolve.mbt
+++ b/renderer/renderer/style_resolve.mbt
@@ -226,13 +226,37 @@ fn collect_root_css_variables(
 }
 
 ///|
-/// Get user-agent default style for an element tag
+/// UA default styles depend only on the (lowercased) tag name and every call
+/// site treats the result as read-only, so memoize them. Building a fresh
+/// `Style` per element — a large struct, plus a spread for the tagged defaults —
+/// was pure allocation/drop churn in the render profile; sharing one instance
+/// per tag is safe because `Rect` fields are immutable and no caller mutates the
+/// returned style.
+let ua_default_style_cache : Ref[Map[String, @style.Style]] = { val: {} }
+
+///|
+/// Get user-agent default style for an element tag (memoized by tag name).
 fn get_ua_default_style(tag : String) -> @style.Style {
+  let key = tag.to_lower()
+  match ua_default_style_cache.val.get(key) {
+    Some(cached) => cached
+    None => {
+      let computed = compute_ua_default_style(key)
+      ua_default_style_cache.val.set(key, computed)
+      computed
+    }
+  }
+}
+
+///|
+/// Compute the user-agent default style for a (already lowercased) tag.
+fn compute_ua_default_style(tag : String) -> @style.Style {
   let default_style = @style.Style::default()
 
   // Default margins for block elements (based on typical browser defaults)
-  // Values are in em units, converted to px assuming 16px base font
-  match tag.to_lower() {
+  // Values are in em units, converted to px assuming 16px base font.
+  // `tag` is already lowercased by the memoizing `get_ua_default_style` wrapper.
+  match tag {
     "html" => { ..default_style, font_family: "serif" }
     "body" =>
       {
@@ -848,19 +872,20 @@ fn apply_cascaded_to_style(
       } else {
         1.2
       }
-      style = {
-        ..style,
-        color: ps.color,
-        font_size: ps.font_size,
-        font_family: ps.font_family,
-        line_height: ps.font_size * lh_ratio,
-        white_space: ps.white_space,
-        writing_mode: ps.writing_mode,
-        direction: ps.direction,
-        pointer_events: ps.pointer_events,
-        letter_spacing: ps.letter_spacing,
-        word_spacing: ps.word_spacing,
-      }
+      // In-place field assignment on the uniquely-owned mutable `style`
+      // avoids allocating (and later dropping) a whole fresh Style per spread;
+      // per-element style resolution dominates the render, and the spread
+      // churn was a large share of the refcount-drop cost.
+      style.color = ps.color
+      style.font_size = ps.font_size
+      style.font_family = ps.font_family
+      style.line_height = ps.font_size * lh_ratio
+      style.white_space = ps.white_space
+      style.writing_mode = ps.writing_mode
+      style.direction = ps.direction
+      style.pointer_events = ps.pointer_events
+      style.letter_spacing = ps.letter_spacing
+      style.word_spacing = ps.word_spacing
     }
     None => ()
   }
@@ -868,63 +893,55 @@ fn apply_cascaded_to_style(
   // Apply user-agent default style
   let ua_style = get_ua_default_style(selector_elem.tag_name)
   if ua_style.color != @types.Color::black() {
-    style = { ..style, color: ua_style.color }
+    style.color = ua_style.color
   }
-  style = { ..style, display: ua_style.display }
-  style = { ..style, box_sizing: ua_style.box_sizing }
+  style.display = ua_style.display
+  style.box_sizing = ua_style.box_sizing
   if ua_style.text_align != default_style.text_align {
-    style = { ..style, text_align: ua_style.text_align }
+    style.text_align = ua_style.text_align
   }
   if ua_style.vertical_align != default_style.vertical_align {
-    style = { ..style, vertical_align: ua_style.vertical_align }
+    style.vertical_align = ua_style.vertical_align
   }
   if ua_style.white_space != default_style.white_space {
-    style = { ..style, white_space: ua_style.white_space }
+    style.white_space = ua_style.white_space
   }
   if ua_style.overflow_x != default_style.overflow_x ||
     ua_style.overflow_y != default_style.overflow_y {
-    style = {
-      ..style,
-      overflow_x: ua_style.overflow_x,
-      overflow_y: ua_style.overflow_y,
-    }
+    style.overflow_x = ua_style.overflow_x
+    style.overflow_y = ua_style.overflow_y
   }
-  style = { ..style, margin: ua_style.margin, padding: ua_style.padding }
+  style.margin = ua_style.margin
+  style.padding = ua_style.padding
   if ua_style.font_size != default_style.font_size {
-    style = { ..style, font_size: ua_style.font_size }
+    style.font_size = ua_style.font_size
   }
   if ua_style.line_height != default_style.line_height {
-    style = { ..style, line_height: ua_style.line_height }
+    style.line_height = ua_style.line_height
   }
   if ua_style.font_family != "" {
-    style = { ..style, font_family: ua_style.font_family }
+    style.font_family = ua_style.font_family
   }
   if ua_style.font_weight != 400.0 {
-    style = { ..style, font_weight: ua_style.font_weight }
+    style.font_weight = ua_style.font_weight
   }
-  style = {
-    ..style,
-    border_spacing: ua_style.border_spacing,
-    border_collapse: ua_style.border_collapse,
-    text_decoration_underline: ua_style.text_decoration_underline,
-    text_decoration_line_through: ua_style.text_decoration_line_through,
-    text_decoration_overline: ua_style.text_decoration_overline,
-  }
-  style = { ..style, min_height: ua_style.min_height }
+  style.border_spacing = ua_style.border_spacing
+  style.border_collapse = ua_style.border_collapse
+  style.text_decoration_underline = ua_style.text_decoration_underline
+  style.text_decoration_line_through = ua_style.text_decoration_line_through
+  style.text_decoration_overline = ua_style.text_decoration_overline
+  style.min_height = ua_style.min_height
   if selector_elem.tag_name.to_lower() == "rt" {
     let inherited_font_size = match parent_style {
       Some(ps) => ps.font_size
       None => style.font_size
     }
     let rt_font_size = inherited_font_size * 0.5
-    style = {
-      ..style,
-      font_size: rt_font_size,
-      line_height: rt_font_size * 1.2,
-    }
+    style.font_size = rt_font_size
+    style.line_height = rt_font_size * 1.2
   }
   if uses_table_normal_line_height(selector_elem.tag_name) {
-    style = { ..style, line_height: style.font_size * normal_line_height_ratio }
+    style.line_height = style.font_size * normal_line_height_ratio
   }
 
   // Apply presentational HTML attributes (bgcolor, width, align, etc.)
@@ -933,7 +950,7 @@ fn apply_cascaded_to_style(
     Some(bg_value) => {
       let parsed = @css.parse_color(bg_value)
       match parsed.get_color() {
-        Some(color) => style = { ..style, background_color: color }
+        Some(color) => style.background_color = color
         None => ()
       }
     }
@@ -972,7 +989,7 @@ fn apply_cascaded_to_style(
           }
         }
         if dim != @types.Dimension::Auto {
-          style = { ..style, width: dim }
+          style.width = dim
         }
       }
     }
@@ -981,9 +998,9 @@ fn apply_cascaded_to_style(
   match selector_elem.get_attribute("align") {
     Some(align_value) =>
       match align_value.to_lower() {
-        "center" => style = { ..style, text_align: @style.TextAlign::Center }
-        "right" => style = { ..style, text_align: @style.TextAlign::Right }
-        "left" => style = { ..style, text_align: @style.TextAlign::Left }
+        "center" => style.text_align = @style.TextAlign::Center
+        "right" => style.text_align = @style.TextAlign::Right
+        "left" => style.text_align = @style.TextAlign::Left
         _ => ()
       }
     None => ()
@@ -992,10 +1009,10 @@ fn apply_cascaded_to_style(
   match selector_elem.get_attribute("valign") {
     Some(valign_value) =>
       match valign_value.to_lower() {
-        "top" => style = { ..style, vertical_align: @style.Top }
-        "middle" => style = { ..style, vertical_align: @style.Middle }
-        "bottom" => style = { ..style, vertical_align: @style.Bottom }
-        "baseline" => style = { ..style, vertical_align: @style.Baseline }
+        "top" => style.vertical_align = @style.Top
+        "middle" => style.vertical_align = @style.Middle
+        "bottom" => style.vertical_align = @style.Bottom
+        "baseline" => style.vertical_align = @style.Baseline
         _ => ()
       }
     None => ()
@@ -1012,15 +1029,12 @@ fn apply_cascaded_to_style(
         }
         if n > 0.0 {
           let bw = @types.Dimension::Length(n)
-          style = {
-            ..style,
-            border: { top: bw, right: bw, bottom: bw, left: bw },
-            border_style: {
-              top: @style.BorderStyle::Solid,
-              right: @style.BorderStyle::Solid,
-              bottom: @style.BorderStyle::Solid,
-              left: @style.BorderStyle::Solid,
-            },
+          style.border = { top: bw, right: bw, bottom: bw, left: bw }
+          style.border_style = {
+            top: @style.BorderStyle::Solid,
+            right: @style.BorderStyle::Solid,
+            bottom: @style.BorderStyle::Solid,
+            left: @style.BorderStyle::Solid,
           }
         }
       }
@@ -1036,15 +1050,12 @@ fn apply_cascaded_to_style(
   if cell_tag == "td" || cell_tag == "th" {
     if table_ancestor_has_border(selector_elem) {
       let bw = @types.Dimension::Length(1.0)
-      style = {
-        ..style,
-        border: { top: bw, right: bw, bottom: bw, left: bw },
-        border_style: {
-          top: @style.BorderStyle::Solid,
-          right: @style.BorderStyle::Solid,
-          bottom: @style.BorderStyle::Solid,
-          left: @style.BorderStyle::Solid,
-        },
+      style.border = { top: bw, right: bw, bottom: bw, left: bw }
+      style.border_style = {
+        top: @style.BorderStyle::Solid,
+        right: @style.BorderStyle::Solid,
+        bottom: @style.BorderStyle::Solid,
+        left: @style.BorderStyle::Solid,
       }
     }
   }
@@ -1179,13 +1190,13 @@ fn apply_cascaded_to_style(
     let keeps_non_table_display = style.display == @types.Contents ||
       style.display == @types.Display::None
     if !is_table_display(style.display) && !keeps_non_table_display {
-      style = { ..style, display: ua_style.display }
+      style.display = ua_style.display
     }
   }
   // Size containment does not apply to table-cell elements, while
   // layout/paint/style containment still can.
   if style.display == @types.TableCell && style.contain.size {
-    style = { ..style, contain: { ..style.contain, size: false } }
+    style.contain = { ..style.contain, size: false }
   }
 
   // Apply inline styles
@@ -1245,13 +1256,10 @@ fn apply_cascaded_to_style(
   // true. Set it authoritatively from the var-aware determination above; this
   // covers every trigger @css uses (cascaded filter, cascaded backdrop-filter,
   // and the inline path), so it neither under- nor over-establishes the CB.
-  style = {
-    ..style,
-    has_filter: establishes_effect_cb,
-    contain: {
-      ..style.contain,
-      paint: style.contain.paint || establishes_effect_cb,
-    },
+  style.has_filter = establishes_effect_cb
+  style.contain = {
+    ..style.contain,
+    paint: style.contain.paint || establishes_effect_cb,
   }
 
   // Apply viewport dimensions if root
@@ -1271,10 +1279,7 @@ fn apply_cascaded_to_style(
     if !has_horizontal_inset_pair {
       match style.width {
         @types.Dimension::Auto =>
-          style = {
-            ..style,
-            width: @types.Dimension::Length(ctx.viewport_width),
-          }
+          style.width = @types.Dimension::Length(ctx.viewport_width)
         _ => ()
       }
     }

--- a/testing/e2e/native_v8/browser_v8_e2e_test.mbt
+++ b/testing/e2e/native_v8/browser_v8_e2e_test.mbt
@@ -216,6 +216,43 @@ test "E2E: incremental reflow matches a full rebuild on the dynamic JS path" {
 }
 
 ///|
+/// Cascade reuse (incremental *scoped cascade*) on the native dynamic path must
+/// equal a full rebuild. Same shape as the incremental-reflow e2e above, but the
+/// flag-on browser also enables `set_cascade_reuse`; the page carries a
+/// reuse-safe `<style>` (class / descendant / sibling selectors) so the reuse
+/// fast path engages on the post-mutation re-render. This is the native-V8
+/// sign-off for the js-target equivalence in
+/// browser/shell/cascade_reuse_wbtest.mbt — the correctness bar for flipping
+/// `set_cascade_reuse` default-on (it stays off by default until then).
+test "E2E: cascade reuse matches a full rebuild on the dynamic JS path" {
+  let html =
+    "<html><head><style>" +
+    ".box{color:#112233;padding:4px}.row .cell{margin:2px;color:#334455}.box + .box{padding:6px}" +
+    "</style></head><body>" +
+    "<div class=\"row\"><div class=\"box\"><span class=\"cell\">alpha</span></div>" +
+    "<div class=\"box\"><span class=\"cell\" id=\"b\">beta</span></div></div>" +
+    "<script>" +
+    "document.getElementById('b').textContent = 'beta beta beta beta';" +
+    "</script></body></html>"
+  // Flags off: run the script, then render the final DOM from scratch.
+  let full = new_v8_browser(800, 600)
+  full.set_incremental_reflow(false)
+  full.set_cascade_reuse(false)
+  full.set_html_content(html)
+  let _ = full.execute_scripts()
+  let want = full.render_text_full_page()
+  // Flags on: baseline render, run the script (mutates), reuse re-render.
+  let incr = new_v8_browser(800, 600)
+  incr.set_incremental_reflow(true)
+  incr.set_cascade_reuse(true)
+  incr.set_html_content(html)
+  let _ = incr.render_text_full_page()
+  let _ = incr.execute_scripts()
+  let got = incr.render_text_full_page()
+  assert_eq(got, want)
+}
+
+///|
 test "E2E: console.log captured" {
   let browser = make_v8_browser(
     "<html><body><script>console.log('hello from script');</script></body></html>",


### PR DESCRIPTION
## Summary

Profile-driven performance work on the render / VRT hot paths. Two landed, **wall-clock-validated** micro-wins, plus a new **incremental (scoped) cascade** for the dynamic-reflow path, implemented in four phases behind an **off-by-default** flag with a full js-target equivalence suite.

Method note: callgrind instruction count proved a poor proxy for wall-clock in MoonBit-native allocation-bound code (one Ir-reducing change regressed wall time and was reverted), so every perf claim here is a **median-of-N wall-clock A/B**, not Ir.

## Landed perf wins (wall-clock A/B)

- **`perf(renderer)`: memoize UA default styles** — `get_ua_default_style(tag)` built a fresh (large) `Style` per element but depends only on the tag and is read-only at every call site. Memoized per tag (safe: `Rect` fields immutable, no caller mutates it). **−6.2%** on a synthetic render loop; `moonbit_drop_object` −6M.
- **`perf(raster)`: fuse RGBA expansion into base64 encode** — the native `framebuffer_to_rgba_base64` (WebDriver BiDi `captureScreenshot` path) materialized a ~7.7 MB `Array[Int]` RGBA buffer before encoding. Fused the two passes (lcm(4,3)=12 bytes = 3 pixels = 4 base64 quads, so groups align with no carry). Byte-identical (new equivalence test, n=1..12 tail cases). **−20%** on an 800×600 raster+encode loop.

## Incremental (scoped) cascade — off by default

Layout reflow is already incremental; the remaining ceiling was the **full O(n) cascade re-run on every mutation** (~all of a reflow's app work + churn). This reuses an element's prior computed style when it is provably unaffected.

- **Mechanism**: key on `owner_id` (the structural path already threaded through the build). A node is *clean* iff the stylesheet is reuse-safe, its input signature is unchanged, and its parent is clean — the ancestor-clean chain makes descendant/child combinators and inherited context (style + css vars) safe. Non-clean nodes fall back to a normal cascade, so a miss is never wrong.
- **Selector coverage** (`css_allows_cascade_reuse`, conservative substring gate):
  - Phase 1: type / id / class / attribute + descendant / child.
  - Phase 2: sibling combinators (`+`/`~`) via a preceding-sibling gate.
  - Phase 3: positional-from-start (`:first-child`, `:nth-child`) via owner_id keying (no new machinery).
  - Phase 4: `:empty`/`:blank` and positional-from-end / only / of-type via a child-structure summary appended to the signature.
  - Still disqualified: `:has` (needs a subtree-clean pre-pass), `:focus-within`, pseudo-elements.
- **Wiring**: `Browser::set_cascade_reuse` (off by default, same rollout the incremental-layout work used). Prior styles keyed by `owner_id` are reused only when the CSS signature is unchanged (a CSS edit resets them). `cascade_reuse_last_count` exposes engagement for tests.
- **Measured**: **−14.7%** on the renderer reflow path with reuse on (unchanged re-render, ~80% of elements reused).

## Validation

- Correctness is a pure render property, covered on the **js** target (`browser/shell/cascade_reuse_wbtest.mbt`): incremental-with-reuse is byte-identical to a full rebuild for text edits, class changes, ancestor-combinator invalidation, sibling-combinator invalidation, `calc()` non-disable, `:first-child` prepend, `:empty` empty↔filled transition, and `:last-child` append — each a stale-style bug if mishandled — with engagement assertions so a silently-disabled fast path can't read as a pass.
- Suites green: **shell 198, renderer 399, renderer/vrt 12, layout/tree 66**.
- Perf harnesses added under `benchmarks/` (`render_profile`, `paint_raster_profile`, `cascade_reuse_profile`; native, samply/callgrind + A/B ready).

## Remaining before `set_cascade_reuse` goes default-on

The **native-V8 dynamic round-trip** sign-off — `testing/e2e/native_v8` "E2E: cascade reuse matches a full rebuild on the dynamic JS path" is added (enables the flag on the real script-driven mutation path and asserts equivalence). That suite is V8-gated, so it runs in the native-V8 CI job / a V8 environment, not the no-v8 sandbox. Design + progress in `docs/incremental-cascade-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgmgHovSTV6mEzFYNLy959)_