### PR TITLE
test(reflow): confirm :not/:is/:where cascade reuse; record :has as net-negative

### DIFF
--- a/browser/shell/cascade_reuse_functional_wbtest.mbt
+++ b/browser/shell/cascade_reuse_functional_wbtest.mbt
@@ -1,0 +1,69 @@
+///|
+/// Incremental cascade — functional pseudo-classes `:not()` / `:is()` /
+/// `:where()`. No new machinery: they are transparent to the substring guards,
+/// so their argument's features route to the right gate — `:not(.x)` keys on the
+/// element signature, `:is(.a .b)` on the ancestor-clean chain, and any unsafe
+/// feature nested inside (e.g. `:not(:has(.x))`) trips the same disqualifier as
+/// at top level. These tests confirm equivalence to a full rebuild. Uses
+/// `cascade_reuse_equiv` from cascade_reuse_wbtest.mbt.
+
+///|
+test "cascade reuse :not: a class flip under :not(...) matches full (own-input)" {
+  // `.item:not(.muted)` keys on the element's own class list, which is in the
+  // signature — losing `.muted` must recompute it.
+  let css = ".item{color:#111111}.item:not(.muted){color:#0000ff;padding:5px}"
+  let v1 = "<html><head><style>" +
+    css +
+    "</style></head><body><span class=\"item muted\">a</span></body></html>"
+  let v2 = "<html><head><style>" +
+    css +
+    "</style></head><body><span class=\"item\">a</span></body></html>"
+  let (equal, _) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+}
+
+///|
+test "cascade reuse :is: an ancestor class flip under :is(...) matches full" {
+  // `:is(.on, .active) .item` — the descendant `.item` depends on an ancestor
+  // matching `:is(...)`; the ancestor-clean chain must invalidate it.
+  let css = ".item{color:#111111}:is(.on, .active) .item{color:#00aa00;padding:6px}"
+  let v1 = "<html><head><style>" +
+    css +
+    "</style></head><body><div class=\"wrap\"><span class=\"item\">a</span></div></body></html>"
+  let v2 = "<html><head><style>" +
+    css +
+    "</style></head><body><div class=\"wrap on\"><span class=\"item\">a</span></div></body></html>"
+  let (equal, _) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+}
+
+///|
+test "cascade reuse :not(:has()): a :has inside :not is disqualified and matches full" {
+  // The `:has` inside `:not` still trips the guard, so the whole sheet is
+  // disqualified (`:has` is not reuse-supported — a subtree-clean pre-pass was
+  // measured as a net loss; see docs/incremental-cascade-design.md). The sheet
+  // therefore falls back to a full cascade and must still render correctly.
+  let css = ".card{color:#111111}.card:not(:has(.badge)){color:#0000ff;padding:5px}"
+  let v1 = "<html><head><style>" +
+    css +
+    "</style></head><body><div class=\"card\"><span class=\"badge\">b</span></div></body></html>"
+  let v2 = "<html><head><style>" +
+    css +
+    "</style></head><body><div class=\"card\"><span class=\"label\">l</span></div></body></html>"
+  let (equal, _) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+}
+
+///|
+test "cascade reuse :not: a :not(...) sheet still reuses on a text edit" {
+  let css = ".item{color:#111111}.item:not(.muted){color:#0000ff;padding:5px}"
+  let v1 = "<html><head><style>" +
+    css +
+    "</style></head><body><span class=\"item\">a</span><span class=\"other\">x</span></body></html>"
+  let v2 = "<html><head><style>" +
+    css +
+    "</style></head><body><span class=\"item\">a</span><span class=\"other\">x changed</span></body></html>"
+  let (equal, reused) = cascade_reuse_equiv(v1, v2)
+  inspect(equal, content="true")
+  inspect(reused > 0, content="true")
+}

--- a/docs/incremental-cascade-design.md
+++ b/docs/incremental-cascade-design.md
@@ -26,9 +26,29 @@ without new machinery. **Phase 4** adds `:empty`/`:blank` and positional-from-**
 the *parent's* summary reaching children via the ancestor-clean chain, the
 child list a from-end/of-type match depends on (count, order, tags). A
 non-whitespace text edit keeps the same summary shape, so text-edit reuse is
