### PR TITLE
chore(deps): update external dependencies to latest

### DIFF
--- a/.github/actions/moon-prefetch/action.yml
+++ b/.github/actions/moon-prefetch/action.yml
@@ -30,7 +30,9 @@ runs:
           manifest="${manifest%% }"
           if [ -z "$manifest" ]; then continue; fi
           echo "::group::Update + prefetch ${manifest}"
-          bash scripts/ci/moon-update-retry.sh --manifest-path "$manifest"
-          bash scripts/ci/prefetch-moon-deps.sh --manifest-path "$manifest"
+          # `moon tree` / `moon update` take no `--manifest-path`; select the
+          # module with the common `-C <dir>` option instead.
+          bash scripts/ci/moon-update-retry.sh -C "$(dirname "$manifest")"
+          bash scripts/ci/prefetch-moon-deps.sh -C "$(dirname "$manifest")"
           echo "::endgroup::"
         done <<<"$EXTRA_MANIFESTS"

--- a/TODO.md
+++ b/TODO.md
@@ -87,6 +87,7 @@ scenario 化していない (contract として書く粒度ではない) もの�
 - `mizchi/css`: mixed `calc()` (percentage + length) の Dimension 表現が無く `Auto` に落ちる → #67 (css-values), 設計メモ `docs/css-calc-and-border-longhand-design.md`
 - `mizchi/css`: `border` shorthand が後続の `border-*-width` longhand を上書き (cascade order) → #68 (css-images)
 - `mizchi/css`: `sibling-index()` 未実装 → #68
+- `mizchi/v8`: 公開済み最新の 0.2.0 が現行 moonbitlang/core でコンパイル不能 (`@strconv.parse_int` が `moonbitlang/core/string` へ移動、 `StrConvError` 廃止) → `moon check --target native` / `just check` が `.mooncakes/mizchi/v8` で失敗する。 v8.mbt main は修正済み (version 0.3.0) なので mooncakes へ publish 後、 `browser/native/moon.mod` の pin を 0.3.0 に上げれば解消
 - `mizchi/kagura`: SVG rasterizer alpha 問題 (テキスト色が薄い) → #19 / #47 関連
 - `mizchi/kagura`: glyph mirror per-quad UV swap workaround の正しい層での解消
 - CI: llvmpipe セットアップ判断 (`LIBGL_ALWAYS_SOFTWARE=1` / `mesa-vulkan-drivers`)

--- a/TODO.md
+++ b/TODO.md
@@ -87,7 +87,6 @@ scenario 化していない (contract として書く粒度ではない) もの�
 - `mizchi/css`: mixed `calc()` (percentage + length) の Dimension 表現が無く `Auto` に落ちる → #67 (css-values), 設計メモ `docs/css-calc-and-border-longhand-design.md`
 - `mizchi/css`: `border` shorthand が後続の `border-*-width` longhand を上書き (cascade order) → #68 (css-images)
 - `mizchi/css`: `sibling-index()` 未実装 → #68
-- `mizchi/v8`: 公開済み最新の 0.2.0 が現行 moonbitlang/core でコンパイル不能 (`@strconv.parse_int` が `moonbitlang/core/string` へ移動、 `StrConvError` 廃止) → `moon check --target native` / `just check` が `.mooncakes/mizchi/v8` で失敗する。 v8.mbt main は修正済み (version 0.3.0) なので mooncakes へ publish 後、 `browser/native/moon.mod` の pin を 0.3.0 に上げれば解消
 - `mizchi/kagura`: SVG rasterizer alpha 問題 (テキスト色が薄い) → #19 / #47 関連
 - `mizchi/kagura`: glyph mirror per-quad UV swap workaround の正しい層での解消
 - CI: llvmpipe セットアップ判断 (`LIBGL_ALWAYS_SOFTWARE=1` / `mesa-vulkan-drivers`)

