### PR TITLE
fix(conformance): regenerate taffy grid tests for css 0.7.x Repeat

### DIFF
--- a/conformance/moon.mod.json
+++ b/conformance/moon.mod.json
@@ -6,7 +6,7 @@
       "path": "../core",
       "version": "0.19.0"
     },
-    "mizchi/css": "0.7.0",
+    "mizchi/css": "0.7.3",
     "mizchi/crater-dom": {
       "path": "../dom",
       "version": "0.19.0"

--- a/conformance/taffy/gen_grid_test.mbt
+++ b/conformance/taffy/gen_grid_test.mbt
@@ -8663,7 +8663,7 @@ test "taffy/grid_auto_fill_fixed_size" {
     height: @types.Length(120.0),
     grid_template_columns: [
       @types.TrackSizingFunction::Length(40.0),
-      @types.Repeat(@types.AutoFill, [@types.SingleTrackSizing::Length(40.0)]),
+      @types.Repeat(@types.AutoFill, [@types.SingleTrackSizing::Length(40.0)], []),
     ],
     grid_template_rows: [
       @types.TrackSizingFunction::Length(40.0),
@@ -8797,7 +8797,7 @@ test "taffy/grid_auto_fill_with_empty_auto_track" {
     width: @types.Length(120.0),
     height: @types.Length(120.0),
     grid_template_columns: [
-      @types.Repeat(@types.AutoFill, [@types.SingleTrackSizing::Length(40.0)]),
+      @types.Repeat(@types.AutoFill, [@types.SingleTrackSizing::Length(40.0)], []),
     ],
     grid_template_rows: [
       @types.TrackSizingFunction::Length(40.0),
@@ -8868,7 +8868,7 @@ test "taffy/grid_auto_fit_definite_percentage" {
           @types.MinTrackSizing::Length(150.0),
           @types.MaxTrackSizing::Fr(1.0),
         ),
-      ]),
+      ], []),
     ],
     row_gap: @types.Length(10.0),
     column_gap: @types.Length(10.0),
