### PR TITLE
feat(runtime): Add js_engine as an optional JavaScript runtime written in MoonBit

### DIFF
--- a/runtime/js_runtime_jsengine.mbt
+++ b/runtime/js_runtime_jsengine.mbt
@@ -1,0 +1,72 @@
+///|
+/// JavaScript Runtime - js_engine implementation
+///
+/// Pure MoonBit JS interpreter. Compiles on all targets:
+///   native: moon check -p runtime --target native
+///   js:     moon check -p runtime --target js
+///   wasm:   moon check -p runtime --target wasm
+///
+/// Opt-in via: browser.set_js_runtime(jsengine_runtime_ref())
+///
+/// Alternatives:
+///   Default: NativeStubRuntime (NotSupported)
+///   V8:      browser/native/js_v8/js_runtime_v8.mbt
+
+///|
+priv struct JsEngineRuntime {
+  _unused : Int
+}
+
+///|
+let jsengine_runtime : JsEngineRuntime = { _unused: 0 }
+
+///|
+/// Get a reference to the js_engine runtime for opt-in use.
+pub fn jsengine_runtime_ref() -> &JsRuntime {
+  jsengine_runtime as &JsRuntime
+}
+
+///|
+impl JsRuntime for JsEngineRuntime with fn init(self : JsEngineRuntime) -> Unit {
+  let _ = self
+}
+
+///|
+impl JsRuntime for JsEngineRuntime with fn execute(
+  self : JsEngineRuntime,
+  context_id : Int,
+  dom : @dom.DomTree,
+  code : String,
+  async_mode : AsyncExecutionMode,
+) -> JsResult raise JsError {
+  let _ = (self, context_id, dom, async_mode)
+  try {
+    let interp = @interpreter.new_interpreter()
+    let prog = @parser.parse(code)
+    let result = interp.run(prog.stmts)
+    interp.run_microtasks()
+    interp.run_timers()
+    JsResult::new(result.to_string(), interp.host.output, true)
+  } catch {
+    e => raise JsError::ExecutionError(describe_js_engine_error(e))
+  }
+}
+
+///|
+impl JsRuntime for JsEngineRuntime with fn tick(
+  self : JsEngineRuntime,
+  context_id : Int,
+  dom : @dom.DomTree,
+) -> JsResult raise JsError {
+  let _ = (self, context_id, dom)
+  JsResult::new("false", [], true)
+}
+
+///|
+fn describe_js_engine_error(err : Error) -> String {
+  @js_errors.name_message_if_js_error(err)
+  .map_or(err.to_string(), fn(pair) {
+    let (name, msg) = pair
+    name + ": " + msg
+  })
+}

--- a/runtime/js_runtime_native_stub.mbt
+++ b/runtime/js_runtime_native_stub.mbt
@@ -1,8 +1,13 @@
 ///|
 /// JavaScript Runtime - Native target
 ///
-/// Default is stub (NotSupported). To enable V8, use JsContext::new_with_runtime()
-/// with the V8JsRuntime from mizchi/crater-browser-native/js_v8.
+/// Default stub raises NotSupported. Opt-in backends:
+///
+///   - js_engine (pure MoonBit): browser.set_js_runtime(jsengine_runtime_ref())
+///     See runtime/js_runtime_jsengine.mbt
+///
+///   - V8 (native FFI):          browser.set_js_runtime(V8JsRuntime::new())
+///     See browser/native/js_v8/js_runtime_v8.mbt
 
 ///|
 priv struct NativeStubRuntime {

--- a/runtime/moon.mod
+++ b/runtime/moon.mod
@@ -4,6 +4,7 @@ version = "0.19.0"
 
 import {
   "mizchi/crater-dom@0.19.0",
+  "dowdiness/js_engine@0.5.0",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/runtime/moon.pkg
+++ b/runtime/moon.pkg
@@ -2,17 +2,22 @@ import {
   "mizchi/crater-dom/dom",
   "mizchi/crater-dom/scheduler",
   "moonbitlang/core/string",
+  "dowdiness/js_engine/errors" @js_errors,
+  "dowdiness/js_engine/interpreter" @interpreter,
+  "dowdiness/js_engine/parser",
 }
 
 options(
   targets: {
-    // Stubs
-    "js_runtime_native_stub.mbt": [ "native" ],
+    // QuickJS runtime (JS target)
     "js_runtime_quickjs.mbt": [ "js" ],
     "js_runtime_quickjs_dom_ops.mbt": [ "js" ],
     "dom_ops_wbtest.mbt": [ "js" ],
     "js_runtime_quickjs_ffi.mbt": [ "js" ],
+    // WASM stub
     "js_runtime_wasm.mbt": [ "wasm", "wasm-gc" ],
+    "js_runtime_jsengine.mbt": [ "js", "native", "wasm", "wasm-gc" ],
+    // Scheduler integration
     "scheduler_integration_js.mbt": [ "js", "native" ],
     "scheduler_integration_stub.mbt": [ "wasm", "wasm-gc" ],
   },


### PR DESCRIPTION
## Summary

crater's native backend defaulted to a stub that raised NotSupported. For JS execution, users had to set up V8 (native FFI) or switch to the JS target which uses QuickJS. This PR adds a third option: [js_engine](https://mooncakes.io/docs/dowdiness/js_engine), a JavaScript interpreter written in MoonBit.

Because [js_engine ](https://mooncakes.io/docs/dowdiness/js_engine)is written entirely in MoonBit, the same implementation can be compiled to the native, JavaScript, and WebAssembly targets without FFI.

Please feel free to close this PR if you don't think it's a good fit for the project.

## Opt-in

The default runtime for each target remains unchanged

native: NotSupported stub
JavaScript: QuickJS
WebAssembly: NotSupported stub

This PR only adds an opt-in runtime and does not change existing default behavior.

## Usage

To enable js_engine:

```mbt
let browser = Browser::new(1024, 768)
browser.set_js_runtime(jsengine_runtime_ref())
```

## Conformance

[Current test262 results](https://github.com/dowdiness/js_engine#conformance) for js_engine

strict:     29,526/ 44,986 passed  65.6%
non-strict: 31,341/ 47,692  passed  65.7%

## Limitations

js_engine is a tree-walking interpreter and is slower than V8 or QuickJS.

It is intended for testing, scripting, and environments where avoiding native FFI is more important than JavaScript execution performance. It is not currently intended for production page-loading workloads.
