### PR TITLE
perf(layout): memoize width-independent box-model resolution on the node

### DIFF
--- a/.github/actions/setup-crater/action.yml
+++ b/.github/actions/setup-crater/action.yml
@@ -56,7 +56,26 @@ runs:
       if: inputs.native-deps == 'true'
       shell: bash
       run: |
-        sudo apt-get update
+        # `apt-get update` exits non-zero when ANY configured index fails to
+        # refresh, and the runner image ships a Google Chrome source this repo
+        # does not use. A hash-sum mismatch there (Google's CDN serving a stale
+        # Packages.gz against a fresh Release file) has taken the whole `test`
+        # job down at this step, before MoonBit was even installed. Only the
+        # Ubuntu archive provides libsqlite3-dev, so retry the refresh and then
+        # let the install be the gate: apt keeps the previous index for a source
+        # it could not refresh, and a genuinely missing package still fails here.
+        refreshed=0
+        for attempt in 1 2 3; do
+          if sudo apt-get update; then
+            refreshed=1
+            break
+          fi
+          echo "apt-get update failed (attempt ${attempt}/3); retrying" >&2
+          sleep $((attempt * 5))
+        done
+        if [[ "${refreshed}" -ne 1 ]]; then
+          echo "apt-get update never refreshed every index; continuing to the install" >&2
+        fi
         sudo apt-get install -y libsqlite3-dev
 
     - name: Set up MoonBit

--- a/benchmarks/BASELINE.md
+++ b/benchmarks/BASELINE.md
@@ -886,3 +886,88 @@ Optimizations (all bit-identical to the general path):
    single pass for the common uniform clears (opaque white / transparent
    black), and full-frame `read_pixels` does one bulk copy instead of a
    per-pixel gather.