@@ -8995,7 +8995,7 @@ test "taffy/grid_auto_fit_with_empty_auto_track" {
     width: @types.Length(120.0),
     height: @types.Length(120.0),
     grid_template_columns: [
-      @types.Repeat(@types.AutoFit, [@types.SingleTrackSizing::Length(40.0)]),
+      @types.Repeat(@types.AutoFit, [@types.SingleTrackSizing::Length(40.0)], []),
     ],
     grid_template_rows: [
       @types.TrackSizingFunction::Length(40.0),
@@ -22412,10 +22412,10 @@ test "taffy/grid_repeat_integer" {
     width: @types.Length(120.0),
     height: @types.Length(120.0),
     grid_template_columns: [
-      @types.Repeat(@types.Count(3), [@types.SingleTrackSizing::Length(40.0)]),
+      @types.Repeat(@types.Count(3), [@types.SingleTrackSizing::Length(40.0)], []),
     ],
     grid_template_rows: [
-      @types.Repeat(@types.Count(3), [@types.SingleTrackSizing::Length(40.0)]),
+      @types.Repeat(@types.Count(3), [@types.SingleTrackSizing::Length(40.0)], []),
     ],
   }
   let root_children : Array[@node.Node] = []
@@ -22545,13 +22545,13 @@ test "taffy/grid_repeat_mixed" {
     height: @types.Length(120.0),
     grid_template_columns: [
       @types.TrackSizingFunction::Length(40.0),
-      @types.Repeat(@types.Count(1), [@types.SingleTrackSizing::Length(40.0)]),
-      @types.Repeat(@types.AutoFill, [@types.SingleTrackSizing::Length(40.0)]),
+      @types.Repeat(@types.Count(1), [@types.SingleTrackSizing::Length(40.0)], []),
+      @types.Repeat(@types.AutoFill, [@types.SingleTrackSizing::Length(40.0)], []),
     ],
     grid_template_rows: [
       @types.TrackSizingFunction::Length(40.0),
-      @types.Repeat(@types.Count(1), [@types.SingleTrackSizing::Length(40.0)]),
-      @types.Repeat(@types.AutoFill, [@types.SingleTrackSizing::Length(40.0)]),
+      @types.Repeat(@types.Count(1), [@types.SingleTrackSizing::Length(40.0)], []),
+      @types.Repeat(@types.AutoFill, [@types.SingleTrackSizing::Length(40.0)], []),
     ],
   }
   let root_children : Array[@node.Node] = []

--- a/layout/grid/grid.mbt
+++ b/layout/grid/grid.mbt
@@ -4797,11 +4797,143 @@ fn style_has_explicit_row(style : @style.Style) -> Bool {
 }
 
 ///|
+/// Trim leading / trailing ASCII whitespace.
+fn trim_grid_ws(s : String) -> String {
+  let chars : Array[Char] = []
+  for c in s {
+    chars.push(c)
+  }
+  let mut start = 0
+  let mut end = chars.length()
+  while start < end && (chars[start] == ' ' || chars[start] == '\t') {
+    start = start + 1
+  }
+  while end > start && (chars[end - 1] == ' ' || chars[end - 1] == '\t') {
+    end = end - 1
+  }
+  let mut r = ""
+  for i = start; i < end; i = i + 1 {
+    r = r + chars[i].to_string()
+  }
+  r
+}
+
+///|
+/// Parse a signed base-10 integer; `None` when the string isn't a bare integer.
+fn parse_grid_int(s : String) -> Int? {
+  let chars : Array[Char] = []
+  for c in s {
+    chars.push(c)
+  }
+  if chars.length() == 0 {
+    return None
+  }
+  let mut i = 0
+  let mut neg = false
+  if chars[0] == '-' {
+    neg = true
+    i = 1
+  } else if chars[0] == '+' {
+    i = 1
+  }
+  if i >= chars.length() {
+    return None
+  }
+  let mut val = 0
+  while i < chars.length() {
+    let c = chars[i]
+    if c >= '0' && c <= '9' {
+      val = val * 10 + (c.to_int() - 48)
+    } else {
+      return None
+    }
+    i = i + 1
+  }
+  Some(if neg { -val } else { val })
+}
+
+///|
+/// Parse one `grid-area` component (`auto`, `<integer>`, or `span <integer>`)
+/// into a placement. Returns `None` for names (`foo`) or `span <ident>`, which
+/// aren't line-based and should fall back to named-area handling.
+fn parse_grid_area_token(raw : String) -> @types.GridPlacement? {
+  let t = trim_grid_ws(raw)
+  if t == "" || t == "auto" {
+    return Some(@types.GridPlacement::Auto)
+  }
+  let chars : Array[Char] = []
+  for c in t {
+    chars.push(c)
+  }
+  if chars.length() >= 4 &&
+    chars[0] == 's' &&
+    chars[1] == 'p' &&
+    chars[2] == 'a' &&
+    chars[3] == 'n' {
+    let mut rest = ""
+    for i = 4; i < chars.length(); i = i + 1 {
+      rest = rest + chars[i].to_string()
+    }
+    match parse_grid_int(trim_grid_ws(rest)) {
+      Some(n) => return Some(@types.GridPlacement::Span(n))
+      None => return None
+    }
+  }
+  match parse_grid_int(t) {
+    Some(n) => Some(@types.GridPlacement::Line(n))
+    None => None
+  }
+}
+
+///|
+/// Parse a numeric / line-based `grid-area` shorthand
+/// (`<row-start> / <col-start> / <row-end> / <col-end>`) into (column, row)
+/// grid lines. Returns `None` when the value isn't line-based (a single token,
+/// or any component that is a bare name), so callers keep the named-area path.
+fn parse_grid_area_lines(area : String) -> (@types.GridLine, @types.GridLine)? {
+  let tokens : Array[String] = []
+  let mut current = ""
+  for c in area {
+    if c == '/' {
+      tokens.push(current)
+      current = ""
+    } else {
+      current = current + c.to_string()
+    }
+  }
+  tokens.push(current)
+  if tokens.length() < 2 {
+    return None
+  }
+  let placements : Array[@types.GridPlacement] = []
+  for t in tokens {
+    match parse_grid_area_token(t) {
+      Some(p) => placements.push(p)
+      None => return None
+    }
+  }
+  let row_start = placements[0]
+  let col_start = placements[1]
+  let row_end = if placements.length() > 2 {
+    placements[2]
+  } else {
+    @types.GridPlacement::Auto
+  }
+  let col_end = if placements.length() > 3 {
+    placements[3]
+  } else {
+    @types.GridPlacement::Auto
+  }
+  Some(({ start: col_start, end: col_end }, { start: row_start, end: row_end }))
+}
+
+///|
 /// Resolve a fully-explicit item's track span (col_start, col_end, row_start,
-/// row_end). A `grid-area` first tries the `grid-template-areas` map; when the
-/// name isn't a declared area it falls back to named-line placement (`grid-area:
-/// foo` => `foo / foo` on both axes, with the implicit `<name>-start` /
-/// `<name>-end` area expansion). Otherwise grid-column / grid-row are resolved.
+/// row_end). A `grid-area` first tries the `grid-template-areas` map; then the
+/// numeric / line-based shorthand (`3 / 3`, `1 / 1 / auto / span 2`); when the
+/// name is neither, it falls back to named-line placement (`grid-area: foo` =>
+/// `foo / foo` on both axes, with the implicit `<name>-start` / `<name>-end`
+/// area expansion). Otherwise grid-column / grid-row are resolved.
 fn resolve_explicit_item_placement(
   style : @style.Style,
   grid_areas : Array[Array[String]],
@@ -4815,20 +4947,34 @@ fn resolve_explicit_item_placement(
       match find_grid_area_bounds(grid_areas, area_name) {
         Some(bounds) =>
           (bounds.col_start, bounds.col_end, bounds.row_start, bounds.row_end)
-        None => {
-          // Not a template area: treat the name as a line for all four edges.
-          let line : @types.GridLine = {
-            start: @types.GridPlacement::Named(area_name),
-            end: @types.GridPlacement::Named(area_name),
+        None =>
+          // Not a template area. Try the numeric / line-based `grid-area`
+          // shorthand (`3 / 3`); only a bare name falls through to named lines.
+          match parse_grid_area_lines(area_name) {
+            Some((col_line, row_line)) => {
+              let (cs, ce) = resolve_line_placement(
+                col_line, 0, columns, column_line_names,
+              )
+              let (rs, re) = resolve_line_placement(
+                row_line, 0, explicit_rows, row_line_names,
+              )
+              (cs, ce, rs, re)
+            }
+            None => {
+              // Treat the name as a line for all four edges.
+              let line : @types.GridLine = {
+                start: @types.GridPlacement::Named(area_name),
+                end: @types.GridPlacement::Named(area_name),
+              }
+              let (cs, ce) = resolve_line_placement(
+                line, 0, columns, column_line_names,
+              )
+              let (rs, re) = resolve_line_placement(
+                line, 0, explicit_rows, row_line_names,
+              )
+              (cs, ce, rs, re)
+            }
           }
-          let (cs, ce) = resolve_line_placement(
-            line, 0, columns, column_line_names,
-          )
-          let (rs, re) = resolve_line_placement(
-            line, 0, explicit_rows, row_line_names,
-          )
-          (cs, ce, rs, re)
-        }
       }
     None => {
       let (cs, ce) = resolve_line_placement(

--- a/scripts/gen-taffy-tests.ts
+++ b/scripts/gen-taffy-tests.ts
@@ -164,7 +164,10 @@ function trackSizingToMoonBit(track: TrackSizing): string {
                     track.repeatCount === 'auto-fit' ? '@types.RepeatCount::AutoFit' :
                     `@types.RepeatCount::Count(${track.repeatCount})`;
       const innerTracks = track.tracks!.map(t => singleTrackToMoonBit(t)).join(', ');
-      return `@types.TrackSizingFunction::Repeat(${count}, [${innerTracks}])`;
+      // 3rd arg is line_names (Array[Array[String]]); taffy fixtures carry no
+      // named grid lines, so emit an empty list. Added for mizchi/css 0.7.x,
+      // which extended Repeat from (count, tracks) to (count, tracks, line_names).
+      return `@types.TrackSizingFunction::Repeat(${count}, [${innerTracks}], [])`;
     default:
       return '@types.TrackSizingFunction::Auto';
   }

--- a/specs/crater.pkl
+++ b/specs/crater.pkl
@@ -835,6 +835,16 @@ scenarios {
     contributes { "goal.css-compat"; "goal.paint-accuracy" }
   }
   new {
+    id = "bug.flex-auto-min-nested-margin"
+    name = "flex automatic minimum size measures nested margined child at the right width"
+    description =
+      "The taffy conformance fixture taffy/bevy_issue_9530 (conformance/taffy/gen_flex_test.mbt) fails: a flex-grow column item's automatic minimum size (min-height: auto) computes 360 instead of 420. The min-content path in layout/flex/flex.mbt (~6689-6704, use_max_content_min) reflows a nested measured child at the container content width (260) without subtracting that child's own horizontal margins (20+20), and crater's compute_measured_cross_size uses a continuous area-preserving reflow (area/width) where taffy uses a discrete line-count measure (ceil(max_width/avail) * line_height). Both compound: the nested child measures 180 where taffy expects 240 (Δ60). The four reduced variants pass because they either drop the nested margins or make the measure node a direct flex item. A correct fix subtracts the nested cross-axis margin AND reconciles the reflow model, but both touch the shared intrinsic-sizing core exercised by all 537 flex conformance tests, so it is treated as a risky flex-algorithm change rather than a spot fix. Pre-existing on main; not introduced by the css 0.7.x grid regen (PR #334). Source: taffy bevy_issue_9530."
+    tags { "css"; "flexbox"; "bug"; "taffy"; "conformance" }
+    severity = "minor"
+    reviewStatus = "draft"
+    contributes { "goal.css-compat" }
+  }
+  new {
     id = "bug.samesite.psl-required"
     name = "SameSite site classification needs Public Suffix List"
     description =


### PR DESCRIPTION
`mizchi/css` 0.7.x extended `TrackSizingFunction::Repeat` from `(count, tracks)` to `(count, tracks, line_names)`. The generated taffy grid suite still emitted 2-arg calls, so `moon -C conformance check` failed with **10 arity errors** — which is why the `conformance` module sits outside the CI `check` gate and had silently rotted. Regenerating surfaced 25 latent grid layout failures, which this PR also fixes at the root.

## Changes
- **`scripts/gen-taffy-tests.ts`** — emit the 3rd `Repeat` arg. taffy fixtures carry no named grid lines, so `line_names` is always `[]`.
- **`conformance/taffy/gen_grid_test.mbt`** — apply the same change to the 10 existing `Repeat` calls. The taffy JSON fixtures are not vendored (no submodule), so the generated file is patched to match exactly what the fixed generator would emit.
- **`conformance/moon.mod.json`** — pin `mizchi/css` to `0.7.3` to match the version its sibling path-deps already resolve (removes the 0.7.0 / 0.7.3 skew).
- **`layout/grid/grid.mbt`** — parse the numeric / line-based `grid-area` shorthand (`3 / 3`, `1 / 1 / auto / span 2`) into column/row grid lines. Previously `resolve_explicit_item_placement` only understood template-area names and named lines, so a non-name `grid-area` fell through to named-line resolution and collapsed the item onto the grid origin (track 0), losing the track offset. New helpers are private → `.mbti` unchanged (safe internal change).
- **`specs/crater.pkl`** — record the one remaining, pre-existing flex failure (`bevy_issue_9530`) as a draft `bug.flex-auto-min-nested-margin` scenario.

## Verification
- `moon -C conformance check --target js` → **0 errors** (was 10).
- `moon -C conformance test -p mizchi/crater-conformance/taffy` → **1029 / 1030 pass** (was 1004 / 1030).
- `moon test ./grid` in `layout/` → **62 / 62 pass** (named-area handling unaffected).

## Grid fix — root cause
25 grid snapshots (`grid_align_items_*`, `grid_justify_items_*`, `grid_span_*`, negative-line placement, `grid_taffy_issue_624`) all failed with `actual = expected − track_origin`. taffy fixtures set `grid-area` to line-based shorthand alongside equivalent `grid-column` / `grid-row`; crater only handled the name form, so the numeric value resolved to a nonexistent named line and placed the item at the origin. Parsing the shorthand into grid lines before the named-line fallback fixes all 25 at once.

## Remaining residual (out of scope)
`taffy/bevy_issue_9530` (flex, not grid) still fails: a flex-grow column item's automatic minimum size computes 360 vs 420. Pre-existing on `main`, independent of the grid regen. A fix reflows a nested margined child at the wrong width and needs the shared intrinsic-sizing core reconciled with taffy's discrete line-count measure — a risky flex-algorithm change, tracked as a draft `bug.*` scenario rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)