--- a/benchmarks/moon.mod
+++ b/benchmarks/moon.mod
@@ -10,7 +10,7 @@ import {
   "mizchi/crater-layout@0.19.0",
   "mizchi/crater-painter@0.19.0",
   "mizchi/crater-renderer@0.19.0",
-  "mizchi/svg@0.2.1",
+  "mizchi/svg@0.2.3",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/browser/moon.mod
+++ b/browser/moon.mod
@@ -16,11 +16,11 @@ import {
   "mizchi/crater-html-assets@0.19.0",
   "mizchi/crater-terminal-image-cache@0.19.0",
   "mizchi/crater-terminal-protocol@0.19.0",
-  "mizchi/font@0.7.3",
+  "mizchi/font@0.7.4",
   "mizchi/tui-terminal-buffer@0.1.3",
-  "mizchi/x@0.5.1",
-  "moonbitlang/async@0.20.1",
-  "moonbitlang/x@0.4.46",
+  "mizchi/x@0.6.0",
+  "moonbitlang/async@0.21.3",
+  "moonbitlang/x@0.5.4",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/browser/native/moon.mod
+++ b/browser/native/moon.mod
@@ -5,17 +5,10 @@ version = "0.19.0"
 import {
   "mizchi/crater-browser-runtime@0.19.0",
   "mizchi/crater-dom@0.19.0",
-  // Pinned to the newest published mizchi/v8. It does not compile against the
-  // current moonbitlang/core (`@strconv.parse_int` was moved to
-  // `moonbitlang/core/string` and `StrConvError` is gone), so
-  // `moon check --target native` fails inside `.mooncakes/mizchi/v8`.
-  // v8.mbt main already carries the fix and is versioned 0.3.0; bump this pin
-  // to 0.3.0 once that is published to mooncakes. See TODO.md External / Blocker.
-  "mizchi/v8@0.2.0",
-  // mizchi/v8 pins moonbitlang/async 0.16.8, which no longer compiles against
-  // the current core (`IterResult` undefined in task_group.mbt). This module is
-  // its own single-member workspace (`browser/native/moon.work`), so it resolves
-  // deps independently of the root workspace and needs the floor stated here.
+  "mizchi/v8@0.3.0",
+  // This module is its own single-member workspace (`browser/native/moon.work`),
+  // so it resolves deps independently of the root workspace. State the async
+  // floor here rather than inheriting whatever mizchi/v8 happens to pin.
   "moonbitlang/async@0.21.3",
 }
 

--- a/browser/native/moon.mod
+++ b/browser/native/moon.mod
@@ -5,7 +5,18 @@ version = "0.19.0"
 import {
   "mizchi/crater-browser-runtime@0.19.0",
   "mizchi/crater-dom@0.19.0",
+  // Pinned to the newest published mizchi/v8. It does not compile against the
+  // current moonbitlang/core (`@strconv.parse_int` was moved to
+  // `moonbitlang/core/string` and `StrConvError` is gone), so
+  // `moon check --target native` fails inside `.mooncakes/mizchi/v8`.
+  // v8.mbt main already carries the fix and is versioned 0.3.0; bump this pin
+  // to 0.3.0 once that is published to mooncakes. See TODO.md External / Blocker.
   "mizchi/v8@0.2.0",
+  // mizchi/v8 pins moonbitlang/async 0.16.8, which no longer compiles against
+  // the current core (`IterResult` undefined in task_group.mbt). This module is
+  // its own single-member workspace (`browser/native/moon.work`), so it resolves
+  // deps independently of the root workspace and needs the floor stated here.
+  "moonbitlang/async@0.21.3",
 }
 
 readme = "README.md"

--- a/browser/scripts/mizchi-v8-consumer-prebuild.mjs
+++ b/browser/scripts/mizchi-v8-consumer-prebuild.mjs
@@ -65,8 +65,23 @@ function candidate_mooncakes_roots(root) {
   return candidates
 }
 
+// A module manifest is `moon.mod.json` on older MoonBit and `moon.mod` on
+// current ones, and a published package ships whichever its author used:
+// mizchi/v8 0.2.0 shipped `moon.mod.json`, 0.3.0 ships `moon.mod`. Probing only
+// the JSON name made an installed 0.3.0 invisible here, which surfaced as
+// "failed to locate mizchi/v8" even though `.mooncakes/mizchi/v8` was present.
+export function has_moon_module_manifest(dir) {
+  return (
+    fs.existsSync(path.join(dir, "moon.mod.json")) ||
+    fs.existsSync(path.join(dir, "moon.mod"))
+  )
+}
+
 export function resolve_v8_module_root(module_root, search_roots = []) {
   const roots = collect_search_roots(module_root, search_roots)
+  // A local path dependency is only expressible in the JSON manifest, so this
+  // lookup stays JSON-only; consumers on `moon.mod` fall through to the
+  // `.mooncakes` scan below.
   for (const root of roots) {
     const moon_mod_path = path.join(root, "moon.mod.json")
     if (!fs.existsSync(moon_mod_path)) {
@@ -81,7 +96,7 @@ export function resolve_v8_module_root(module_root, search_roots = []) {
 
   for (const root of roots) {
     for (const mooncakes_root of candidate_mooncakes_roots(root)) {
-      if (fs.existsSync(path.join(mooncakes_root, "moon.mod.json"))) {
+      if (has_moon_module_manifest(mooncakes_root)) {
         return mooncakes_root
       }
     }

--- a/browser/scripts/mizchi-v8-consumer-prebuild.test.mjs
+++ b/browser/scripts/mizchi-v8-consumer-prebuild.test.mjs
@@ -15,6 +15,11 @@ function write_json(file_path, value) {
   fs.writeFileSync(file_path, `${JSON.stringify(value, null, 2)}\n`)
 }
 
+function write_text(file_path, contents) {
+  fs.mkdirSync(path.dirname(file_path), { recursive: true })
+  fs.writeFileSync(file_path, contents)
+}
+
 test("resolve_v8_module_root prefers a local path dependency", (t) => {
   const temp_root = fs.mkdtempSync(path.join(os.tmpdir(), "mizchi-v8-prebuild-"))
   t.after(() => fs.rmSync(temp_root, { recursive: true, force: true }))
@@ -73,6 +78,23 @@ test("resolve_v8_module_root falls back to ancestor workspace mooncakes", (t) =>
   write_json(path.join(v8_root, "moon.mod.json"), {
     name: "mizchi/v8",
   })
+
+  assert.equal(resolve_v8_module_root(native_root), v8_root)
+})
+
+test("resolve_v8_module_root finds a mooncakes install shipping moon.mod", (t) => {
+  const temp_root = fs.mkdtempSync(path.join(os.tmpdir(), "mizchi-v8-prebuild-"))
+  t.after(() => fs.rmSync(temp_root, { recursive: true, force: true }))
+
+  // mizchi/v8 0.2.0 shipped `moon.mod.json`; 0.3.0 ships the `moon.mod` format.
+  // The consumer manifest is on `moon.mod` too, so nothing here is JSON.
+  const native_root = path.join(temp_root, "browser", "native")
+  const v8_root = path.join(native_root, ".mooncakes", "mizchi", "v8")
+  write_text(
+    path.join(native_root, "moon.mod"),
+    'name = "mizchi/crater-browser-native"\n\nimport {\n  "mizchi/v8@0.3.0",\n}\n',
+  )
+  write_text(path.join(v8_root, "moon.mod"), 'name = "mizchi/v8"\n\nversion = "0.3.0"\n')
 
   assert.equal(resolve_v8_module_root(native_root), v8_root)
 })

--- a/http/http_native.mbt
+++ b/http/http_native.mbt
@@ -49,8 +49,14 @@ pub async fn fetch(
   // Extract host URL (without path) and path separately
   let host_url = extract_host_url(url)
   let path = extract_path_from_url(url)
-  // Create HTTP client with just the host
-  let client = @async_http.Client::new(host_url, headers=prepared.headers) catch {
+  // Create HTTP client with just the host.
+  // @async_http keys headers by `CaseInsensitiveString`, so lift the plain
+  // `Map[String, String]` the crater API exposes into that key type.
+  let request_headers : Map[@async_http.CaseInsensitiveString, String] = {}
+  for k, v in prepared.headers {
+    request_headers[@async_http.CaseInsensitiveString(k)] = v
+  }
+  let client = @async_http.Client::new(host_url, headers=request_headers) catch {
     _ => raise InvalidUrl(url)
   }
   // Perform request based on method
@@ -76,10 +82,10 @@ pub async fn fetch(
   }
   let body = body_data.text() catch { _ => "" }
   client.close()
-  // Convert headers
+  // Convert headers back to the plain lowercase-keyed map crater exposes
   let headers : Map[String, String] = {}
   for k, v in response.headers {
-    headers[k.to_lower()] = v
+    headers[k.0.to_lower()] = v
   }
   let result = { status: response.code, headers, body }
   enforce_cors_response(url, prepared, result)

--- a/http/moon.mod
+++ b/http/moon.mod
@@ -3,7 +3,7 @@ name = "mizchi/crater-browser-http"
 version = "0.19.0"
 
 import {
-  "moonbitlang/async@0.20.1",
+  "moonbitlang/async@0.21.3",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/layout/moon.mod
+++ b/layout/moon.mod
@@ -7,7 +7,7 @@ description = "Layout kernel for crater CSS layout engine"
 import {
   "mizchi/css@0.7.3",
   "mizchi/crater-core@0.19.0",
-  "mizchi/layout@0.2.0",
+  "mizchi/layout@0.2.1",
 }
 
 preferred_target = "js"

--- a/painter/moon.mod
+++ b/painter/moon.mod
@@ -6,10 +6,10 @@ import {
   "mizchi/css@0.7.3",
   "mizchi/crater-core@0.19.0",
   "mizchi/crater-terminal-protocol@0.19.0",
-  "mizchi/font@0.7.3",
-  "mizchi/svg@0.2.1",
-  "mizchi/x@0.5.1",
-  "moonbitlang/async@0.20.1",
+  "mizchi/font@0.7.4",
+  "mizchi/svg@0.2.3",
+  "mizchi/x@0.6.0",
+  "moonbitlang/async@0.21.3",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/renderer/moon.mod
+++ b/renderer/moon.mod
@@ -9,8 +9,8 @@ import {
   "mizchi/crater-layout@0.19.0",
   "mizchi/crater-painter@0.19.0",
   "mizchi/gfx@0.1.0",
-  "mizchi/svg@0.2.1",
-  "moonbitlang/async@0.20.1",
+  "mizchi/svg@0.2.3",
+  "moonbitlang/async@0.21.3",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/scripts/ci/moon-update-retry.sh
+++ b/scripts/ci/moon-update-retry.sh
@@ -5,14 +5,28 @@
 # That host occasionally times out in CI (observed: a ~135s connect timeout
 # failing the whole prefetch job), which is a transient infra blip, not a real
 # dependency problem. Retry with exponential backoff so a one-off mooncakes.io
-# outage doesn't fail the run. Any extra args (e.g. `--manifest-path <p>`) are
-# forwarded to `moon update`.
+# outage doesn't fail the run.
+#
+# A leading `-C <dir>` selects the module to update. It is hoisted in front of
+# the subcommand (`moon -C <dir> update`) because `-C` is a common option that
+# must precede it; `moon update` itself takes no `--manifest-path`. Any
+# remaining args are forwarded to `moon update`.
 set -euo pipefail
+
+moon_common=()
+if [[ "${1:-}" == "-C" ]]; then
+  if [[ $# -lt 2 ]]; then
+    echo "usage: $(basename "$0") [-C <dir>] [moon update args...]" >&2
+    exit 2
+  fi
+  moon_common=(-C "$2")
+  shift 2
+fi
 
 attempts=4
 delay=5
 for attempt in $(seq 1 "$attempts"); do
-  if moon update "$@"; then
+  if moon ${moon_common[@]+"${moon_common[@]}"} update "$@"; then
     exit 0
   fi
   if [ "$attempt" -eq "$attempts" ]; then

--- a/scripts/ci/prefetch-moon-deps.sh
+++ b/scripts/ci/prefetch-moon-deps.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
+# Prefetch every registry dependency of a module so later steps run offline.
+#
+# A leading `-C <dir>` selects the module. It is hoisted in front of the
+# subcommand (`moon -C <dir> tree`) because `-C` is a common option that must
+# precede it; neither `moon tree` nor `moon fetch` accepts `--manifest-path`.
+# Any remaining args are forwarded to `moon tree`.
 set -euo pipefail
+
+moon_common=()
+if [[ "${1:-}" == "-C" ]]; then
+  if [[ $# -lt 2 ]]; then
+    echo "usage: $(basename "$0") [-C <dir>] [moon tree args...]" >&2
+    exit 2
+  fi
+  moon_common=(-C "$2")
+  shift 2
+fi
 
 tmp_tree="$(mktemp)"
 tmp_deps="$(mktemp)"
 trap 'rm -f "$tmp_tree" "$tmp_deps"' EXIT
 
-if [[ $# -gt 0 ]]; then
-  moon tree "$@" >"$tmp_tree"
-else
-  moon tree >"$tmp_tree"
-fi
+moon ${moon_common[@]+"${moon_common[@]}"} tree "$@" >"$tmp_tree"
 
 awk '
   /->/ {
@@ -32,9 +44,5 @@ echo "Prefetching MoonBit dependencies"
 cat "$tmp_deps"
 
 while IFS= read -r dep; do
-  if [[ $# -gt 0 ]]; then
-    moon fetch --no-update "$@" "$dep"
-  else
-    moon fetch --no-update "$dep"
-  fi
+  moon ${moon_common[@]+"${moon_common[@]}"} fetch --no-update "$dep"
 done <"$tmp_deps"

--- a/terminal_protocol/moon.mod
+++ b/terminal_protocol/moon.mod
@@ -4,7 +4,7 @@ version = "0.19.0"
 
 import {
   "mizchi/tui-terminal-protocol@0.1.2",
-  "moonbitlang/async@0.20.1",
+  "moonbitlang/async@0.21.3",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/tools/moon.mod
+++ b/tools/moon.mod
@@ -4,8 +4,8 @@ version = "0.19.0"
 
 import {
   "mizchi/crater-webdriver-bidi@0.19.0",
-  "mizchi/js@0.12.1",
-  "mizchi/js_deno@0.12.1",
+  "mizchi/js@0.12.2",
+  "mizchi/js_deno@0.12.2",
 }
 
 repository = "https://github.com/mizchi/crater"

--- a/webdriver/moon.mod
+++ b/webdriver/moon.mod
@@ -6,8 +6,8 @@ import {
   "mizchi/css@0.7.3",
   "mizchi/crater-core@0.19.0",
   "mizchi/crater-network@0.19.0",
-  "mizchi/font@0.7.3",
-  "mizchi/svg@0.2.1",
+  "mizchi/font@0.7.4",
+  "mizchi/svg@0.2.3",
   "mizchi/crater-dom@0.19.0",
   "mizchi/crater-layout@0.19.0",
   "mizchi/crater-painter@0.19.0",
@@ -16,9 +16,9 @@ import {
   "mizchi/crater-browser-http@0.19.0",
   "mizchi/crater-browser-helpers@0.19.0",
   "mizchi/webdriver@0.2.6",
-  "mizchi/js@0.12.1",
-  "mizchi/js_deno@0.12.1",
-  "moonbitlang/async@0.20.1",
+  "mizchi/js@0.12.2",
+  "mizchi/js_deno@0.12.2",
+  "moonbitlang/async@0.21.3",
 }
 
 readme = "README.md"


### PR DESCRIPTION
外部依存を publish 済み最新に更新し、それに伴うコンパイルエラーと CI の破綻を修正しました。**`moon check` は全ターゲットで 0 errors、CI / Browser 両ワークフローとも green です。**

## 依存の更新

| package | before | after |
| --- | --- | --- |
| `mizchi/font` | 0.7.3 | 0.7.4 |
| `mizchi/js` | 0.12.1 | 0.12.2 |
| `mizchi/js_deno` | 0.12.1 | 0.12.2 |
| `mizchi/layout` | 0.2.0 | 0.2.1 |
| `mizchi/svg` | 0.2.1 | 0.2.3 |
| `mizchi/v8` | 0.2.0 | 0.3.0 |
| `mizchi/x` | 0.5.1 | 0.6.0 |
| `moonbitlang/async` | 0.20.1 | 0.21.3 |
| `moonbitlang/x` | 0.4.46 | 0.5.4 |

`mizchi/css@0.7.3` / `mizchi/webdriver@0.2.6` / `mizchi/gfx@0.1.0` / `mizchi/tui-terminal-buffer@0.1.3` / `mizchi/tui-terminal-protocol@0.1.2` は既に registry 最新のため据え置きです。

## 追随した修正

**`http/http_native.mbt`** — moonbitlang/async 0.21 で HTTP header の key が `String` から `@async_http.CaseInsensitiveString` に変わりました。`prepare_fetch_options` の header を送信時にその key 型へ lift し、レスポンス側は crater の `HttpResponse` が公開している素の lowercase key の `Map[String, String]` に戻しています。

**`browser/native/moon.mod`** — `browser/native` は `browser/native/moon.work` を持つ単独 workspace なので root workspace とは独立に依存解決され、`mizchi/v8` が pin していた moonbitlang/async 0.16.8 を拾っていました。このバージョンは現行 core でコンパイルできない (`task_group.mbt` で `IterResult` undefined) ため、0.21.3 の下限をここに明示しています。

**`browser/scripts/mizchi-v8-consumer-prebuild.mjs`** — `resolve_v8_module_root` が `.mooncakes` のインストールを `moon.mod.json` の有無だけで判定していました。v8 0.2.0 はその名前でしたが **0.3.0 は `moon.mod` 形式**を同梱しているため、ディレクトリはあるのに `failed to locate mizchi/v8` になり Browser ワークフローが落ちました。どちらの manifest 名も受け付けるようにし、回帰テストを追加しています (旧判定に戻すと落ちることを確認済み)。

## CI の修復 (既存の破綻)

`scripts/ci/prefetch-moon-deps.sh` と `moon-update-retry.sh` が `moon tree` / `moon update` / `moon fetch` に `--manifest-path` を渡していましたが、現行 MoonBit はこれを受け付けません:

```
error: unexpected argument '--manifest-path' found
Usage: moon tree [OPTIONS]
```

`-C <dir>` はサブコマンドの前に置く common option です。そのため追加マニフェストを prefetch するジョブ (`test` / `wasm-component` / `js-package` / `playwright-bidi-tests` / `wpt-dom` / `wpt-webdriver`) が軒並み "Prefetch MoonBit dependencies" で落ち、root しか prefetch しない `vrt-bench` だけが緑という状態でした。

両スクリプトが先頭の `-C <dir>` を受け取ってサブコマンドの前に置くようにし、action 側は既存の manifest パスから dirname を渡します。ワークフロー側の変更は不要で、引数なしの挙動は従来どおりです。

これは依存更新の巻き添えではなく**このブランチの前 head でも同じ 4 ジョブが同じ step で落ちていた既存のツールチェイン追随漏れ**ですが、これがないと本 PR の CI が緑にならないため、ここで直しています。

## mizchi/v8 の blocker は解消済み

作業開始時点で publish 済み最新だった `mizchi/v8@0.2.0` は現行 core でコンパイルできず (`@strconv.parse_int` が `moonbitlang/core/string` へ移動、`StrConvError` 廃止)、`moon check --target native` / `just check` がそこで落ちていました。

upstream を修正して 0.3.0 が publish されたため ([mizchi/v8.mbt#1](https://github.com/mizchi/v8.mbt/pull/1), [#2](https://github.com/mizchi/v8.mbt/pull/2))、本 PR では pin を 0.3.0 に上げて blocker を解消しています。`TODO.md` の External / Blocker エントリも削除しました。

## 検証

### CI (ubuntu runner, 実 rusty_v8 ビルドあり)

CI / Browser 両ワークフローとも全ジョブ success。特に `test` ジョブの hard gate:

- `just check` (`moon -C browser/native check --target native` を含む): **success**
- native facade smoke / native V8 runtime smoke / native V8 DOM・snapshot smoke: **すべて success**

### ローカル (moon 0.1.20260904 / moonc v0.10.12)

**実際に publish された 0.3.0** に対して確認しています (両方の `.mooncakes` を registry から取り直し、ローカルパッチなし):

- `moon check --target js` (root workspace 全 member): **0 errors**
- `moon check --target native` (root workspace): **0 errors**
- `moon -C browser/native check --target native`: **0 errors**
- `moon -C wasm check --target wasm`: **0 errors**
- `moon -C conformance check --target js`: **0 errors**
- `moon -C {aomx,benchmarks,browser_helpers,testing,webvitals,http,dom,layout,painter,renderer,runtime,browser,js} check --target js`: **0 errors**
- `moon test -p mizchi/crater-browser-http --target native`: 70/70 passed
- `moon test --target js`: 3641 中 3639 passed
- `node --test browser/scripts/mizchi-v8-consumer-prebuild.test.mjs`: 6/6 passed

`moon test --target js` の残る 2 件 (browser の js mutation records / shell sixel snapshot) は本 PR 適用前のツリーでも同じように落ちるため、この変更とは無関係の既存の失敗です。

作業環境からは rusty_v8 の source archive を取得できない (github egress が 403) ため、ローカルの `moon check` 群は `CRATER_SKIP_V8_BUILD=1` 付きで実行しています。`browser/scripts/mizchi-v8-consumer-prebuild.mjs` が既に想定しているケースで、スキップされるのはネイティブ bridge のビルドだけです。ネイティブのリンクと実行は上記 CI が実機で確認しています。

## 含めていないもの

`moon info` / `moon fmt` を現行ツールチェインで流すと、struct literal の trailing comma や `options("is-main")` → `pkgtype(kind:)` 移行、`.mbti` の末尾空行削除など 380 ファイル超のフォーマッタ差分が出ます。依存更新とは無関係なツールチェイン drift なので本 PR には含めていません (CI の format check は `continue-on-error`)。別 PR で一括適用するのが良さそうです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114XoakYgfkaMBMwWr9WmMT
