### PR TITLE
chore: post-0.19.0 release cleanup

### DIFF
--- a/benchmarks/cascade_reuse_profile/main.mbt
+++ b/benchmarks/cascade_reuse_profile/main.mbt
@@ -46,7 +46,7 @@ fn main {
   let prepared = @renderer.prepare_render_document(doc, ctx, [])
 
   // Prime the prior-style maps from one reuse pass over the document.
-  @renderer.cascade_reuse_begin(Map::new(), Map::new())
+  @renderer.cascade_reuse_begin(Map([]), Map([]))
   let _ = @renderer.build_render_root_node(doc, ctx, prepared)
   let (prior_styles, prior_sigs, _) = @renderer.cascade_reuse_end()
 

--- a/browser/shell/render_cache.mbt
+++ b/browser/shell/render_cache.mbt
@@ -123,16 +123,16 @@ fn extract_style_blocks(html : String, out : Array[String]) -> Unit {
   let n = lower.length()
   let mut base = 0
   while base < n {
-    match lower.substring(start=base).find("<style") {
+    match lower[base:].find("<style") {
       Some(rel_open) => {
         let open = base + rel_open
-        match lower.substring(start=open).find(">") {
+        match lower[open:].find(">") {
           Some(rel_gt) => {
             let gt = open + rel_gt
-            match lower.substring(start=gt).find("</style") {
+            match lower[gt:].find("</style") {
               Some(rel_close) => {
                 let close = gt + rel_close
-                out.push(html.substring(start=gt + 1, end=close))
+                out.push(html[gt + 1:close].to_owned())
                 base = close + 1
               }
               None => break

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,129 @@
+# Release runbook (MoonBit workspace → mooncakes)
+
+Crater is a MoonBit **workspace**: ~20 public modules under one repo
+(`moon.work` lists the members). A release publishes all of them to the
+mooncakes registry at the same version, in dependency order.
+
+The publishing itself is driven by
+[`scripts/moon-publish-workspace.mjs`](../scripts/moon-publish-workspace.mjs),
+exposed as pkfire tasks (`pkf run release-*`) and npm scripts
+(`pnpm release:moon:*`).
+
+## 0. Prerequisites
+
+- `~/.moon/credentials.json` present and pointing at the **mizchi** account
+  (not a machine user). The publish uses whatever account this file holds.
+- Clean working tree on the branch you intend to release.
+- `moon update` has been run recently so the local registry index is fresh.
+
+## 1. Bump versions
+
+There is **no automatic version bumper**. Every workspace `moon.mod` (and the
+dev-only `conformance/moon.mod.json`) carries its own `version`, and the
+internal `import { "mizchi/crater-*@X" }` pins reference sibling modules by
+version. All of them must move together.
+
+For a uniform bump (e.g. `0.18.0` → `0.19.0`), replacing the old version
+string across every manifest is safe **only after** confirming no external
+dependency happens to sit on the old version:
+
+```bash
+# Confirm every occurrence of the OLD version is a `version = "..."` field
+# or an internal `mizchi/crater-*` pin (empty output = safe to bulk-replace):
+git ls-files '*moon.mod' '*moon.mod.json' \
+  | xargs grep -rnE '0\.18\.0' \
+  | grep -vE 'version = "0\.18\.0"|"version": *"0\.18\.0"|mizchi/crater'
+
+# Bulk replace (zsh needs xargs word-splitting, not `$(...)`):
+git ls-files '*moon.mod' '*moon.mod.json' \
+  | xargs perl -pi -e 's/0\.18\.0/0.19.0/g'
+```
+
+Then verify a top consumer builds against the bumped internal deps
+(workspace-local resolution means unpublished versions still resolve):
+
+```bash
+moon -C browser check --target js   # expect 0 errors
+```
+
+## 2. Update external dependencies (optional but do it here)
+
+External deps (`mizchi/css`, `mizchi/font`, `mizchi/x`, `moonbitlang/*`, …)
+are pinned per-manifest. Compare against the registry index
+(`~/.moon/registry/index/user/<owner>/<pkg>.index`, last line = latest) and
+bump the pins you want. After bumping, `moon install` **at the repo root will
+fail** because the root module tries to resolve the not-yet-published internal
+deps from the registry — check per package instead:
+
+```bash
+moon -C <pkg> check --target js   # and --target native where relevant
+```
+
+> Gotcha: `mizchi/js` 0.11+ split its runtime bindings into separate modules.
+> `import { "mizchi/js/deno" }` became `import { "mizchi/js_deno" @deno }`
+> (add the `mizchi/js_deno` dep, alias it `@deno`). Same pattern for js_bun etc.
+
+## 3. Preview the publish plan
+
+```bash
+pkf run release-plan     # or: pnpm release:moon:list
+```
+
+Prints the ~20 modules in topological publish order (core first, the
+`mizchi/crater` facade last). Internal-only modules
+(benchmarks / testing / tools / conformance) are excluded.
+
+## 4. Dry run (limited for first releases)
+
+```bash
+pkf run release-dry-run  # or: pnpm release:moon:dry-run
+```
+
+- On **macOS** this uses `moon package` instead of `moon publish --dry-run`
+  (the latter currently panics on macOS).
+- For a **never-published version** the dry run cannot complete: `moon package`
+  resolves cross-module deps from the registry, which is still on the previous
+  version, so the first module whose deps aren't published yet fails. This is
+  expected — there is no way to fully validate a first-time release offline.
+
+## 5. Commit, tag, publish
+
+```bash
+# Commit the bump on a release branch (branch first if on main).
+git commit -am "chore: bump workspace version to 0.19.0"
+
+pkf run release-publish   # or: pnpm release:moon:publish  — IRREVERSIBLE
+```
+
+Publishing is **irreversible**: mooncakes does not allow unpublishing or
+overwriting a version. The script:
+- publishes in dependency order;
+- retries (with `moon update`) when a just-published dep hasn't propagated to
+  the registry index yet (expect several 5s retries — a full run takes a while);
+- skips modules already published at this version (409), so a failed run is
+  **safe to re-run** and resumes where it stopped.
+
+Confirm the registry caught up:
+
+```bash
+moon update
+tail -1 ~/.moon/registry/index/user/mizchi/crater-core.index  # -> "version":"0.19.0"
+```
+
+## 6. Tag at the release *tip*, not the bump commit
+
+Publishing uses the working-tree manifests, so the released content is the
+**tip** of your release branch (bump + dep updates + fixes), not the initial
+bump commit. Tag the tip so `git checkout v0.19.0` matches the published
+packages:
+
+```bash
+git tag v0.19.0 <release-tip-sha>
+git push origin main --tags   # fast-forward main; avoid squash (orphans the tag)
+```
+
+## CI
+
+The automated release workflow is `.github/workflows/release-moon.yml`
+(`workflow_dispatch`, needs the `MOON_CREDENTIALS_JSON` secret). Running from
+Linux CI also sidesteps the macOS `--dry-run` panic.

--- a/justfile
+++ b/justfile
@@ -160,6 +160,10 @@ check:
     moon -C painter check --target js -j 1
     moon -C renderer check --target js -j 1
     moon -C runtime check --target js -j 1
+    # runtime ships native-target code (js_runtime_native_stub.mbt, scheduler
+    # integration); check it on native too so js-only helpers referenced from
+    # non-target-gated tests are caught here instead of only at publish time.
+    moon -C runtime check --target native -j 1
     moon -C browser check --target js -j 1
     moon -C browser/native check --target native -j 1
     moon -C js check --target js

--- a/layout/block/block.mbt
+++ b/layout/block/block.mbt
@@ -1172,17 +1172,17 @@ fn layout_simple_block_stack(
 // correctness. This collapses the otherwise exponential mutual recursion
 // between min/max-content over deep trees (the dominant layout cost on
 // text-heavy pages — see #316).
-let min_intrinsic_width_cache : Ref[Map[String, Double]] = { val: Map::new() }
+let min_intrinsic_width_cache : Ref[Map[String, Double]] = { val: Map([]) }
 
 ///|
-let max_intrinsic_width_cache : Ref[Map[String, Double]] = { val: Map::new() }
+let max_intrinsic_width_cache : Ref[Map[String, Double]] = { val: Map([]) }
 
 ///|
 /// Reset the intrinsic-width memoization caches. Called once at the start of a
 /// top-level layout so they don't accumulate across renders.
 pub fn clear_block_intrinsic_caches() -> Unit {
-  min_intrinsic_width_cache.val = Map::new()
-  max_intrinsic_width_cache.val = Map::new()
+  min_intrinsic_width_cache.val = Map([])
+  max_intrinsic_width_cache.val = Map([])
 }
 
 ///|
@@ -1208,7 +1208,7 @@ priv struct BlockFlowCacheEntry {
 }
 
 ///|
-let block_flow_cache : Ref[Map[Int, BlockFlowCacheEntry]] = { val: Map::new() }
+let block_flow_cache : Ref[Map[Int, BlockFlowCacheEntry]] = { val: Map([]) }
 
 ///|
 let block_flow_cache_hits : Ref[Int] = { val: 0 }
@@ -1229,7 +1229,7 @@ pub fn reset_block_flow_cache_hits() -> Unit {
 ///|
 /// Drop the whole block-flow memoization cache (memory hygiene / test isolation).
 pub fn clear_block_flow_cache() -> Unit {
-  block_flow_cache.val = Map::new()
+  block_flow_cache.val = Map([])
   block_flow_cache_hits.val = 0
 }
 

--- a/renderer/gfx_text/bitmap_font.mbt
+++ b/renderer/gfx_text/bitmap_font.mbt
@@ -18,7 +18,7 @@
 /// their uppercase form.
 fn glyph_rows(ch : Char) -> Array[String]? {
   let c = if ch >= 'a' && ch <= 'z' {
-    Char::from_int(ch.to_int() - 32)
+    Int::unsafe_to_char(ch.to_int() - 32)
   } else {
     ch
   }

--- a/renderer/renderer/cascade_reuse.mbt
+++ b/renderer/renderer/cascade_reuse.mbt
@@ -175,7 +175,7 @@ fn cascade_reuse_sig(
 /// Returns None for a top-level key (no `/`).
 fn cascade_reuse_parent_key(owner_id : String) -> String? {
   match owner_id.rev_find("/") {
-    Some(idx) => Some(owner_id.substring(start=0, end=idx))
+    Some(idx) => Some(owner_id[0:idx].to_owned())
     None => None
   }
 }
@@ -209,7 +209,7 @@ fn cascade_reuse_try(owner_id : String, elem : @html.Element) -> @style.Style? {
       let preceding_ok = if ctx.uses_sibling {
         match parent {
           None => true
-          Some(pk) => not(ctx.preceding_clean.get(pk) is Some(false))
+          Some(pk) => !(ctx.preceding_clean.get(pk) is Some(false))
         }
       } else {
         true

--- a/renderer/renderer/measurement_record.mbt
+++ b/renderer/renderer/measurement_record.mbt
@@ -233,7 +233,7 @@ pub fn deserialize_text_metrics_recording(
     while i < len && unit_at(i) != stop {
       i = i + 1
     }
-    let s = data[start:i].to_string()
+    let s = data[start:i].to_owned()
     i = i + 1 // consume stop
     s
   }
@@ -243,7 +243,7 @@ pub fn deserialize_text_metrics_recording(
     let mh = @string.parse_double(read_until(sp)) catch { _ => 0.0 }
     let xh = @string.parse_double(read_until(sp)) catch { _ => 0.0 }
     let key_len = @string.parse_int(read_until(colon)) catch { _ => 0 }
-    let key = data[i:i + key_len].to_string()
+    let key = data[i:i + key_len].to_owned()
     i = i + key_len
     result.push({
       key,
@@ -382,7 +382,7 @@ pub fn deserialize_image_intrinsic_recording(
     while i < len && unit_at(i) != stop {
       i = i + 1
     }
-    let s = data[start:i].to_string()
+    let s = data[start:i].to_owned()
     i = i + 1
     s
   }
@@ -391,7 +391,7 @@ pub fn deserialize_image_intrinsic_recording(
     let w = @string.parse_double(read_until(sp)) catch { _ => 0.0 }
     let h = @string.parse_double(read_until(sp)) catch { _ => 0.0 }
     let src_len = @string.parse_int(read_until(colon)) catch { _ => 0 }
-    let src = data[i:i + src_len].to_string()
+    let src = data[i:i + src_len].to_owned()
     i = i + src_len
     result.push({ src, has_size: has, width: w, height: h })
   }

--- a/renderer/renderer/shadow_style_test.mbt
+++ b/renderer/renderer/shadow_style_test.mbt
@@ -80,7 +80,7 @@ test "compute_shadow_tree_styles threads inheritance across the boundary" {
   )
 
   // Host, wrapper, and leaf are all styled.
-  inspect(styles.size(), content="3")
+  inspect(styles.length(), content="3")
 
   // font-size: 20px on .wrap inherits into its leaf child.
   let wrap_style = styles.get(wrap.to_int()).unwrap()
@@ -121,7 +121,7 @@ test "compute_slotted_styles applies ::slotted rules to assigned light nodes" {
   )
 
   // Both light children are slotted, so both receive an entry.
-  inspect(styles.size(), content="2")
+  inspect(styles.length(), content="2")
 
   // Only .tag matches ::slotted(.tag): its color differs from the plain node's.
   let tagged_style = styles.get(tagged.to_int()).unwrap()

--- a/renderer/vrt/pkg.generated.mbti
+++ b/renderer/vrt/pkg.generated.mbti
@@ -83,7 +83,7 @@ pub(all) struct LayoutBox {
   y : Double
   width : Double
   height : Double
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 
 pub(all) struct PreparedVrtPage {
   doc : @html.Document

--- a/renderer/vrt/top.mbt
+++ b/renderer/vrt/top.mbt
@@ -496,7 +496,7 @@ pub fn RenderSession::branch_reusing_layout_diff(
 /// box geometry — i.e. whether a branch carrying only such mutations can reuse
 /// the base layout.
 pub fn CssMutation::is_paint_only(self : CssMutation) -> Bool {
-  not(@dom.is_layout_property(self.property.to_lower()))
+  !(@dom.is_layout_property(self.property.to_lower()))
 }
 
 ///|
@@ -538,7 +538,7 @@ pub(all) struct LayoutBox {
   y : Double
   width : Double
   height : Double
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 fn collect_layout_boxes_into(

--- a/tasks/release.pkl
+++ b/tasks/release.pkl
@@ -1,31 +1,48 @@
 import "package://pkg.pkl-lang.org/github.com/mizchi/pkfire/pkfire@0.10.0#/Taskfile.pkl" as pkfire
 
+// Shared cache inputs for the workspace release tooling. The repo migrated to
+// the `moon.mod` (TOML) format; `moon.mod.json` remains only for the dev-only
+// conformance module, so both globs are tracked.
+local releaseInputs: Listing<String> = new {
+  "package.json"
+  "scripts/moon-publish-workspace.mjs"
+  "moon.work"
+  "**/moon.mod"
+  "**/moon.mod.json"
+}
+
 releaseCheck: pkfire.Task = new {
   name = "release-check"
   description = "Validate MoonBit publish order without publishing"
   visibility = "internal"
   cmd = "pnpm release:moon:check"
-  inputs {
-    "package.json"
-    "scripts/moon-publish-workspace.mjs"
-    "moon.work"
-    "**/moon.mod.json"
-  }
+  inputs = releaseInputs
 }
 
 releasePlan: pkfire.Task = new {
   name = "release-plan"
   description = "Print MoonBit publish order"
   cmd = "pnpm release:moon:list"
-  inputs {
-    "package.json"
-    "scripts/moon-publish-workspace.mjs"
-    "moon.work"
-    "**/moon.mod.json"
-  }
+  inputs = releaseInputs
+}
+
+releaseDryRun: pkfire.Task = new {
+  name = "release-dry-run"
+  description = "Package every workspace module in publish order (macOS uses `moon package` to avoid the publish --dry-run panic). Cannot fully complete for a never-published version; see docs/release.md."
+  cmd = "pnpm release:moon:dry-run"
+  inputs = releaseInputs
+}
+
+releasePublish: pkfire.Task = new {
+  name = "release-publish"
+  description = "Publish all public workspace modules to mooncakes in dependency order. IRREVERSIBLE. Bump versions first; see docs/release.md."
+  cmd = "pnpm release:moon:publish"
+  inputs = releaseInputs
 }
 
 tasks: Listing<pkfire.Task> = new {
   releaseCheck
   releasePlan
+  releaseDryRun
+  releasePublish
 }

--- a/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
+++ b/webdriver/webdriver/bidi_browsing_context_actual_paint.mbt
@@ -920,11 +920,11 @@ fn paint_node_matches_selector(
   }
   if sel.has_prefix("#") {
     // `#main` matches a node whose id is `<tag>#main`.
-    return id.has_suffix("#" + sel.substring(start=1))
+    return id.has_suffix("#" + sel[1:].to_owned())
   }
   if sel.has_prefix(".") {
     // `.card` matches a node whose id is `<tag>.card`.
-    return id.has_suffix("." + sel.substring(start=1))
+    return id.has_suffix("." + sel[1:].to_owned())
   }
   false
 }


### PR DESCRIPTION
Follow-up housekeeping after the 0.19.0 workspace release. Three independent, low-risk cleanups; each is its own commit.

## Commits

- **`ci`: check runtime on the native target in `just check`**
  The `check` recipe only checked `runtime` with `--target js`. A js-only function referenced from a non-target-gated whitebox test (`dom_ops_wbtest.mbt`) therefore failed only during `moon publish` verification, never in CI — that's how the native bug fixed in the 0.19.0 release slipped through. Adds a native check for `runtime` (which ships native-target code). Green locally.

- **`docs(release)`: add workspace publish runbook + pkfire tasks**
  The workspace release flow was undocumented/tribal (the publish script had even bit-rotted on the `moon.mod` migration). Adds `docs/release.md` capturing: manual multi-manifest version bump, external-dep gotchas (root `moon install` fails pre-publish; the `mizchi/js` → `mizchi/js_deno` split), the first-release dry-run limitation, the macOS `moon publish --dry-run` panic fallback, irreversibility + propagation-retry + re-run safety, and tagging the release *tip* (not the bump commit). Also adds `release-dry-run` / `release-publish` pkfire tasks and fixes the task cache inputs to track `moon.mod` (not just the legacy `moon.mod.json`).

- **`chore`: sweep deprecated MoonBit API/syntax warnings**
  25 mechanical, green-safe fixes: `str.substring(...)` → slicing, `Map::new()` → `Map([])`, StringView `.to_string()` → `.to_owned()`, `not(e)` → `!(e)`, `.size()` → `.length()`, `Char::from_int` → `Int::unsafe_to_char`, and one debug-only `derive(Show)` → `derive(Debug)`. Warning count 66 → 43. The remaining ~37 "Use Debug instead of Show" are `inspect()` call sites on collections whose *core* Show impl is deprecated — a snapshot-risky trait migration, intentionally left for a separate change.

## Deliberately NOT included

- **conformance moon.mod migration** — investigation showed `conformance` is not a format leftover but a pre-existing **broken** dev-only module: css 0.7.x changed `@types.Repeat` from 2 → 3 args and the generated `gen_grid_test.mbt` still passes 2 (10 errors), which is why it sits outside the CI `check` gate. Migrating its manifest format wouldn't fix that; regenerating the taffy grid tests for css 0.7.x is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)