-preserved. Only **`:has`** (arbitrary-depth descendant dependency — needs a
-subtree-clean pre-pass), **`:focus-within`** (descendant focus state), and
-**pseudo-elements** remain disqualified.
+preserved. **`:has`**, **`:focus-within`**, and **pseudo-elements** remain
+disqualified.
+
+**Functional pseudo-classes `:not()` / `:is()` / `:where()` need no new work.**
+The guards are substring scans over the raw CSS, so they see *inside* the
+functional-pseudo parens: `:not(.x)` keys on the element signature (a compound on
+the element itself), `:is(.a .b)` / `:where(.a .b)` on the ancestor-clean chain,
+and any unsafe feature nested inside (`:not(:has(...))`, `:is(.a + .b)`,
+`:where(:nth-last-child(2))`) trips the matching gate / disqualifier just as if
+written at top level. Covered by `browser/shell/cascade_reuse_functional_wbtest.mbt`.
+
+**`:has` was prototyped and rejected on cost.** A correct subtree-clean pre-pass
+(walk the document post-order, gate reuse on the element's whole subtree being
+unchanged) was implemented and validated equivalent to a full rebuild. But the
+pre-pass is an extra full-document walk, and an A/B on a `:has` sheet with an
+otherwise cheap (class-selector) cascade measured **reuse ~5% *slower* than a
+full cascade** (has/reuse ≈ 2.82s vs has/full ≈ 2.70s, even after sharing the
+pre-pass's signatures with the build) — the walk costs more than the cheap
+cascade it saves. It may pay off on sheets with an expensive cascade, but since
+it is a net loss on a plausible common case, `:has` stays disqualified (those
+sheets fall back to a full cascade, which is both correct and faster than
+reuse+pre-pass). A future gate that only runs the pre-pass when the cascade is
+expensive enough could revisit this.
 
 **Flag-on readiness.** Correctness is covered offline on the js target
 (`browser/shell/cascade_reuse_wbtest.mbt` — text edit, `:empty` fallback, class


### PR DESCRIPTION
## Summary

Follow-up to the incremental scoped-cascade work (#331). Two things:

1. **`:not()` / `:is()` / `:where()` need no new machinery** — confirmed with tests.
2. **`:has` was prototyped and rejected on a benchmarked slowdown** — documented; it stays disqualified.

The feature remains **off by default** (`set_cascade_reuse`).

## Benchmark check (no slowdown on covered phases)

`benchmarks/cascade_reuse_profile`, native A/B, median of 5, 90-block / ~360-element reflow:

| scenario | reuse | full | delta |
|---|---|---|---|
| plain (Phase 1–4 selectors) | 2.24s | 2.81s | **−20%** |
| `:has` sheet | 2.82s | 2.70s | **+5% (slower)** |

Plain-path reuse is unchanged (no regression); `reused_per_pass` is unchanged.

## `:not()` / `:is()` / `:where()` — already covered

The reuse guards are substring scans over the raw CSS, so they see *inside* the functional-pseudo parens: `:not(.x)` keys on the element signature (a compound on the element itself), `:is(.a .b)` / `:where(.a .b)` on the ancestor-clean chain, and any unsafe feature nested inside (`:not(:has(...))`, `:is(.a + .b)`, `:where(:nth-last-child(2))`) trips the matching gate / disqualifier exactly as at top level. Adds `browser/shell/cascade_reuse_functional_wbtest.mbt` proving equivalence to a full rebuild for each routing, plus that a `:not(.x)` sheet still reuses on a text edit.

## `:has` — prototyped, measured net-negative, left disqualified

A correct subtree-clean pre-pass (walk the document post-order; gate reuse on the element's whole subtree being unchanged) was implemented and validated equivalent to a full rebuild. But it is an extra full-document walk, and the A/B above shows reuse **~5% slower** than a full cascade on a `:has` sheet with an otherwise cheap (class-selector) cascade — even after sharing the pre-pass's signatures with the build — because the walk costs more than the cheap cascade it saves. So `:has` stays disqualified (those sheets fall back to a full cascade, which is both correct and faster than reuse + pre-pass). The finding and a possible future "only run the pre-pass when the cascade is expensive enough" gate are recorded in `docs/incremental-cascade-design.md`.

## Validation

- `browser/shell` 202 tests green (incl. the new `:not`/`:is`/`:where` cases).
- No public interface change (`.mbti` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgmgHovSTV6mEzFYNLy959)_