+
+## Box-Model Resolution (2026-09-09)
+
+### How this was measured
+
+`moon bench` reports each benchmark once per invocation, so comparing a "before"
+run of the whole suite against an "after" run charges every benchmark whatever
+the machine happened to be doing while it ran. On this runner that is enough to
+drown the signal: the suite diff for the change below came back 93 benchmarks
+faster and 85 slower, with `parse_simple_10` moving +59% and `render_cards_24`
++301% — from a change that cannot touch either.
+
+`benchmarks/scripts/ab-bench.mjs` alternates two prebuilt bundles benchmark by
+benchmark and repeats the sweep, so both variants meet the same machine seconds
+apart, and reports the median of each variant's per-run medians. Always include a
+benchmark the change cannot affect and read its delta as the run's noise floor —
+with 11 repetitions here, `parse_simple_100`, `match_non_idx_1k` and
+`render_large_2k5` all landed inside ±1%.
+
+```bash
+moon -C benchmarks bench --target js --build-only
+cp _build/js/release/bench/mizchi/crater-benchmarks/{crater-benchmarks.internal_test.js,package.json,__internal_test_info.json} /tmp/ab/after/
+git stash && moon -C benchmarks bench --target js --build-only \
+  && cp _build/js/release/bench/mizchi/crater-benchmarks/{crater-benchmarks.internal_test.js,package.json,__internal_test_info.json} /tmp/ab/before/ \
+  && git stash pop
+node benchmarks/scripts/ab-bench.mjs --before /tmp/ab/before --after /tmp/ab/after --reps 11 \
+  --filter deep_flex --filter render_flex --filter parse_simple
+```
+
+### What the profile said
+
+`node --cpu-prof` / `--heap-prof` on `render_large_2k5` (2.5k nodes):
+
+- the garbage collector was the single largest CPU entry at **14.4%**;
+- `@css.resolve_rect` was the largest allocator of the whole layout phase at
+  **21%** of sampled bytes — 141k calls per 10 renders, each materializing a
+  fresh `Rect[Double]`;
+- **every one of those 141k calls** resolved a rect whose four sides were plain
+  lengths, i.e. whose result did not depend on the containing-block width at all;
+- flex's `(uid, quantized width)`-keyed resolved-rect cache hit **0 times in
+  19,668 lookups** — but 58.6% of those lookups were repeat visits to a node it
+  had already resolved, missing only because the width in the key differed. It
+  was allocating a `ResolvedRects` plus a map entry per call for nothing.
+
+### What changed
+
+`Node::resolved_rects` resolves `padding`/`margin`/`border` once and memoizes the
+result on the node whenever the three rects ignore the containing-block width.
+`Node::style` is immutable, so a node-attached memo cannot go stale and needs no
+reset discipline; a rect that genuinely reads the width is resolved every time,
+as before. Flex, block and table now go through it instead of calling
+`resolve_rect` directly. Two smaller allocation fixes rode along: the block-flow
+cache key (five `Double::to_string()` calls and six concatenations) is now built
+only where it is consulted rather than on every block child of every static
+render, and `compute_block_child_memoized` stops rebuilding its result record
+when scroll-snap hands the layout straight back.
+
+Sampled workload allocation on `render_large_2k5` fell from **20.4 MB to 7.1 MB**
+(excluding Node's own module loading), and the GC's CPU share from **14.4% to
+8.8%**.
+
+### Result
+
+Final confirmation run, 9 interleaved repetitions, median of medians; the delta
+range is across three separate sweeps (5, 11 and 9 repetitions), so it also shows
+how much each figure still moves run to run.
+
+| Benchmark | Before | After | Delta | Range over 3 sweeps |
+|-----------|--------|-------|-------|---------------------|
+| `render_flex_d5` | 8.10 ms | 6.02 ms | **-25.6%** | -23% … -28% |
+| `deep_flex_d6` | 9.30 ms | 7.12 ms | **-23.5%** | -23% … -28% |
+| `render_flex_d6` | 25.06 ms | 21.39 ms | **-14.6%** | -9% … -15% |
+| `dashboard_layout` | 1.35 ms | 1.17 ms | **-13.9%** | -11% … -16% |
+| `nested_flex_d4` | 683.25 µs | 630.67 µs | -7.7% | -8% … -13% |
+| `render_large_2k5` | 30.20 ms | 29.35 ms | -2.8% | -3% … +0% |
+| `parse_simple_100` (control) | 32.83 µs | 34.06 µs | +3.8% | -1% … +4% |
+| `parse_simple_1000` (control) | 393.30 µs | 377.93 µs | -3.9% | — |
+| `match_non_idx_1k` (control) | 31.79 µs | 30.63 µs | -3.7% | -4% … +2% |
+
+The controls put this runner's noise floor at roughly ±4%, so the nested-flex and
+dashboard figures are the real signal. The gain concentrates where intrinsic
+sizing revisits the same node many times — nested flex, deep block nesting,
+dashboard-shaped documents. Benchmarks bound by parsing, selector matching or
+rasterization sit inside the noise floor, as expected: this change removes
+allocation from layout, not work from any other phase.

--- a/benchmarks/scripts/ab-bench.mjs
+++ b/benchmarks/scripts/ab-bench.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+// Interleaved A/B benchmark runner.
+//
+// `moon bench` reports each benchmark once per invocation, so the obvious way to
+// judge an optimization -- run the whole suite before, run it again after, diff
+// the two tables -- charges every benchmark whatever the machine happened to be
+// doing at the moment it ran. On a shared or virtualized runner that is enough
+// to swamp the signal: a change that touches only layout can come back showing
+// double-digit swings in both directions on the HTML tokenizer.
+//
+// This runner instead alternates the two builds benchmark by benchmark and
+// repeats the whole sweep, so both variants meet the same machine within seconds
+// of each other, and reports the median of each variant's per-run medians.
+// Include a benchmark the change cannot possibly affect (a parser or selector
+// benchmark for a layout change) and read its delta as the run's noise floor.
+//
+// Usage:
+//   moon -C benchmarks bench --target js --build-only
+//   cp _build/js/release/bench/mizchi/crater-benchmarks/{crater-benchmarks.internal_test.js,package.json,__internal_test_info.json} /tmp/ab/after/
+//   git stash && moon -C benchmarks bench --target js --build-only && cp ... /tmp/ab/before/ && git stash pop
+//   node benchmarks/scripts/ab-bench.mjs --before /tmp/ab/before --after /tmp/ab/after --reps 9 \
+//     --filter deep_flex --filter render_flex --filter parse_simple
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const BUNDLE_NAME = "crater-benchmarks.internal_test.js";
+const INFO_NAME = "__internal_test_info.json";
+const PACKAGE = "mizchi/crater-benchmarks";
+const DEFAULT_REPS = 9;
+const RUN_TIMEOUT_MS = 600_000;
+
+/** Pull the summary object out of one `moon bench` child-process stdout. */
+export function parseBatchBench(stdout) {
+  for (const line of stdout.split("\n")) {
+    if (!line.includes("@BATCH_BENCH")) continue;
+    const message = JSON.parse(line).message;
+    const payload = message.slice(message.indexOf("@BATCH_BENCH ") + "@BATCH_BENCH ".length);
+    const summary = JSON.parse(payload).summaries[0];
+    return { name: summary.name, median: summary.median };
+  }
+  return null;
+}
+
+export function median(values) {
+  if (values.length === 0) throw new Error("median of an empty sample");
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** Every `b.bench(...)` entry the bundle can run, in declaration order. */
+export function collectBenchmarks(info, filters) {
+  const out = [];
+  for (const [file, entries] of Object.entries(info.with_bench_args_tests ?? {})) {
+    for (const entry of entries) {
+      if (filters.length > 0 && !filters.some((f) => entry.name.includes(f))) continue;
+      out.push({ file, index: entry.index, test: entry.name });
+    }
+  }
+  return out;
+}
+
+export function formatMicros(us) {
+  return us < 1000 ? `${us.toFixed(2)} µs` : `${(us / 1000).toFixed(2)} ms`;
+}
+
+function parseArgs(argv) {
+  const args = { reps: DEFAULT_REPS, filter: [], json: null, before: null, after: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      i += 1;
+      if (i >= argv.length) throw new Error(`${arg} needs a value`);
+      return argv[i];
+    };
+    if (arg === "--before") args.before = next();
+    else if (arg === "--after") args.after = next();
+    else if (arg === "--reps") args.reps = Number.parseInt(next(), 10);
+    else if (arg === "--filter") args.filter.push(next());
+    else if (arg === "--json") args.json = next();
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!args.before || !args.after) throw new Error("--before and --after are both required");
+  if (!Number.isInteger(args.reps) || args.reps < 1) throw new Error("--reps must be a positive integer");
+  return args;
+}
+
+function runOne(variantDir, item) {
+  const filter = JSON.stringify({
+    package: PACKAGE,
+    file_and_index: [[item.file, [{ start: item.index, end: item.index + 1 }]]],
+  });
+  const result = spawnSync(process.execPath, [path.join(variantDir, BUNDLE_NAME), filter], {
+    encoding: "utf8",
+    timeout: RUN_TIMEOUT_MS,
+  });
+  const parsed = result.stdout ? parseBatchBench(result.stdout) : null;
+  if (!parsed) {
+    throw new Error(`no benchmark result for ${item.test} in ${variantDir}: ${result.stderr?.slice(0, 400) ?? ""}`);
+  }
+  return parsed;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const info = JSON.parse(fs.readFileSync(path.join(args.after, INFO_NAME), "utf8"));
+  const items = collectBenchmarks(info, args.filter);
+  if (items.length === 0) throw new Error("no benchmarks matched --filter");
+
+  const samples = { before: new Map(), after: new Map() };
+  const reported = new Map();
+  for (let rep = 0; rep < args.reps; rep += 1) {
+    for (const item of items) {
+      for (const [variant, dir] of [["before", args.before], ["after", args.after]]) {
+        const { name, median: value } = runOne(dir, item);
+        reported.set(item.test, name);
+        const bucket = samples[variant];
+        if (!bucket.has(item.test)) bucket.set(item.test, []);
+        bucket.get(item.test).push(value);
+      }
+    }
+    process.stderr.write(`  rep ${rep + 1}/${args.reps} done\n`);
+  }
+
+  const rows = items.map((item) => {
+    const before = median(samples.before.get(item.test));
+    const after = median(samples.after.get(item.test));
+    return { name: reported.get(item.test), before, after, delta: (100 * (after - before)) / before };
+  });
+
+  console.log(`${"delta".padStart(8)}  ${"before".padStart(11)}  ${"after".padStart(11)}  benchmark   (median of ${args.reps} runs)`);
+  for (const row of rows) {
+    const delta = `${row.delta >= 0 ? "+" : ""}${row.delta.toFixed(1)}%`;
+    console.log(
+      `${delta.padStart(8)}  ${formatMicros(row.before).padStart(11)}  ${formatMicros(row.after).padStart(11)}  ${row.name}`,
+    );
+  }
+  const overall = median(rows.map((r) => r.delta));
+  console.log(`\nmedian delta across ${rows.length} benchmarks: ${overall >= 0 ? "+" : ""}${overall.toFixed(1)}%`);
+  if (args.json) fs.writeFileSync(args.json, `${JSON.stringify({ reps: args.reps, rows }, null, 2)}\n`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)) {
+  main();
+}

--- a/benchmarks/tests/ab-bench.test.mjs
+++ b/benchmarks/tests/ab-bench.test.mjs
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  collectBenchmarks,
+  formatMicros,
+  median,
+  parseBatchBench,
+} from "../scripts/ab-bench.mjs";
+
+function benchLine(name, medianUs) {
+  const summary = { name, median: medianUs, mean: medianUs, runs: 10 };
+  return JSON.stringify({
+    type: "result",
+    file: "render_bench.mbt",
+    index: 27,
+    message: `@BATCH_BENCH ${JSON.stringify({ summaries: [summary] })}`,
+  });
+}
+
+test("parseBatchBench picks the summary out of a moon bench stdout", () => {
+  const stdout = [
+    "----- BEGIN MOON TEST RESULT -----",
+    JSON.stringify({ type: "start", file: "render_bench.mbt", index: 27 }),
+    "----- END MOON TEST RESULT -----",
+    benchLine("render_large_2k5", 41226.62),
+    "----- END MOON TEST RESULT -----",
+  ].join("\n");
+
+  assert.deepEqual(parseBatchBench(stdout), {
+    name: "render_large_2k5",
+    median: 41226.62,
+  });
+});
+
+test("parseBatchBench returns null when the child produced no benchmark", () => {
+  assert.equal(parseBatchBench("moonbit test driver crashed\n"), null);
+});
+
+test("median is order independent and averages the middle pair when even", () => {
+  assert.equal(median([3, 1, 2]), 2);
+  assert.equal(median([4, 1, 3, 2]), 2.5);
+  assert.throws(() => median([]), /empty sample/);
+});
+
+test("collectBenchmarks flattens every file and honours name filters", () => {
+  const info = {
+    with_bench_args_tests: {
+      "layout_bench.mbt": [
+        { index: 0, name: "bench_flat_block_10" },
+        { index: 6, name: "bench_nested_flex_depth4" },
+      ],
+      "parse_bench.mbt": [{ index: 3, name: "bench_parse_flat_100" }],
+    },
+  };
+
+  assert.equal(collectBenchmarks(info, []).length, 3);
+  assert.deepEqual(collectBenchmarks(info, ["flex", "parse_flat"]), [
+    { file: "layout_bench.mbt", index: 6, test: "bench_nested_flex_depth4" },
+    { file: "parse_bench.mbt", index: 3, test: "bench_parse_flat_100" },
+  ]);
+});
+
+test("collectBenchmarks tolerates a bundle that declares no benchmarks", () => {
+  assert.deepEqual(collectBenchmarks({}, []), []);
+});
+
+test("formatMicros switches to milliseconds past 1000 µs", () => {
+  assert.equal(formatMicros(41.5), "41.50 µs");
+  assert.equal(formatMicros(999.994), "999.99 µs");
+  assert.equal(formatMicros(41226.62), "41.23 ms");
+});

--- a/core/node/node.mbt
+++ b/core/node/node.mbt
@@ -25,6 +25,10 @@ pub struct Node {
   /// A stable, mutation-surviving identity used to key incremental reflow (see
   /// docs/incremental-reflow-design.md); does not affect layout or cascade.
   mut dom_id : Int?
+  /// Memo for `Node::resolved_rects`, filled on first use and only when the
+  /// resolved value does not depend on the containing-block width. `style` is
+  /// immutable, so this never goes stale for the node's lifetime.
+  mut resolved_rects_memo : ResolvedRects?
 }
 
 ///|
@@ -56,6 +60,7 @@ pub fn Node::new(
     text: None,
     src: None,
     dom_id: None,
+    resolved_rects_memo: None,
   }
 }
 
@@ -76,6 +81,7 @@ pub fn Node::with_uid(
     text: None,
     src: None,
     dom_id: None,
+    resolved_rects_memo: None,
   }
 }
 
@@ -90,7 +96,17 @@ pub fn Node::with_uid_and_measure(
   text : String?,
   src? : String? = None,
 ) -> Node {
-  { id, uid, style, children, measure, text, src, dom_id: None }
+  {
+    id,
+    uid,
+    style,
+    children,
+    measure,
+    text,
+    src,
+    dom_id: None,
+    resolved_rects_memo: None,
+  }
 }
 
 ///|
@@ -104,6 +120,7 @@ pub fn Node::leaf(id : String, style : @style.Style) -> Node {
     text: None,
     src: None,
     dom_id: None,
+    resolved_rects_memo: None,
   }
 }
 
@@ -126,6 +143,7 @@ pub fn Node::with_measure(
     text,
     src,
     dom_id: None,
+    resolved_rects_memo: None,
   }
 }
 
@@ -146,6 +164,7 @@ pub fn Node::text(
     text: Some(content),
     src: None,
     dom_id: None,
+    resolved_rects_memo: None,
   }
 }
 

--- a/core/node/pkg.generated.mbti
+++ b/core/node/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "mizchi/crater-core/node"
 import {
   "mizchi/crater-core",
   "mizchi/css/style",
+  "mizchi/css/values",
 }
 
 // Values
@@ -41,15 +42,23 @@ pub struct Node {
   text : String?
   src : String?
   mut dom_id : Int?
+  mut resolved_rects_memo : ResolvedRects?
 }
 pub fn Node::leaf(String, @style.Style) -> Self
 pub fn Node::new(String, @style.Style, Array[Self]) -> Self
+pub fn Node::resolved_rects(Self, Double) -> ResolvedRects
 pub fn Node::set_dom_id(Self, Int?) -> Unit
 pub fn Node::set_uid(Self, Int) -> Unit
 pub fn Node::text(String, @style.Style, @crater-core.MeasureFunc, String) -> Self
 pub fn Node::with_measure(String, @style.Style, @crater-core.MeasureFunc, text? : String, src? : String?) -> Self
 pub fn Node::with_uid(String, Int, @style.Style, Array[Self]) -> Self
 pub fn Node::with_uid_and_measure(String, Int, @style.Style, Array[Self], @crater-core.MeasureFunc?, String?, src? : String?) -> Self
+
+pub(all) struct ResolvedRects {
+  padding : @values.Rect[Double]
+  margin : @values.Rect[Double]
+  border : @values.Rect[Double]
+}
 
 pub struct UidRegistry {
   dom_to_uid : Map[Int, Int]

--- a/core/node/resolved_rects.mbt
+++ b/core/node/resolved_rects.mbt
@@ -1,0 +1,76 @@
+///|
+/// A node's `padding` / `margin` / `border`, resolved to pixels.
+pub(all) struct ResolvedRects {
+  padding : @types.Rect[Double]
+  margin : @types.Rect[Double]
+  border : @types.Rect[Double]
+}
+
+///|
+/// Whether `dim` resolves to the same length whatever containing-block basis it
+/// is given, i.e. whether `Dimension::resolve_or(dim, basis, 0.0)` reads `basis`.
+///
+/// The three forms that read it are `Percent`, `Calc` (which carries a
+/// percentage ratio beside its fixed part) and `MathFn` (which mixes lengths and
+/// percentages that cannot be ordered without a basis). `Calc` with a ratio of
+/// zero would resolve to its fixed part alone, but `mizchi/css` keeps a
+/// pure-length `calc()` as a `Length`, so that form does not arise — and reading
+/// the basis even to multiply it by zero would propagate a non-finite width.
+fn dimension_ignores_basis(dim : @types.Dimension) -> Bool {
+  match dim {
+    @types.Length(_)
+    | @types.Auto
+    | @types.MinContent
+    | @types.MaxContent
+    | @types.FitContent(_) => true
+    @types.Percent(_) | @types.Calc(_, _) | @types.MathFn(_, _) => false
+  }
+}
+
+///|
+fn rect_ignores_basis(rect : @types.Rect[@types.Dimension]) -> Bool {
+  dimension_ignores_basis(rect.left) &&
+  dimension_ignores_basis(rect.right) &&
+  dimension_ignores_basis(rect.top) &&
+  dimension_ignores_basis(rect.bottom)
+}
+
+///|
+/// Resolve this node's `padding` / `margin` / `border` against `parent_width`,
+/// keeping the answer on the node when it does not depend on that width.
+///
+/// Layout asks for these three rects constantly: a CPU/heap profile of a
+/// 2.5k-node render had `@types.resolve_rect` as the single largest allocator of
+/// the whole layout phase (~21% of sampled bytes, ~14k calls per render), each
+/// call materializing a fresh `Rect[Double]`. In that document *every* one of
+/// those calls resolved a rect whose sides were all plain lengths — so the
+/// result did not depend on `parent_width` at all and the allocation was pure
+/// waste on every visit after the first.
+///
+/// `Node::style` is immutable, so a memo attached to the node stays correct for
+/// as long as the node lives, no matter which width a later caller passes. A
+/// rect that genuinely reads the width (a percentage, a mixed `calc()`, a
+/// `min()`/`max()`/`clamp()`) is resolved on every call as before, and never
+/// memoized.
+pub fn Node::resolved_rects(
+  self : Node,
+  parent_width : Double,
+) -> ResolvedRects {
+  match self.resolved_rects_memo {
+    Some(memo) => memo
+    None => {
+      let style = self.style
+      let resolved : ResolvedRects = {
+        padding: @types.resolve_rect(style.padding, parent_width),
+        margin: @types.resolve_rect(style.margin, parent_width),
+        border: @types.resolve_rect(style.border, parent_width),
+      }
+      if rect_ignores_basis(style.padding) &&
+        rect_ignores_basis(style.margin) &&
+        rect_ignores_basis(style.border) {
+        self.resolved_rects_memo = Some(resolved)
+      }
+      resolved
+    }
+  }
+}

--- a/layout/block/block.mbt
+++ b/layout/block/block.mbt
@@ -1270,21 +1270,45 @@ fn compute_block_child_memoized(
   warnings : Array[@layout_types.LayoutWarning],
   dispatch : @node.DispatchFn,
 ) -> LayoutWithCollapse {
-  let key = block_flow_cache_key(ctx)
-  if @node.node_is_clean(child.uid) {
-    match block_flow_cache.val.get(child.uid) {
-      Some(entry) =>
-        if entry.key == key {
-          block_flow_cache_hits.val = block_flow_cache_hits.val + 1
-          return entry.result
+  // `node_is_clean` only answers true while an incremental reflow has a clean
+  // predicate installed, which is also the one condition under which this
+  // cache is written, so outside such a reflow the key has no reader at all.
+  // Building it up front spent five `Double::to_string()` calls and six string
+  // concatenations per block child of every static render, then threw the
+  // result away.
+  let key : String? = if @node.node_incremental_active() {
+    Some(block_flow_cache_key(ctx))
+  } else {
+    None
+  }
+  match key {
+    Some(key) =>
+      if @node.node_is_clean(child.uid) {
+        match block_flow_cache.val.get(child.uid) {
+          Some(entry) =>
+            if entry.key == key {
+              block_flow_cache_hits.val = block_flow_cache_hits.val + 1
+              return entry.result
+            }
+          None => ()
         }
-      None => ()
-    }
+      }
+    None => ()
   }
   let raw = compute_with_collapse(child, ctx, warnings, dispatch)
-  let result = { ..raw, layout: apply_initial_scroll_snap(child, raw.layout) }
-  if @node.node_incremental_active() {
-    block_flow_cache.val.set(child.uid, { key, result })
+  let snapped = apply_initial_scroll_snap(child, raw.layout)
+  // `apply_initial_scroll_snap` hands its input straight back for any child
+  // without overflow alignment or mandatory scroll snap (nearly all of them),
+  // so rebuilding the record unconditionally allocated one
+  // `LayoutWithCollapse` per block child per render for no change at all.
+  let result = if physical_equal(snapped, raw.layout) {
+    raw
+  } else {
+    { ..raw, layout: snapped }
+  }
+  match key {
+    Some(key) => block_flow_cache.val.set(child.uid, { key, result })
+    None => ()
   }
   result
 }
@@ -2498,9 +2522,10 @@ fn try_layout_empty_block_leaf_with_definite_height(
     _ => return None
   }
 
-  let margin = @types.resolve_rect(style.margin, available_width)
-  let padding = @types.resolve_rect(style.padding, available_width)
-  let border = @types.resolve_rect(style.border, available_width)
+  let resolved = node.resolved_rects(available_width)
+  let margin = resolved.margin
+  let padding = resolved.padding
+  let border = resolved.border
   let mut box_width = match style.width {
     @types.Length(w) =>
       if style.box_sizing == @types.BorderBox {
@@ -3105,9 +3130,10 @@ fn compute_with_collapse(
         let parent_width = ctx.available_width
         let parent_height_opt = ctx.available_height
         let parent_height = parent_height_opt.unwrap_or(0.0)
-        let margin = @types.resolve_rect(style.margin, parent_width)
-        let padding = @types.resolve_rect(style.padding, parent_width)
-        let border = @types.resolve_rect(style.border, parent_width)
+        let resolved = node.resolved_rects(parent_width)
+        let margin = resolved.margin
+        let padding = resolved.padding
+        let border = resolved.border
         let available_h = ctx.available_height.unwrap_or(0.0)
         let intrinsic = (mf.func)(parent_width, available_h)
         let suppress_inline_intrinsic = style.suppresses_intrinsic_width()

--- a/layout/dispatch/dispatch.mbt
+++ b/layout/dispatch/dispatch.mbt
@@ -192,7 +192,6 @@ pub fn clear_intrinsic_cache_for_node(uid : Int) -> Unit {
 /// Call this for a full re-layout.
 pub fn reset_intrinsic_cache() -> Unit {
   @flex.reset_intrinsic_cache()
-  @flex.reset_resolved_cache()
 }
 
 ///|

--- a/layout/flex/flex.mbt
+++ b/layout/flex/flex.mbt
@@ -1292,7 +1292,7 @@ fn compute_column_cross_baseline(
   if node.children.length() == 0 {
     return own_cross
   }
-  let resolved = get_resolved_rects(node.style, node.uid, own_cross)
+  let resolved = node.resolved_rects(own_cross)
   let cross_start = resolved.padding.left + resolved.border.left
   for child in node.children {
     let child_style = child.style
@@ -1307,7 +1307,7 @@ fn compute_column_cross_baseline(
       @types.Float::Left | @types.Float::Right => continue
       @types.Float::None => ()
     }
-    let child_resolved = get_resolved_rects(child_style, child.uid, own_cross)
+    let child_resolved = child.resolved_rects(own_cross)
     let child_cross = compute_intrinsic_main_size(
       child,
       true,
@@ -1392,7 +1392,7 @@ fn first_row_flex_line_baseline_override(
     if !is_in_flow_baseline_child(child) {
       continue
     }
-    let resolved = get_resolved_rects(child.style, child.uid, main_size)
+    let resolved = child.resolved_rects(main_size)
     let child_main_base = match child.style.width {
       @types.Length(w) => w
       @types.Percent(p) => main_size * p
@@ -1616,8 +1616,9 @@ fn compute_trivial_leaf_intrinsic_main_box(
     _ => ()
   }
   let box_reference = if is_row { 0.0 } else { available_cross.unwrap_or(0.0) }
-  let padding = @types.resolve_rect(node.style.padding, box_reference)
-  let border = @types.resolve_rect(node.style.border, box_reference)
+  let resolved = node.resolved_rects(box_reference)
+  let padding = resolved.padding
+  let border = resolved.border
   if is_row {
     Some(padding.horizontal_sum() + border.horizontal_sum())
   } else {
@@ -1680,11 +1681,7 @@ fn compute_inline_flow_height(
     let mut max_height = 0.0
     for child in flow_inline_children {
       let child_style = child.style
-      let child_resolved = get_resolved_rects(
-        child_style,
-        child.uid,
-        available_width,
-      )
+      let child_resolved = child.resolved_rects(available_width)
       let child_height = match child_style.height {
         @types.Length(h) => h
         _ =>
@@ -1826,8 +1823,9 @@ fn compute_intrinsic_main_size(
       Some(w) if !is_row => w
       _ => 0.0
     }
-    let padding = @types.resolve_rect(style.padding, available_width)
-    let border = @types.resolve_rect(style.border, available_width)
+    let resolved = node.resolved_rects(available_width)
+    let padding = resolved.padding
+    let border = resolved.border
     let mut result = if is_row {
       padding.horizontal_sum() + border.horizontal_sum()
     } else {
@@ -2325,8 +2323,9 @@ fn compute_min_content_main_size(
       Some(w) if !is_row => w
       _ => 0.0
     }
-    let padding = @types.resolve_rect(style.padding, available_width)
-    let border = @types.resolve_rect(style.border, available_width)
+    let resolved = node.resolved_rects(available_width)
+    let padding = resolved.padding
+    let border = resolved.border
     return if is_row {
       padding.horizontal_sum() + border.horizontal_sum()
     } else {
@@ -2538,11 +2537,7 @@ fn compute_min_content_flex_main_size(
         continue
       }
       // Use cached resolved rects
-      let child_resolved = get_resolved_rects(
-        child_style,
-        child.uid,
-        content_width_for_children,
-      )
+      let child_resolved = child.resolved_rects(content_width_for_children)
       let child_main = if child_is_row {
         let intrinsic_cross_for_aspect : Double? = match style.height {
           @types.Length(h) =>
@@ -2643,11 +2638,7 @@ fn compute_min_content_flex_main_size(
         continue
       }
       // Use cached resolved rects
-      let child_resolved = get_resolved_rects(
-        child_style,
-        child.uid,
-        content_width_for_children,
-      )
+      let child_resolved = child.resolved_rects(content_width_for_children)
       let child_cross = if child_is_row {
         match child_style.height {
           @types.Length(h) => h
@@ -2701,8 +2692,9 @@ fn compute_min_content_grid_main_size(
         _ => 0.0
       }
   }
-  let padding = @types.resolve_rect(style.padding, available_width)
-  let border = @types.resolve_rect(style.border, available_width)
+  let resolved = node.resolved_rects(available_width)
+  let padding = resolved.padding
+  let border = resolved.border
   let cache = IntrinsicCache::new()
 
   if parent_is_row {
@@ -2718,11 +2710,7 @@ fn compute_min_content_grid_main_size(
         child_style.position == @types.Fixed {
         continue
       }
-      let child_resolved = get_resolved_rects(
-        child_style,
-        child.uid,
-        available_width,
-      )
+      let child_resolved = child.resolved_rects(available_width)
       let child_width = match child_style.width {
         @types.Length(w) =>
           w + child_resolved.margin.left + child_resolved.margin.right
@@ -2762,8 +2750,9 @@ fn compute_min_content_block_main_size(
         _ => 0.0
       }
   }
-  let padding = @types.resolve_rect(style.padding, available_width)
-  let border = @types.resolve_rect(style.border, available_width)
+  let resolved = node.resolved_rects(available_width)
+  let padding = resolved.padding
+  let border = resolved.border
   if parent_is_row {
     let intrinsic_cross_for_children : Double? = match style.height {
       @types.Length(h) => {
@@ -2847,11 +2836,7 @@ fn compute_min_content_block_main_size(
         continue
       }
       // Use cached resolved rects
-      let child_resolved = get_resolved_rects(
-        child_style,
-        child.uid,
-        available_width,
-      )
+      let child_resolved = child.resolved_rects(available_width)
       let raw_child_width = match child_style.width {
         @types.Length(w) => w
         _ =>
@@ -2950,11 +2935,7 @@ fn compute_min_content_block_main_size(
             continue
           }
           // Use cached resolved rects
-          let child_resolved = get_resolved_rects(
-            child_style,
-            child.uid,
-            available_width,
-          )
+          let child_resolved = child.resolved_rects(available_width)
           let child_height = match child_style.height {
             @types.Length(h) => h
             _ =>
@@ -3094,11 +3075,7 @@ fn compute_intrinsic_flex_main_size(
         continue
       }
       // Use cached resolved rects for all child box model values
-      let child_resolved = get_resolved_rects(
-        child_style,
-        child.uid,
-        content_width_for_children,
-      )
+      let child_resolved = child.resolved_rects(content_width_for_children)
       let child_margin = child_resolved.margin
       let child_padding = child_resolved.padding
       let child_border = child_resolved.border
@@ -3519,11 +3496,7 @@ fn compute_intrinsic_flex_main_size(
         continue
       }
       // Use cached resolved rects
-      let child_resolved = get_resolved_rects(
-        child_style,
-        child.uid,
-        content_width_for_children,
-      )
+      let child_resolved = child.resolved_rects(content_width_for_children)
       let child_margin = child_resolved.margin
       let (child_main, child_cross) = if child_is_row {
         // Main is width, cross is height
@@ -3819,8 +3792,9 @@ fn compute_intrinsic_block_main_size(
         _ => 0.0
       }
   }
-  let padding = @types.resolve_rect(style.padding, available_width)
-  let border = @types.resolve_rect(style.border, available_width)
+  let resolved = node.resolved_rects(available_width)
+  let padding = resolved.padding
+  let border = resolved.border
 
   // For block layout, if parent is row, intrinsic width is max of children's widths
   // If parent is column, intrinsic height is sum of children's heights
@@ -4027,11 +4001,7 @@ fn compute_intrinsic_block_main_size(
           only_inline_flow = false
           break
         }
-        let child_resolved = get_resolved_rects(
-          child_style,
-          child.uid,
-          available_width,
-        )
+        let child_resolved = child.resolved_rects(available_width)
         let child_margin = child_resolved.margin
         let child_width = match child_style.width {
           @types.Length(w) => w + child_margin.left + child_margin.right
@@ -4092,11 +4062,7 @@ fn compute_intrinsic_block_main_size(
           only_inline_flow = false
           break
         }
-        let child_resolved = get_resolved_rects(
-          child_style,
-          child.uid,
-          available_width,
-        )
+        let child_resolved = child.resolved_rects(available_width)
         let child_margin = child_resolved.margin
         let child_width = match child_style.width {
           @types.Length(w) => w + child_margin.left + child_margin.right
@@ -4135,11 +4101,7 @@ fn compute_intrinsic_block_main_size(
         continue
       }
       // Use cached resolved rects
-      let child_resolved = get_resolved_rects(
-        child_style,
-        child.uid,
-        available_width,
-      )
+      let child_resolved = child.resolved_rects(available_width)
       let child_margin = child_resolved.margin
       let child_width = match child_style.width {
         @types.Length(w) => w + child_margin.left + child_margin.right
@@ -4175,11 +4137,7 @@ fn compute_intrinsic_block_main_size(
             continue
           }
           // Use cached resolved rects
-          let child_resolved = get_resolved_rects(
-            child_style,
-            child.uid,
-            available_width,
-          )
+          let child_resolved = child.resolved_rects(available_width)
           let child_margin = child_resolved.margin
           let child_is_table = child_style.display == @types.Table ||
             child_style.display == @types.InlineTable
@@ -4296,8 +4254,9 @@ fn try_layout_simple_row_space_between_fixed_leaves(
       !is_zero_non_auto_dimension(child_style.margin.bottom) {
       return None
     }
-    let child_padding = @types.resolve_rect(child_style.padding, parent_width)
-    let child_border = @types.resolve_rect(child_style.border, parent_width)
+    let child_resolved = child.resolved_rects(parent_width)
+    let child_padding = child_resolved.padding
+    let child_border = child_resolved.border
     if child_padding.horizontal_sum() != 0.0 ||
       child_padding.vertical_sum() != 0.0 ||
       child_border.horizontal_sum() != 0.0 ||
@@ -4524,9 +4483,10 @@ fn compute_internal(
   let parent_height = ctx.available_height.unwrap_or(0.0)
 
   // Resolve box model
-  let margin = @types.resolve_rect(style.margin, parent_width)
-  let padding = @types.resolve_rect(style.padding, parent_width)
-  let border = @types.resolve_rect(style.border, parent_width)
+  let resolved = node.resolved_rects(parent_width)
+  let margin = resolved.margin
+  let padding = resolved.padding
+  let border = resolved.border
   let wrap_explicit_size_is_content_box = match style.flex_wrap {
     @types.Wrap | @types.WrapReverse => true
     @types.NoWrap => false
@@ -5228,11 +5188,7 @@ fn compute_internal(
       continue
     }
     // Use cached resolved rects for margin
-    let child_resolved = get_resolved_rects(
-      child_style,
-      child.uid,
-      content_width,
-    )
+    let child_resolved = child.resolved_rects(content_width)
     let child_margin = child_resolved.margin
     let margin_cross_for_intrinsic = if is_row {
       child_margin.top + child_margin.bottom
@@ -9554,11 +9510,7 @@ fn compute_internal(
 
     // CSS rule: padding+border override explicit size constraints
     // Use cached resolved rects
-    let child_resolved = get_resolved_rects(
-      child_style,
-      child.uid,
-      container_width,
-    )
+    let child_resolved = child.resolved_rects(container_width)
     let child_padding = child_resolved.padding
     let child_border = child_resolved.border
     let min_child_width = child_padding.horizontal_sum() +
@@ -9872,11 +9824,7 @@ fn compute_internal(
       ctx.viewport_height,
     )
     // Use cached resolved rects
-    let child_resolved = get_resolved_rects(
-      child_style,
-      child.uid,
-      ctx.viewport_width,
-    )
+    let child_resolved = child.resolved_rects(ctx.viewport_width)
 
     // Build child layout
     let child_layout : @layout_types.Layout = {

--- a/layout/flex/flex_cache.mbt
+++ b/layout/flex/flex_cache.mbt
@@ -62,53 +62,6 @@ pub fn reset_intrinsic_cache() -> Unit {
   global_intrinsic_cache.val = {}
 }
 
-// =============================================================================
-// Resolved Style Cache
-// =============================================================================
-
-///|
-/// Cached resolved rectangle values (padding, margin, border)
-priv struct ResolvedRects {
-  padding : @types.Rect[Double]
-  margin : @types.Rect[Double]
-  border : @types.Rect[Double]
-}
-
-///|
-/// Global cache for resolved style values.
-/// Key: node_uid * 1000000 + quantized_parent_width
-/// This avoids repeated resolve_rect calls for the same node/width combination.
-let global_resolved_cache : Ref[Map[Int, ResolvedRects]] = { val: {} }
-
-///|
-/// Quantize parent_width to reduce cache key variation
-/// Uses 0.1px precision which is sufficient for layout
-fn quantize_width(width : Double) -> Int {
-  (width * 10.0).to_int()
-}
-
-///|
-/// Get or compute resolved rects for a node's style
-fn get_resolved_rects(
-  style : @style.Style,
-  node_uid : Int,
-  parent_width : Double,
-) -> ResolvedRects {
-  let key = node_uid * 1000000 + quantize_width(parent_width)
-  match global_resolved_cache.val.get(key) {
-    Some(cached) => cached
-    None => {
-      let resolved : ResolvedRects = {
-        padding: @types.resolve_rect(style.padding, parent_width),
-        margin: @types.resolve_rect(style.margin, parent_width),
-        border: @types.resolve_rect(style.border, parent_width),
-      }
-      global_resolved_cache.val.set(key, resolved)
-      resolved
-    }
-  }
-}
-
 ///|
 /// Detect whether a subtree contains a table element with percentage width.
 /// Such descendants need a definite containing block width during flex base-size
@@ -142,12 +95,6 @@ fn has_flex_grow_descendant(node : @node.Node) -> Bool {
     }
   }
   false
-}
-
-///|
-/// Reset resolved style cache
-pub fn reset_resolved_cache() -> Unit {
-  global_resolved_cache.val = {}
 }
 
 ///|

--- a/layout/flex/pkg.generated.mbti
+++ b/layout/flex/pkg.generated.mbti
@@ -22,8 +22,6 @@ pub fn compute_with_warnings(@node.Node, @crater-core.LayoutContext, @node.Dispa
 
 pub fn reset_intrinsic_cache() -> Unit
 
-pub fn reset_resolved_cache() -> Unit
-
 // Errors
 
 // Types and methods

--- a/layout/table/table.mbt
+++ b/layout/table/table.mbt
@@ -1899,9 +1899,10 @@ fn layout_row(
 ) -> @layout_types.Layout {
   let style = row.style
   let parent_width = ctx.available_width
-  let margin = @types.resolve_rect(style.margin, parent_width)
-  let padding = @types.resolve_rect(style.padding, parent_width)
-  let border = @types.resolve_rect(style.border, parent_width)
+  let resolved = row.resolved_rects(parent_width)
+  let margin = resolved.margin
+  let padding = resolved.padding
+  let border = resolved.border
 
   // Resolve explicit row height from style
   // This is needed BEFORE laying out cells so percentage heights can resolve
@@ -2753,9 +2754,10 @@ pub fn compute(
     return create_zero_layout(node)
   }
   let parent_width = ctx.available_width
-  let margin = @types.resolve_rect(style.margin, parent_width)
-  let padding = @types.resolve_rect(style.padding, parent_width)
-  let border = @types.resolve_rect(style.border, parent_width)
+  let resolved = node.resolved_rects(parent_width)
+  let margin = resolved.margin
+  let padding = resolved.padding
+  let border = resolved.border
 
   // Check if border-collapse is enabled
   let is_border_collapse = style.border_collapse == @style.Collapse

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bench:crater-cli:check-baseline": "node benchmarks/scripts/crater-cli-bench-baseline.mjs check",
     "test:all": "pnpm test:vitest && pnpm test:node",
     "test:vitest": "vitest run --config vitest.config.ts",
-    "test:node": "node --test js/test/yoga-api.test.mjs wasm/test/component.test.mjs browser/scripts/mizchi-v8-consumer-prebuild.test.mjs browser/scripts/run-rolldown.test.mjs browser/tests/crater-cli.test.mjs benchmarks/tests/component-vrt-bench-baseline.test.mjs benchmarks/tests/crater-cli-bench-baseline.test.mjs scripts/find-dead-mbt-packages.test.mjs scripts/moon-publish-workspace.test.mjs scripts/prefetch-rusty-v8-source-binding.test.mjs scripts/public-api-boundary.test.mjs",
+    "test:node": "node --test js/test/yoga-api.test.mjs wasm/test/component.test.mjs browser/scripts/mizchi-v8-consumer-prebuild.test.mjs browser/scripts/run-rolldown.test.mjs browser/tests/crater-cli.test.mjs benchmarks/tests/ab-bench.test.mjs benchmarks/tests/component-vrt-bench-baseline.test.mjs benchmarks/tests/crater-cli-bench-baseline.test.mjs scripts/find-dead-mbt-packages.test.mjs scripts/moon-publish-workspace.test.mjs scripts/prefetch-rusty-v8-source-binding.test.mjs scripts/public-api-boundary.test.mjs",
     "test:component-vrt:baseline": "node --test benchmarks/tests/component-vrt-bench-baseline.test.mjs",
     "test:crater-cli:baseline": "node --test benchmarks/tests/crater-cli-bench-baseline.test.mjs",
     "test:bidi-e2e": "playwright test tests/bidi-e2e.test.ts",


### PR DESCRIPTION
最新の MoonBit / `moonbitlang/core` の変更を確認したうえで、プロファイルを取って layout のアロケーションを削り、ベンチマークを実測で改善した。

## MoonBit 側の調査結果

`~/.moon/lib/core/CHANGELOG.md`（0.10.12 系）を追って、最適化に使えそうな新機能を洗い出した:

- `ReadOnlyArray` / `FixedArray` の推奨（`prefer_readonly_array` #65, `prefer_fixed_array` #66）、`unnecessary_view_op` (#75) — いずれも既定 off の lint。`moon check --warn-list '+prefer_readonly_array+prefer_fixed_array+unnecessary_view_op'` をワークスペース全体にかけたところ **15 件しか出ず、しかもほぼテストコード**。ここは既にきれいなので触っていない。
- `ArrayView` の immutable slice 統一 / `Iter` の外部イテレータ化 / `Array::release_unused` — 現状のホットパスに刺さる使い方は見つからなかった。
- `Array::new(capacity=)` → `Array(capacity=)` の deprecation は **意図的に見送り**。mizchi/v8 で同じ移行をしたときに、手元の toolchain でコンパイルできなくなった前例がある。

結局効いたのは言語機能ではなく、プロファイルが示したアロケーション量だった。

## プロファイルで分かったこと

`render_large_2k5`（2.5k ノード）に `node --cpu-prof` / `--heap-prof`:

- GC が CPU 単独最大の **14.4%**
- `@css.resolve_rect` が layout フェーズ最大のアロケータで **サンプル bytes の 21%**。10 render で 141,240 回呼ばれ、毎回 `Rect[Double]` を新規生成
- **その 141,240 回すべてが4辺すべて plain length**、つまり containing block 幅にまったく依存しない値だった
- flex 側の `(uid, quantized width)` キーのキャッシュは **19,668 lookup で hit 0**。しかもそのうち **58.6% は同じ uid への再訪**で、キーに含まれる幅だけが違うために外していた。毎回 `ResolvedRects` と map エントリを確保するだけの純粋なオーバーヘッドになっていた
- ついでに、そのキーは `uid * 1000000 + quantized_width` で、uid 2147 以降 Int32 が溢れる

## 変更

**`Node::resolved_rects`** — `padding` / `margin` / `border` を一度だけ解決し、3つとも幅に依存しないときだけ node 自身に memo する。`Node::style` は immutable なので node に貼った memo は stale になりようがなく、リセット規律も不要。幅を実際に読む rect（percent / calc / min-max-clamp）は従来どおり毎回解決し、memo しない。flex / block / table をこの経路に載せ替え、上記の壊れたグローバルキャッシュ（と `reset_resolved_cache`）は削除した。

小さいアロケーション修正を2つ同梱:

- block-flow キャッシュのキー生成（`Double::to_string()` 5回 + 文字列連結6回）を、incremental reflow が実際に読む場合だけに限定。静的 render では `node_is_clean` が常に false でキャッシュも書かれないため、全 block child 分を作っては捨てていた
- `compute_block_child_memoized` が、scroll-snap がレイアウトをそのまま返したときにレコードを組み直さないようにした

## 計測方法（ここが本題でもある）

`moon bench` は1回の実行で各ベンチを1回しか出さないので、「前でスイート全体 → 後でスイート全体 → 差分」だと、そのベンチが走った瞬間のマシンの機嫌をそのまま計上してしまう。実際この変更で素朴に比較したら **93 本速くなって 85 本遅くなり**、layout に触っていない `parse_simple_10` が +59%、`render_cards_24` が +301% と出た。使い物にならない。

そこで **`benchmarks/scripts/ab-bench.mjs`** を追加した。ビルド済みの2つのバンドルをベンチ単位で交互に走らせ、スイープ自体を複数回繰り返して、各 variant の run 中央値の中央値を出す。両者が数秒差で同じマシンに当たるのでノイズが相殺される。変更が影響しえないベンチ（layout の変更ならパーサやセレクタ）を必ず混ぜて、その delta をそのランのノイズ床として読む運用にしてある。ユニットテストは `benchmarks/tests/ab-bench.test.mjs`（`pnpm test:node` に登録済み）。

## 結果

9回インターリーブ、median of medians。コントロールが示すこのランナーのノイズ床は ±4% 程度:

| Benchmark | Before | After | Delta |
|-----------|--------|-------|-------|
| `render_flex_d5` | 8.10 ms | 6.02 ms | **-25.6%** |
| `deep_flex_d6` | 9.30 ms | 7.12 ms | **-23.5%** |
| `render_flex_d6` | 25.06 ms | 21.39 ms | **-14.6%** |
| `dashboard_layout` | 1.35 ms | 1.17 ms | **-13.9%** |
| `nested_flex_d4` | 683.25 µs | 630.67 µs | -7.7% |
| `render_large_2k5` | 30.20 ms | 29.35 ms | -2.8% |
| `parse_simple_100` (control) | 32.83 µs | 34.06 µs | +3.8% |
| `parse_simple_1000` (control) | 393.30 µs | 377.93 µs | -3.9% |
| `match_non_idx_1k` (control) | 31.79 µs | 30.63 µs | -3.7% |

同じ傾向を 5 / 11 / 9 回の3スイープで再現している（`deep_flex_d6` は -23%〜-28%、`render_flex_d5` は -23%〜-28%）。効くのは intrinsic sizing が同じノードを何度も訪ねる形 — ネストした flex、深い block ネスト、ダッシュボード状の文書。パースやセレクタマッチング、ラスタライズ律速のベンチはノイズ床の中に収まる。これは layout からアロケーションを削る変更であって、他フェーズの仕事を減らすものではないので、想定どおり。

`render_large_2k5` のサンプル済みワークロードアロケーションは **20.4 MB → 7.1 MB**（Node 自身のモジュール読み込みを除く）、GC の CPU 占有は **14.4% → 8.8%**。

経緯と手順は `benchmarks/BASELINE.md` の "Box-Model Resolution (2026-09-09)" に残した。

## 検証

- `moon check --target js`: 0 errors
- `moon test --target js`: 3639/3641 — 失敗2件は main と同じ既存のもの（browser の mutation records、sixel img スナップショット）
- `pnpm test:node`: 新規6件を含め、この環境でビルド成果物がなくて落ちる既存11件以外はすべて green
- `.mbti` は `core/node` と `layout/flex` の意味のある差分だけ反映。`moon info` / `moon fmt` が全体に出す trailing-comma などの toolchain drift（233ファイル）は別件として持ち込んでいない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114XoakYgfkaMBMwWr9WmMT

---
_Generated by [Claude Code](https://claude.ai/code/session_0114XoakYgfkaMBMwWr9WmMT)_