### PR TITLE
perf: skip the identity zoom walk, and test payload-less enums with `is`

### DIFF
--- a/benchmarks/BASELINE.md
+++ b/benchmarks/BASELINE.md
@@ -971,3 +971,71 @@ sizing revisits the same node many times — nested flex, deep block nesting,
 dashboard-shaped documents. Benchmarks bound by parsing, selector matching or
 rasterization sit inside the noise floor, as expected: this change removes
 allocation from layout, not work from any other phase.
+
+## Zoom Walk and Enum Comparisons (2026-09-09)
+
+Two follow-ups to the box-model work above, both aimed at work the renderer and
+layout do on every node regardless of the document. Measured the same way
+(`benchmarks/scripts/ab-bench.mjs`, interleaved), plus deterministic counters
+obtained by instrumenting the built bundle, which do not move run to run.
+
+### The zoom / transform walk deep-copied the layout tree
+
+`apply_zoom_and_scale` rebuilds every `Layout` record it visits — a new record,
+a new children array and three new `Rect[Double]` for margin/padding/border —
+so a render always ended with a full copy of the layout tree. Instrumenting the
+walk on `render_large_2k5` showed all 8,173 calls were the identity case:
+inherited zoom 1, no zoom of its own, identity transform.
+
+The walk cannot simply be skipped: it also shifts absolutely-positioned children
+onto their real containing block. So the fast path is bottom-up — a node hands
+`layout` straight back when it neither zooms nor transforms *and* every child
+came back physically unchanged (`physical_equal`), which is exactly the case
+where the record it would build equals the one it was given, field for field.
+
+### `==` on a payload-less enum is a function call
+
+`x == @types.Display::None` compiles to a call into the derived `Eq::equal`,
+which is a switch over all 20 variants; `x != ...` costs two calls, through the
+default `not_equal` wrapper. The pattern form `x is @types.Display::None`
+compiles to `x === 17` — a plain integer comparison, inlined, in both debug and
+release. `match` compiles the same way, so this is purely about the operator.
+
+Attributing the calls to their callers on `render_large_2k5` showed 92% of them
+came from 18 functions, so only those were converted (222 comparisons across
+five files) rather than the ~1,200 sites in the workspace. The remaining sites
+are colder by construction and are left alone deliberately: the tail is not
+worth the diff.
+
+### Deterministic counters (10 renders of `render_large_2k5`)
+
+| Counter | Before | After | Delta |
+|---------|--------|-------|-------|
+| `Display::equal` calls | 407,352 | 175,186 | **-57.0%** |
+| `Position::equal` calls | 364,430 | 34,386 | **-90.6%** |
+| `Layout` records constructed | 58,971 | 50,798 | -13.9% |
+| `Rect[Double]` constructed | 87,551 | 63,032 | -28.0% |
+
+### Wall clock (21 interleaved repetitions, median of medians)
+
+| Benchmark | Before | After | Delta |
+|-----------|--------|-------|-------|
+| `deep_flex_d6` | 6.71 ms | 6.51 ms | -3.0% |
+| `dashboard_layout` | 1.13 ms | 1.11 ms | -1.8% |
+| `render_flat_1000` | 25.30 ms | 25.16 ms | -0.6% |
+| `render_dash_med` | 7.40 ms | 7.59 ms | +2.6% |
+| `parse_simple_100` (control) | 36.90 µs | 36.33 µs | -1.6% |
+| `parse_simple_1000` (control) | 397.24 µs | 397.79 µs | +0.1% |
+| `match_non_idx_1k` (control) | 32.15 µs | 32.85 µs | +2.2% |
+
+Read this honestly: the controls put the noise floor at about ±2%, and only
+`deep_flex_d6` clears it. An earlier 11-repetition sweep of the same two changes
+reported `dashboard_layout` at -10.8%; at 21 repetitions that collapsed to -1.8%,
+which is a good reminder that a single sweep at low repetition count on this
+runner will happily invent a double-digit result.
+
+So: the work removed is real and large — three quarters of the enum-equality
+calls and a whole tree copy per render — but at this document size it is worth
+roughly one to three percent of wall clock, not more. Both changes are kept
+because they are strictly less work for identical output, not because the
+stopwatch shows much.

--- a/layout/block/block.mbt
+++ b/layout/block/block.mbt
@@ -237,7 +237,7 @@ fn is_table_internal_flow_node(node : @node.Node) -> Bool {
   if is_table_internal_display(node.style.display) {
     return true
   }
-  node.style.display == @types.Contents && has_table_internal_descendant(node)
+  node.style.display is @types.Contents && has_table_internal_descendant(node)
 }
 
 ///|
@@ -552,8 +552,8 @@ fn get_inflow_children_flow_extent_height(
     let child_layout = children[i]
     let skip_out_of_flow = if i < source_node.children.length() {
       let child_style = source_node.children[i].style
-      child_style.position == @types.Absolute ||
-      child_style.position == @types.Fixed
+      child_style.position is @types.Absolute ||
+      child_style.position is @types.Fixed
     } else {
       false
     }
@@ -954,7 +954,7 @@ fn block_flow_establishes_bfc(style : @style.Style) -> Bool {
   overflow_blocks ||
   display_establishes_bfc ||
   non_normal_block_alignment ||
-  style.display == @types.FlowRoot ||
+  style.display is @types.FlowRoot ||
   containment_establishes_bfc
 }
 
@@ -2680,7 +2680,7 @@ fn place_fixed_children_for_parent(
 ) -> Unit {
   for i = 0; i < node.children.length(); i = i + 1 {
     let child = node.children[i]
-    if child.style.position == @types.Fixed {
+    if child.style.position is @types.Fixed {
       let fixed_layout = layout_fixed_child_for_parent(
         child, parent_style, parent_width, parent_height, box_width, box_height,
         border, viewport_width, viewport_height, warnings, dispatch,
@@ -2892,7 +2892,7 @@ fn compute_with_collapse(
 
   // Handle no-principal-box displays (display: contents and table-internal no-principal
   // values) - element doesn't generate a box but children do.
-  if style.display == @types.Contents ||
+  if style.display is @types.Contents ||
     is_no_principal_table_internal_display(style.display) {
     let keep_intrinsic_size = is_no_principal_table_internal_display(
       style.display,
@@ -2901,11 +2901,11 @@ fn compute_with_collapse(
     let flow_inline_nodes : Array[@node.Node] = []
     let mut has_out_of_flow = false
     for child in node.children {
-      if child.style.display == @types.Display::None {
+      if child.style.display is @types.Display::None {
         continue
       }
-      if child.style.position == @types.Absolute ||
-        child.style.position == @types.Fixed {
+      if child.style.position is @types.Absolute ||
+        child.style.position is @types.Fixed {
         has_out_of_flow = true
         break
       }
@@ -2935,7 +2935,7 @@ fn compute_with_collapse(
       for i = 0; i < ifc_result.layouts.length(); i = i + 1 {
         let child_layout = ifc_result.layouts[i]
         let normalized_layout = if i < flow_inline_nodes.length() &&
-          flow_inline_nodes[i].style.display == @types.Contents {
+          flow_inline_nodes[i].style.display is @types.Contents {
           {
             ..child_layout,
             width: 0.0,
@@ -2999,7 +2999,7 @@ fn compute_with_collapse(
         !should_preserve_flow_whitespace_text(node.children, i) {
         continue
       }
-      if child.style.position == @types.Absolute {
+      if child.style.position is @types.Absolute {
         let abs_layout_raw = layout_absolute_child(
           child,
           ctx.available_width,
@@ -3010,7 +3010,7 @@ fn compute_with_collapse(
           warnings,
           dispatch,
         )
-        let abs_layout = if child.style.width == @types.Auto &&
+        let abs_layout = if child.style.width is @types.Auto &&
           abs_layout_raw.height > 0.0 {
           let min_width_from_font = abs_layout_raw.height * 0.6
           if abs_layout_raw.width < min_width_from_font {
@@ -3024,7 +3024,7 @@ fn compute_with_collapse(
         layout_map[i] = abs_layout
         continue
       }
-      if child.style.position == @types.Fixed {
+      if child.style.position is @types.Fixed {
         layout_map[i] = layout_fixed_child(
           child,
           ctx.viewport_width,
@@ -3235,11 +3235,11 @@ fn compute_with_collapse(
               definite_height_for_auto_width > 0.0 {
               None
             } else if auto_viewbox_svg_leaf &&
-              ctx.sizing_mode == @layout_types.Definite &&
+              ctx.sizing_mode is @layout_types.Definite &&
               parent_width > 0.0 {
               Some(parent_width)
-            } else if style.display == @types.Block &&
-              ctx.sizing_mode == @layout_types.Definite &&
+            } else if style.display is @types.Block &&
+              ctx.sizing_mode is @layout_types.Definite &&
               !suppress_inline_intrinsic {
               Some(
                 @types.max(
@@ -3254,7 +3254,7 @@ fn compute_with_collapse(
               // Text nodes should wrap to available inline size, but replaced elements
               // keep their intrinsic width contribution for shrink-to-fit/abspos sizing.
               if node.text is Some(_) &&
-                ctx.sizing_mode == @layout_types.Definite {
+                ctx.sizing_mode is @layout_types.Definite {
                 Some(@types.min(content_width, parent_width))
               } else {
                 Some(content_width)
@@ -3489,9 +3489,9 @@ fn compute_with_collapse(
     @types.Auto => has_percent_sized_replaced_descendant(node)
     _ => false
   }
-  let supports_vertical_auto_fill = style.display == @types.Block ||
-    style.display == @types.FlowRoot ||
-    style.display == @types.Table
+  let supports_vertical_auto_fill = style.display is @types.Block ||
+    style.display is @types.FlowRoot ||
+    style.display is @types.Table
   let is_empty_leaf_for_vertical_fill = supports_vertical_auto_fill &&
     node.children.length() == 0 &&
     node.measure is None
@@ -3510,9 +3510,9 @@ fn compute_with_collapse(
   // Box width - depends on sizing mode and aspect_ratio
   // For MaxContent mode with width:Auto, or explicit width: max-content/min-content
   // InlineBlock elements also use shrink-to-fit (max-content) when width is auto
-  let is_inline_block = style.display == @types.Inline ||
-    style.display == @types.InlineBlock ||
-    style.display == @types.TableCell
+  let is_inline_block = style.display is @types.Inline ||
+    style.display is @types.InlineBlock ||
+    style.display is @types.TableCell
   let use_max_content = match (ctx.sizing_mode, style.width) {
     (@layout_types.MaxContent, @types.Auto) => true
     (_, @types.Dimension::MaxContent) => true
@@ -3527,7 +3527,7 @@ fn compute_with_collapse(
     (@types.Auto, @types.Length(h), Some(ratio)) =>
       // With box-sizing: border-box, aspect-ratio applies to border-box dimensions
       // With content-box (default), it applies to content dimensions
-      if style.box_sizing == @types.BorderBox {
+      if style.box_sizing is @types.BorderBox {
         // aspect-ratio applies to border-box: width = height * ratio
         Some(h * ratio)
       } else {
@@ -3544,7 +3544,7 @@ fn compute_with_collapse(
       match parent_height_opt {
         Some(ph) => {
           let h = ph * p
-          if style.box_sizing == @types.BorderBox {
+          if style.box_sizing is @types.BorderBox {
             Some(h * ratio)
           } else {
             let content_height = h
@@ -3601,7 +3601,7 @@ fn compute_with_collapse(
   // So apply max first, then min
   match style.max_width {
     @types.Length(max_w) => {
-      let max_box_w = if style.box_sizing == @types.BorderBox {
+      let max_box_w = if style.box_sizing is @types.BorderBox {
         max_w
       } else {
         max_w + padding.horizontal_sum() + border.horizontal_sum()
@@ -3612,7 +3612,7 @@ fn compute_with_collapse(
     }
     @types.Percent(p) => {
       let max_content_w = parent_width * p
-      let max_box_w = if style.box_sizing == @types.BorderBox {
+      let max_box_w = if style.box_sizing is @types.BorderBox {
         max_content_w
       } else {
         max_content_w + padding.horizontal_sum() + border.horizontal_sum()
@@ -3623,7 +3623,7 @@ fn compute_with_collapse(
     }
     @types.Calc(px, pct) => {
       let max_content_w = parent_width * pct + px
-      let max_box_w = if style.box_sizing == @types.BorderBox {
+      let max_box_w = if style.box_sizing is @types.BorderBox {
         max_content_w
       } else {
         max_content_w + padding.horizontal_sum() + border.horizontal_sum()
@@ -3637,7 +3637,7 @@ fn compute_with_collapse(
         __mop,
         __mterms.map(fn(__t) { parent_width * __t.1 + __t.0 }),
       )
-      let max_box_w = if style.box_sizing == @types.BorderBox {
+      let max_box_w = if style.box_sizing is @types.BorderBox {
         max_content_w
       } else {
         max_content_w + padding.horizontal_sum() + border.horizontal_sum()
@@ -3658,7 +3658,7 @@ fn compute_with_collapse(
         border.horizontal_sum()
       let aspect_width = match (style.aspect_ratio, style.height) {
         (Some(ar), @types.Length(h)) if ar > 0.0 =>
-          if style.box_sizing == @types.BorderBox {
+          if style.box_sizing is @types.BorderBox {
             h * ar
           } else {
             h * ar + padding.horizontal_sum() + border.horizontal_sum()
@@ -3667,7 +3667,7 @@ fn compute_with_collapse(
           match parent_height_opt {
             Some(ph) => {
               let h = ph * p
-              if style.box_sizing == @types.BorderBox {
+              if style.box_sizing is @types.BorderBox {
                 h * ar
               } else {
                 h * ar + padding.horizontal_sum() + border.horizontal_sum()
@@ -3698,7 +3698,7 @@ fn compute_with_collapse(
   }
   match style.min_width {
     @types.Length(min_w) => {
-      let min_box_w = if style.box_sizing == @types.BorderBox {
+      let min_box_w = if style.box_sizing is @types.BorderBox {
         min_w
       } else {
         min_w + padding.horizontal_sum() + border.horizontal_sum()
@@ -3709,7 +3709,7 @@ fn compute_with_collapse(
     }
     @types.Calc(px, pct) => {
       let min_content_w = parent_width * pct + px
-      let min_box_w = if style.box_sizing == @types.BorderBox {
+      let min_box_w = if style.box_sizing is @types.BorderBox {
         min_content_w
       } else {
         min_content_w + padding.horizontal_sum() + border.horizontal_sum()
@@ -3723,7 +3723,7 @@ fn compute_with_collapse(
         __mop,
         __mterms.map(fn(__t) { parent_width * __t.1 + __t.0 }),
       )
-      let min_box_w = if style.box_sizing == @types.BorderBox {
+      let min_box_w = if style.box_sizing is @types.BorderBox {
         min_content_w
       } else {
         min_content_w + padding.horizontal_sum() + border.horizontal_sum()
@@ -3734,7 +3734,7 @@ fn compute_with_collapse(
     }
     @types.Percent(p) => {
       let min_content_w = parent_width * p
-      let min_box_w = if style.box_sizing == @types.BorderBox {
+      let min_box_w = if style.box_sizing is @types.BorderBox {
         min_content_w
       } else {
         min_content_w + padding.horizontal_sum() + border.horizontal_sum()
@@ -3784,7 +3784,7 @@ fn compute_with_collapse(
   // Calculate available height for children
   let child_available_height : Double? = match style.height {
     @types.Length(h) =>
-      if style.box_sizing == @types.BorderBox {
+      if style.box_sizing is @types.BorderBox {
         Some(h - padding.vertical_sum() - border.vertical_sum())
       } else {
         Some(h)
@@ -3792,7 +3792,7 @@ fn compute_with_collapse(
     @types.Percent(p) =>
       match parent_height_opt {
         Some(ph) =>
-          if style.box_sizing == @types.BorderBox {
+          if style.box_sizing is @types.BorderBox {
             Some(ph * p - padding.vertical_sum() - border.vertical_sum())
           } else {
             Some(ph * p)
@@ -3803,7 +3803,7 @@ fn compute_with_collapse(
           // descendants with percentage heights can resolve against the used size.
           match style.max_height {
             @types.Length(max_h) =>
-              if style.box_sizing == @types.BorderBox {
+              if style.box_sizing is @types.BorderBox {
                 Some(
                   @types.max(
                     0.0,
@@ -3819,7 +3819,7 @@ fn compute_with_collapse(
     @types.Calc(px, pct) =>
       match parent_height_opt {
         Some(ph) =>
-          if style.box_sizing == @types.BorderBox {
+          if style.box_sizing is @types.BorderBox {
             Some(ph * pct + px - padding.vertical_sum() - border.vertical_sum())
           } else {
             Some(ph * pct + px)
@@ -3830,7 +3830,7 @@ fn compute_with_collapse(
           // descendants with percentage heights can resolve against the used size.
           match style.max_height {
             @types.Length(max_h) =>
-              if style.box_sizing == @types.BorderBox {
+              if style.box_sizing is @types.BorderBox {
                 Some(
                   @types.max(
                     0.0,
@@ -3850,7 +3850,7 @@ fn compute_with_collapse(
             __mop,
             __mterms.map(fn(__t) { ph * __t.1 + __t.0 }),
           )
-          if style.box_sizing == @types.BorderBox {
+          if style.box_sizing is @types.BorderBox {
             Some(resolved - padding.vertical_sum() - border.vertical_sum())
           } else {
             Some(resolved)
@@ -3862,7 +3862,7 @@ fn compute_with_collapse(
           // descendants with percentage heights can resolve against the used size.
           match style.max_height {
             @types.Length(max_h) =>
-              if style.box_sizing == @types.BorderBox {
+              if style.box_sizing is @types.BorderBox {
                 Some(
                   @types.max(
                     0.0,
@@ -3890,7 +3890,7 @@ fn compute_with_collapse(
       } else {
         match (ctx.sizing_mode, style.aspect_ratio) {
           (@layout_types.Definite, Some(ratio)) if ratio > 0.0 =>
-            if style.box_sizing == @types.BorderBox {
+            if style.box_sizing is @types.BorderBox {
               Some(
                 @types.max(
                   0.0,
@@ -3914,7 +3914,7 @@ fn compute_with_collapse(
                 node.id == "body" ||
                 has_percent_sized_replaced_descendant(node) ||
                 (
-                  ctx.sizing_mode == @layout_types.Definite &&
+                  ctx.sizing_mode is @layout_types.Definite &&
                   has_percent_sized_descendant(node)
                 ) =>
                 Some(
@@ -3933,7 +3933,7 @@ fn compute_with_collapse(
           node.id == "body" ||
           has_percent_sized_replaced_descendant(node) ||
           (
-            ctx.sizing_mode == @layout_types.Definite &&
+            ctx.sizing_mode is @layout_types.Definite &&
             has_percent_sized_descendant(node)
           ) =>
           Some(
@@ -3969,14 +3969,14 @@ fn compute_with_collapse(
       has_non_flow_children = true
       continue
     }
-    if child.style.display == @types.Display::None {
+    if child.style.display is @types.Display::None {
       // Add zero-sized layout for display:none children (including descendants)
       layout_map[i] = create_zero_layout(child)
       has_non_flow_children = true
       continue
     }
-    if child.style.position == @types.Absolute ||
-      child.style.position == @types.Fixed {
+    if child.style.position is @types.Absolute ||
+      child.style.position is @types.Fixed {
       // Record where this absolute/fixed child appears in flow order
       absolute_static_positions[i] = flow_position
       has_non_flow_children = true
@@ -4156,7 +4156,7 @@ fn compute_with_collapse(
           border_h : Double,
           min_box : Double,
         ) -> Double {
-          if box_sizing == @types.BorderBox {
+          if box_sizing is @types.BorderBox {
             h * ratio
           } else {
             let content_height = h - padding_v - border_v
@@ -4689,7 +4689,7 @@ fn compute_with_collapse(
                   None =>
                     if child.children.length() == 0 {
                       child_min_box // Leaf nodes with no content have padding+border as minimum
-                    } else if child_style.display == @types.Contents {
+                    } else if child_style.display is @types.Contents {
                       if has_table_internal_descendant(child) {
                         // Measure contiguous table-internal descendants as one
                         // anonymous table run so intrinsic width is not fragmented.
@@ -4849,7 +4849,7 @@ fn compute_with_collapse(
           border_h : Double,
           min_box : Double,
         ) -> Double {
-          if box_sizing == @types.BorderBox {
+          if box_sizing is @types.BorderBox {
             h * ratio
           } else {
             let content_height = h - padding_v - border_v
@@ -5124,7 +5124,7 @@ fn compute_with_collapse(
     float_nodes.length() == 0 &&
     !has_non_flow_children &&
     flow_nodes.length() == 1 &&
-    flow_nodes[0].style.display == @types.Contents {
+    flow_nodes[0].style.display is @types.Contents {
     let contents_child = flow_nodes[0]
     let synthetic_node = @node.Node::with_uid_and_measure(
       node.id,
@@ -5224,7 +5224,7 @@ fn compute_with_collapse(
       if i < ifc_result.layouts.length() {
         let flow_node = flow_nodes[i]
         let ifc_layout = ifc_result.layouts[i]
-        let normalized_layout = if flow_node.style.display == @types.Contents {
+        let normalized_layout = if flow_node.style.display is @types.Contents {
           {
             ..ifc_layout,
             width: 0.0,
@@ -5648,7 +5648,7 @@ fn compute_with_collapse(
     }
     let child_for_layout = if child_is_orthogonal &&
       child_has_auto_margin &&
-      child.style.width == @types.Auto {
+      child.style.width is @types.Auto {
       // Orthogonal-flow auto inline-size behaves closer to fit-content than
       // fill-available for these WPT containment cases.
       @node.Node::with_uid_and_measure(
@@ -5766,9 +5766,9 @@ fn compute_with_collapse(
     padding.vertical_sum() > 0.0 ||
     border.horizontal_sum() > 0.0 ||
     border.vertical_sum() > 0.0
-  let can_use_simple_block_stack = ctx.sizing_mode == @layout_types.Definite &&
+  let can_use_simple_block_stack = ctx.sizing_mode is @layout_types.Definite &&
     has_simple_block_stack_hint &&
-    style.align_content == @types.Stretch &&
+    style.align_content is @types.Stretch &&
     !style.writing_mode.is_vertical() &&
     !multicol_enabled &&
     !use_ifc &&
@@ -5820,16 +5820,16 @@ fn compute_with_collapse(
       )
     }
     let mut content_height = flow_content_height
-    if style.height == @types.Auto {
+    if style.height is @types.Auto {
       let mut adjusted_flow_extent = 0.0
       let content_offset_y = padding.top + border.top
       for i = 0
           i < adjusted_child_layouts.length() && i < flow_nodes.length()
           i = i + 1 {
         let child_style = flow_nodes[i].style
-        let skip_out_of_flow = child_style.position == @types.Absolute ||
-          child_style.position == @types.Fixed ||
-          child_style.float != @types.Float::None
+        let skip_out_of_flow = child_style.position is @types.Absolute ||
+          child_style.position is @types.Fixed ||
+          !(child_style.float is @types.Float::None)
         if skip_out_of_flow {
           continue
         }
@@ -6290,7 +6290,7 @@ fn compute_with_collapse(
     }
     inline_run_active = true
   }
-  let default_text_align = style.text_align == @style.TextAlign::Start
+  let default_text_align = style.text_align is @style.TextAlign::Start
   let multicol_height_limit = if multicol_enabled {
     estimate_multicol_column_height_limit(
       child_available_height,
@@ -6305,7 +6305,7 @@ fn compute_with_collapse(
   }
   let multicol_fragment_contained = multicol_enabled &&
     (
-      style.column_fill == @style.ColumnFill::Balance ||
+      style.column_fill is @style.ColumnFill::Balance ||
       style.contain.inline_size ||
       style.contain.size
     ) &&
@@ -6395,8 +6395,8 @@ fn compute_with_collapse(
         is_inline_flow_participant(child_node, child_style) ||
         is_inline_float_only_wrapper
       ) &&
-      child_style.position != @types.Absolute &&
-      child_style.position != @types.Fixed
+      !(child_style.position is @types.Absolute) &&
+      !(child_style.position is @types.Fixed)
     if !participates_in_inline_run && inline_run_active {
       flush_inline_run_state()
     }
@@ -6420,8 +6420,8 @@ fn compute_with_collapse(
 
     let mut deferred_clear_y = current_pos
     let defer_inline_clear = child_node.id == "br" &&
-      child_style.display == @types.Inline &&
-      child_style.clear != @types.Clear::None
+      child_style.display is @types.Inline &&
+      !(child_style.clear is @types.Clear::None)
     // Handle clear property - move current_pos below cleared floats
     match child_style.clear {
       @types.Clear::Left | @types.Clear::Right | @types.Clear::Both => {
@@ -6457,8 +6457,8 @@ fn compute_with_collapse(
       child_establishes_bfc &&
       float_ctx.has_floats() &&
       !participates_in_inline_run &&
-      child_style.position != @types.Absolute &&
-      child_style.position != @types.Fixed {
+      !(child_style.position is @types.Absolute) &&
+      !(child_style.position is @types.Fixed) {
       let probe_height = if child_layout.height > 0.0 {
         child_layout.height
       } else if style.line_height > 0.0 {
@@ -6551,8 +6551,8 @@ fn compute_with_collapse(
     if !is_vertical_writing &&
       child_establishes_bfc &&
       float_ctx.has_floats() &&
-      child_style.position != @types.Absolute &&
-      child_style.position != @types.Fixed {
+      !(child_style.position is @types.Absolute) &&
+      !(child_style.position is @types.Fixed) {
       let required_width = child_layout.width +
         child_layout.margin.left +
         child_layout.margin.right
@@ -6646,8 +6646,8 @@ fn compute_with_collapse(
     let (float_inline_offset, float_inline_constrained) = if !is_vertical_writing &&
       float_ctx.has_floats() &&
       (@inline.is_inline_level(child_style.display) || child_establishes_bfc) &&
-      child_style.position != @types.Absolute &&
-      child_style.position != @types.Fixed {
+      !(child_style.position is @types.Absolute) &&
+      !(child_style.position is @types.Fixed) {
       let probe_height = if child_layout.height > 0.0 {
         child_layout.height
       } else if style.line_height > 0.0 {
@@ -6683,8 +6683,8 @@ fn compute_with_collapse(
       float_ctx.has_floats() &&
       !@inline.is_inline_level(child_style.display) &&
       !child_establishes_bfc &&
-      child_style.position != @types.Absolute &&
-      child_style.position != @types.Fixed {
+      !(child_style.position is @types.Absolute) &&
+      !(child_style.position is @types.Fixed) {
       let probe_height = if child_layout.height > 0.0 {
         child_layout.height
       } else if style.line_height > 0.0 {
@@ -6729,9 +6729,9 @@ fn compute_with_collapse(
     let mut positioned_child_width = child_layout.width
     if !is_vertical_writing &&
       !participates_in_inline_run &&
-      child_style.position != @types.Absolute &&
-      child_style.position != @types.Fixed &&
-      explicit_justify_self == @types.Alignment::Stretch {
+      !(child_style.position is @types.Absolute) &&
+      !(child_style.position is @types.Fixed) &&
+      explicit_justify_self is @types.Alignment::Stretch {
       let stretch_width = child_available_width -
         child_layout.margin.left -
         child_layout.margin.right
@@ -6780,8 +6780,8 @@ fn compute_with_collapse(
           inline_run_offset
         let self_align_offset = if !is_vertical_writing &&
           !participates_in_inline_run &&
-          child_style.position != @types.Absolute &&
-          child_style.position != @types.Fixed {
+          !(child_style.position is @types.Absolute) &&
+          !(child_style.position is @types.Fixed) {
           let free_space = child_available_width -
             positioned_child_width -
             child_layout.margin.left -
@@ -6820,7 +6820,7 @@ fn compute_with_collapse(
     }
 
     // Relative positioning offsets apply only to position:relative.
-    let (raw_final_x, raw_final_y) = if child_style.position == @types.Relative {
+    let (raw_final_x, raw_final_y) = if child_style.position is @types.Relative {
       let height_context = match child_available_height {
         Some(h) => Some(h + padding.vertical_sum() + border.vertical_sum())
         None => None
@@ -6936,7 +6936,7 @@ fn compute_with_collapse(
     } else {
       adjusted_layout
     }
-    let is_display_contents = child_style.display == @types.Contents
+    let is_display_contents = child_style.display is @types.Contents
     let no_principal = is_no_principal_table_internal_display(
       child_style.display,
     )
@@ -7061,7 +7061,7 @@ fn compute_with_collapse(
       if !collapses_through {
         // For display: contents, use children's total height instead of element's height (which is 0)
         // In vertical mode, we advance by width instead of height
-        let effective_size = if child_style.display == @types.Contents {
+        let effective_size = if child_style.display is @types.Contents {
           if is_vertical_writing {
             get_children_flow_extent_width(child_layout.children)
           } else {
@@ -7180,9 +7180,9 @@ fn compute_with_collapse(
     for i = 0; i < flow_children.length() && i < flow_styles.length(); i = i + 1 {
       let child_style = flow_styles[i]
       let child_layout = flow_children[i].layout
-      if child_style.position == @types.Absolute ||
-        child_style.position == @types.Fixed ||
-        child_style.float != @types.Float::None ||
+      if child_style.position is @types.Absolute ||
+        child_style.position is @types.Fixed ||
+        !(child_style.float is @types.Float::None) ||
         @inline.is_inline_level(child_style.display) ||
         child_layout.children.length() > 0 {
         simple_vertical_multicol = false
@@ -7436,7 +7436,7 @@ fn compute_with_collapse(
   // Now handle absolute positioned children
   for i = 0; i < node.children.length(); i = i + 1 {
     let child = node.children[i]
-    if child.style.position == @types.Absolute {
+    if child.style.position is @types.Absolute {
       // Get static y position for this absolute child
       let static_y = match absolute_static_positions.get(i) {
         Some(pos) =>
@@ -7526,7 +7526,7 @@ fn compute_with_collapse(
           raw_layout, child_node, style, is_vertical_writing, true,
         )
         let adjusted_layout = if multicol_enabled &&
-          child_node.style.display == @types.Contents &&
+          child_node.style.display is @types.Contents &&
           adjusted_layout.children.length() > 1 {
           {
             ..adjusted_layout,
@@ -7540,10 +7540,10 @@ fn compute_with_collapse(
           adjusted_layout
         }
         let child_style = child_node.style
-        let skip_out_of_flow = child_style.position == @types.Absolute ||
-          child_style.position == @types.Fixed ||
-          child_style.position == @types.Relative ||
-          child_style.float != @types.Float::None
+        let skip_out_of_flow = child_style.position is @types.Absolute ||
+          child_style.position is @types.Fixed ||
+          child_style.position is @types.Relative ||
+          !(child_style.float is @types.Float::None)
         if !skip_out_of_flow {
           let descendant_h = get_child_descendant_flow_extent_for_auto_height(
             child_node, adjusted_layout,

--- a/layout/flex/flex.mbt
+++ b/layout/flex/flex.mbt
@@ -1659,11 +1659,11 @@ fn compute_inline_flow_height(
   let flow_inline_children : Array[@node.Node] = []
   for child in node.children {
     let child_style = child.style
-    if child_style.display == @types.Display::None {
+    if child_style.display is @types.Display::None {
       continue
     }
-    if child_style.position == @types.Absolute ||
-      child_style.position == @types.Fixed {
+    if child_style.position is @types.Absolute ||
+      child_style.position is @types.Fixed {
       continue
     }
     match child_style.float {
@@ -2756,7 +2756,7 @@ fn compute_min_content_block_main_size(
   if parent_is_row {
     let intrinsic_cross_for_children : Double? = match style.height {
       @types.Length(h) => {
-        let content_h = if style.box_sizing == @types.BorderBox {
+        let content_h = if style.box_sizing is @types.BorderBox {
           h - padding.top - padding.bottom - border.top - border.bottom
         } else {
           h
@@ -2767,7 +2767,7 @@ fn compute_min_content_block_main_size(
         match available_cross {
           Some(cross) => {
             let resolved_h = cross * p
-            let content_h = if style.box_sizing == @types.BorderBox {
+            let content_h = if style.box_sizing is @types.BorderBox {
               resolved_h -
               padding.top -
               padding.bottom -
@@ -2784,7 +2784,7 @@ fn compute_min_content_block_main_size(
         match available_cross {
           Some(cross) => {
             let resolved_h = cross * p
-            let content_h = if style.box_sizing == @types.BorderBox {
+            let content_h = if style.box_sizing is @types.BorderBox {
               resolved_h -
               padding.top -
               padding.bottom -
@@ -2802,7 +2802,7 @@ fn compute_min_content_block_main_size(
         match available_cross {
           Some(cross) => {
             let resolved_h = cross * p
-            let content_h = if style.box_sizing == @types.BorderBox {
+            let content_h = if style.box_sizing is @types.BorderBox {
               resolved_h -
               padding.top -
               padding.bottom -
@@ -2828,11 +2828,11 @@ fn compute_min_content_block_main_size(
     for i = 0; i < children.length(); i = i + 1 {
       let child = children[i]
       let child_style = child.style
-      if child_style.display == @types.Display::None {
+      if child_style.display is @types.Display::None {
         continue
       }
-      if child_style.position == @types.Absolute ||
-        child_style.position == @types.Fixed {
+      if child_style.position is @types.Absolute ||
+        child_style.position is @types.Fixed {
         continue
       }
       // Use cached resolved rects
@@ -2927,11 +2927,11 @@ fn compute_min_content_block_main_size(
         for i = 0; i < children.length(); i = i + 1 {
           let child = children[i]
           let child_style = child.style
-          if child_style.display == @types.Display::None {
+          if child_style.display is @types.Display::None {
             continue
           }
-          if child_style.position == @types.Absolute ||
-            child_style.position == @types.Fixed {
+          if child_style.position is @types.Absolute ||
+            child_style.position is @types.Fixed {
             continue
           }
           // Use cached resolved rects
@@ -3870,7 +3870,7 @@ fn compute_intrinsic_block_main_size(
                 _ => @double.infinity
               }
               let clamped_h = @types.clamp(h, min_h, max_h)
-              if style.box_sizing == @types.BorderBox {
+              if style.box_sizing is @types.BorderBox {
                 Some(clamped_h * ratio)
               } else {
                 let content_h = clamped_h -
@@ -3909,7 +3909,7 @@ fn compute_intrinsic_block_main_size(
     // should resolve against this block's used content-box height when definite.
     let intrinsic_cross_for_children : Double? = match style.height {
       @types.Length(h) => {
-        let content_h = if style.box_sizing == @types.BorderBox {
+        let content_h = if style.box_sizing is @types.BorderBox {
           h - padding.top - padding.bottom - border.top - border.bottom
         } else {
           h
@@ -3920,7 +3920,7 @@ fn compute_intrinsic_block_main_size(
         match available_cross {
           Some(cross) => {
             let resolved_h = cross * p
-            let content_h = if style.box_sizing == @types.BorderBox {
+            let content_h = if style.box_sizing is @types.BorderBox {
               resolved_h -
               padding.top -
               padding.bottom -
@@ -3937,7 +3937,7 @@ fn compute_intrinsic_block_main_size(
         match available_cross {
           Some(cross) => {
             let resolved_h = cross * p
-            let content_h = if style.box_sizing == @types.BorderBox {
+            let content_h = if style.box_sizing is @types.BorderBox {
               resolved_h -
               padding.top -
               padding.bottom -
@@ -3955,7 +3955,7 @@ fn compute_intrinsic_block_main_size(
         match available_cross {
           Some(cross) => {
             let resolved_h = cross * p
-            let content_h = if style.box_sizing == @types.BorderBox {
+            let content_h = if style.box_sizing is @types.BorderBox {
               resolved_h -
               padding.top -
               padding.bottom -
@@ -3985,11 +3985,11 @@ fn compute_intrinsic_block_main_size(
       for i = 0; i < children.length(); i = i + 1 {
         let child = children[i]
         let child_style = child.style
-        if child_style.display == @types.Display::None {
+        if child_style.display is @types.Display::None {
           continue
         }
-        if child_style.position == @types.Absolute ||
-          child_style.position == @types.Fixed {
+        if child_style.position is @types.Absolute ||
+          child_style.position is @types.Fixed {
           continue
         }
         match child_style.float {
@@ -4038,11 +4038,11 @@ fn compute_intrinsic_block_main_size(
       for i = 0; i < children.length(); i = i + 1 {
         let child = children[i]
         let child_style = child.style
-        if child_style.display == @types.Display::None {
+        if child_style.display is @types.Display::None {
           continue
         }
-        if child_style.position == @types.Absolute ||
-          child_style.position == @types.Fixed {
+        if child_style.position is @types.Absolute ||
+          child_style.position is @types.Fixed {
           continue
         }
         match child_style.float {
@@ -4057,7 +4057,7 @@ fn compute_intrinsic_block_main_size(
           current_line_width = 0.0
           continue
         }
-        if child_style.display != @types.Contents &&
+        if !(child_style.display is @types.Contents) &&
           !@inline.is_inline_level(child_style.display) {
           only_inline_flow = false
           break
@@ -4093,11 +4093,11 @@ fn compute_intrinsic_block_main_size(
     for i = 0; i < children.length(); i = i + 1 {
       let child = children[i]
       let child_style = child.style
-      if child_style.display == @types.Display::None {
+      if child_style.display is @types.Display::None {
         continue
       }
-      if child_style.position == @types.Absolute ||
-        child_style.position == @types.Fixed {
+      if child_style.position is @types.Absolute ||
+        child_style.position is @types.Fixed {
         continue
       }
       // Use cached resolved rects
@@ -4129,18 +4129,18 @@ fn compute_intrinsic_block_main_size(
         for i = 0; i < children.length(); i = i + 1 {
           let child = children[i]
           let child_style = child.style
-          if child_style.display == @types.Display::None {
+          if child_style.display is @types.Display::None {
             continue
           }
-          if child_style.position == @types.Absolute ||
-            child_style.position == @types.Fixed {
+          if child_style.position is @types.Absolute ||
+            child_style.position is @types.Fixed {
             continue
           }
           // Use cached resolved rects
           let child_resolved = child.resolved_rects(available_width)
           let child_margin = child_resolved.margin
-          let child_is_table = child_style.display == @types.Table ||
-            child_style.display == @types.InlineTable
+          let child_is_table = child_style.display is @types.Table ||
+            child_style.display is @types.InlineTable
           let child_height = match child_style.height {
             @types.Length(h) if !child_is_table =>
               h + child_margin.top + child_margin.bottom
@@ -4464,7 +4464,7 @@ fn compute_internal(
   let style = node.style
 
   // Handle display: none - return zero-sized layout with zero-sized children
-  if style.display == @types.Display::None {
+  if style.display is @types.Display::None {
     return create_hidden_layout(node)
   }
 
@@ -4528,8 +4528,8 @@ fn compute_internal(
     _ => None
   }
   // Check if this is a block-level flex container (Flex/Block) vs inline-level (InlineFlex)
-  let is_block_level = style.display == @types.Flex ||
-    style.display == @types.Block
+  let is_block_level = style.display is @types.Flex ||
+    style.display is @types.Block
   let mut container_width = match intrinsic_from_measure {
     Some((w, _)) => w
     None =>
@@ -4541,7 +4541,7 @@ fn compute_internal(
             w
           }
           if use_available_width &&
-            ctx.sizing_mode == @layout_types.Definite &&
+            ctx.sizing_mode is @layout_types.Definite &&
             available_width < outer_w {
             available_width
           } else {
@@ -4549,20 +4549,20 @@ fn compute_internal(
           }
         }
         @types.Percent(p) =>
-          if use_available_width && ctx.sizing_mode == @layout_types.Definite {
+          if use_available_width && ctx.sizing_mode is @layout_types.Definite {
             available_width
           } else {
             parent_width * p
           }
         @types.Calc(_, p) =>
-          if use_available_width && ctx.sizing_mode == @layout_types.Definite {
+          if use_available_width && ctx.sizing_mode is @layout_types.Definite {
             available_width
           } else {
             parent_width * p
           }
         @types.MathFn(__mop, __mterms) => {
           let p = @types.apply_math_op(__mop, __mterms.map(fn(__t) { __t.1 }))
-          if use_available_width && ctx.sizing_mode == @layout_types.Definite {
+          if use_available_width && ctx.sizing_mode is @layout_types.Definite {
             available_width
           } else {
             parent_width * p
@@ -4809,7 +4809,7 @@ fn compute_internal(
           match ctx.available_height {
             Some(ah) =>
               if use_available_width &&
-                ctx.sizing_mode == @layout_types.Definite {
+                ctx.sizing_mode is @layout_types.Definite {
                 Some(ah - padding.vertical_sum() - border.vertical_sum())
               } else {
                 Some(
@@ -4824,7 +4824,7 @@ fn compute_internal(
           match ctx.available_height {
             Some(ah) =>
               if use_available_width &&
-                ctx.sizing_mode == @layout_types.Definite {
+                ctx.sizing_mode is @layout_types.Definite {
                 Some(ah - padding.vertical_sum() - border.vertical_sum())
               } else {
                 Some(
@@ -4840,7 +4840,7 @@ fn compute_internal(
           match ctx.available_height {
             Some(ah) =>
               if use_available_width &&
-                ctx.sizing_mode == @layout_types.Definite {
+                ctx.sizing_mode is @layout_types.Definite {
                 Some(ah - padding.vertical_sum() - border.vertical_sum())
               } else {
                 Some(
@@ -5178,13 +5178,13 @@ fn compute_internal(
     let svg_auto_viewbox_box = uses_svg_auto_viewbox_box(child)
 
     // Skip display:none children
-    if child_style.display == @types.Display::None {
+    if child_style.display is @types.Display::None {
       continue
     }
 
     // Skip absolutely positioned children (they don't participate in flex layout)
-    if child_style.position == @types.Absolute ||
-      child_style.position == @types.Fixed {
+    if child_style.position is @types.Absolute ||
+      child_style.position is @types.Fixed {
       continue
     }
     // Use cached resolved rects for margin
@@ -5513,8 +5513,8 @@ fn compute_internal(
       Some(constrain_column_intrinsic_cross(base_cross))
     }
 
-    let is_table_item = child_style.display == @types.Table ||
-      child_style.display == @types.InlineTable
+    let is_table_item = child_style.display is @types.Table ||
+      child_style.display is @types.InlineTable
 
     // Calculate base size on main axis (flex-basis takes priority over width/height)
     // CSS spec: If flex-basis is a percentage of an indefinite size, it resolves
@@ -5524,7 +5524,7 @@ fn compute_internal(
         if is_intrinsic_sizing &&
           width_is_auto &&
           is_row &&
-          child_style.width == @types.Auto {
+          child_style.width is @types.Auto {
           0.0
         } else {
           b
@@ -5632,8 +5632,8 @@ fn compute_internal(
                     child.children.length() == 0 &&
                     child.measure is None &&
                     (
-                      child_style.display == @types.Flex ||
-                      child_style.display == @types.InlineFlex
+                      child_style.display is @types.Flex ||
+                      child_style.display is @types.InlineFlex
                     )
                   if stretched_single_flex_leaf {
                     content_width
@@ -5660,7 +5660,7 @@ fn compute_internal(
                       content_width
                     } else if flattened.length() == 1 &&
                       content_width > 0.0 &&
-                      child_style.flex_direction == @types.Column &&
+                      child_style.flex_direction is @types.Column &&
                       has_flex_grow_descendant(child) {
                       content_width
                     } else {
@@ -5815,10 +5815,10 @@ fn compute_internal(
       if !is_row {
         let mut caption_main_extra = 0.0
         for table_child in child.children {
-          if table_child.style.display == @types.Display::None {
+          if table_child.style.display is @types.Display::None {
             continue
           }
-          if table_child.style.display == @types.TableCaption {
+          if table_child.style.display is @types.TableCaption {
             let caption_height = match table_child.style.height {
               @types.Length(h) => h
               @types.Percent(_) => 0.0
@@ -5835,7 +5835,7 @@ fn compute_internal(
                 )
                 let mut intrinsic_child_height = 0.0
                 for caption_child in table_child.children {
-                  if caption_child.style.display == @types.Display::None {
+                  if caption_child.style.display is @types.Display::None {
                     continue
                   }
                   intrinsic_child_height = intrinsic_child_height +
@@ -6201,8 +6201,8 @@ fn compute_internal(
     // Grid items in row flex containers should not exceed available main size.
     if is_row &&
       (
-        child_style.display == @types.Grid ||
-        child_style.display == @types.InlineGrid
+        child_style.display is @types.Grid ||
+        child_style.display is @types.InlineGrid
       ) {
       let max_main = content_width - margin_main
       if max_main > 0.0 && base_main > max_main {
@@ -6247,7 +6247,7 @@ fn compute_internal(
           let aspect_width = match
             (child_style.aspect_ratio, child_style.height) {
             (Some(ar), @types.Length(h)) if ar > 0.0 =>
-              if child_style.box_sizing == @types.BorderBox {
+              if child_style.box_sizing is @types.BorderBox {
                 h * ar
               } else {
                 (
@@ -6264,7 +6264,7 @@ fn compute_internal(
                 Some(ch) => ch
                 None => 0.0
               }
-              if child_style.box_sizing == @types.BorderBox {
+              if child_style.box_sizing is @types.BorderBox {
                 h * ar
               } else {
                 (
@@ -6289,14 +6289,14 @@ fn compute_internal(
       }
       let can_transfer_cross_max_to_width = child_is_replaced_like &&
         (
-          child_style.width == @types.Auto ||
+          child_style.width is @types.Auto ||
           uses_svg_default_intrinsic_box(child)
         )
       let transferred_max_w = match child_style.aspect_ratio {
         Some(ratio) if ratio > 0.0 && can_transfer_cross_max_to_width =>
           match child_style.max_height {
             @types.Length(v) =>
-              if child_style.box_sizing == @types.BorderBox {
+              if child_style.box_sizing is @types.BorderBox {
                 v * ratio
               } else {
                 let content_h = v -
@@ -6314,7 +6314,7 @@ fn compute_internal(
             @types.Percent(p) =>
               match content_height {
                 Some(ch) =>
-                  if child_style.box_sizing == @types.BorderBox {
+                  if child_style.box_sizing is @types.BorderBox {
                     ch * p * ratio
                   } else {
                     let content_h = ch * p -
@@ -6334,7 +6334,7 @@ fn compute_internal(
             @types.Calc(_, p) =>
               match content_height {
                 Some(ch) =>
-                  if child_style.box_sizing == @types.BorderBox {
+                  if child_style.box_sizing is @types.BorderBox {
                     ch * p * ratio
                   } else {
                     let content_h = ch * p -
@@ -6358,7 +6358,7 @@ fn compute_internal(
               )
               match content_height {
                 Some(ch) =>
-                  if child_style.box_sizing == @types.BorderBox {
+                  if child_style.box_sizing is @types.BorderBox {
                     ch * p * ratio
                   } else {
                     let content_h = ch * p -
@@ -6411,8 +6411,8 @@ fn compute_internal(
             // For flex-grow items, use max-content to match taffy behavior.
             let use_max_content_min = child_style.flex_grow > 0.0 &&
               (
-                child_style.display == @types.Flex ||
-                child_style.display == @types.InlineFlex
+                child_style.display is @types.Flex ||
+                child_style.display is @types.InlineFlex
               ) &&
               child.children.length() > 0
             let content_min = if aspect_min > 0.0 {
@@ -6523,14 +6523,14 @@ fn compute_internal(
       }
       let can_transfer_cross_max_to_height = child_is_replaced_like &&
         (
-          child_style.height == @types.Auto ||
+          child_style.height is @types.Auto ||
           uses_svg_default_intrinsic_box(child)
         )
       let transferred_max_h = match child_style.aspect_ratio {
         Some(ratio) if ratio > 0.0 && can_transfer_cross_max_to_height =>
           match child_style.max_width {
             @types.Length(v) =>
-              if child_style.box_sizing == @types.BorderBox {
+              if child_style.box_sizing is @types.BorderBox {
                 v / ratio
               } else {
                 let content_w = v -
@@ -6546,7 +6546,7 @@ fn compute_internal(
                 }
               }
             @types.Percent(p) =>
-              if child_style.box_sizing == @types.BorderBox {
+              if child_style.box_sizing is @types.BorderBox {
                 content_width * p / ratio
               } else {
                 let content_w = content_width * p -
@@ -6562,7 +6562,7 @@ fn compute_internal(
                 }
               }
             @types.Calc(_, p) =>
-              if child_style.box_sizing == @types.BorderBox {
+              if child_style.box_sizing is @types.BorderBox {
                 content_width * p / ratio
               } else {
                 let content_w = content_width * p -
@@ -6582,7 +6582,7 @@ fn compute_internal(
                 __mop,
                 __mterms.map(fn(__t) { __t.1 }),
               )
-              if child_style.box_sizing == @types.BorderBox {
+              if child_style.box_sizing is @types.BorderBox {
                 content_width * p / ratio
               } else {
                 let content_w = content_width * p -
@@ -6644,8 +6644,8 @@ fn compute_internal(
             // For flex-grow items, use max-content to match taffy behavior.
             let use_max_content_min = child_style.flex_grow > 0.0 &&
               (
-                child_style.display == @types.Flex ||
-                child_style.display == @types.InlineFlex
+                child_style.display is @types.Flex ||
+                child_style.display is @types.InlineFlex
               ) &&
               child.children.length() > 0
             let content_min = if aspect_min > 0.0 {
@@ -6780,8 +6780,8 @@ fn compute_internal(
       (margin_left_auto, margin_right_auto)
     }
 
-    let needs_baseline = style.align_items == @types.Baseline ||
-      child_style.align_self == @types.AlignSelf::Baseline
+    let needs_baseline = style.align_items is @types.Baseline ||
+      child_style.align_self is @types.AlignSelf::Baseline
     // Compute baseline for this item (for Row flex, cross is height)
     // For Row: baseline is relative to the item's height
     // For Column: baseline is relative to the item's width (not commonly used)
@@ -6845,7 +6845,7 @@ fn compute_internal(
   // If content size >= min_height, no flex distribution needed (items keep natural size)
   let suppress_auto_main_distribution = style.writing_mode.is_vertical() &&
     declared_direction_is_row &&
-    style.height == @types.Auto &&
+    style.height is @types.Auto &&
     total_flex_grow <= 0.0
   let (main_size_defined, main_size) = match min_main_for_grow {
     Some(min_main) =>
@@ -7312,8 +7312,8 @@ fn compute_internal(
         @types.MinContent | @types.MaxContent | @types.FitContent(_) => ()
       }
       // Ensure grid items respect available main size in flex rows.
-      if child_style.display == @types.Grid ||
-        child_style.display == @types.InlineGrid {
+      if child_style.display is @types.Grid ||
+        child_style.display is @types.InlineGrid {
         let max_main = content_width - item.margin_main
         if max_main > 0.0 && final_main > max_main {
           final_main = max_main
@@ -7381,8 +7381,8 @@ fn compute_internal(
   for i = 0; i < flex_items.length(); i = i + 1 {
     let item = flex_items[i]
     let child_style = item.node.style
-    let child_is_table = child_style.display == @types.Table ||
-      child_style.display == @types.InlineTable
+    let child_is_table = child_style.display is @types.Table ||
+      child_style.display is @types.InlineTable
 
     // Determine effective alignment (align-self overrides align-items)
     let effective_align = match child_style.align_self {
@@ -7774,7 +7774,7 @@ fn compute_internal(
         child_border.horizontal_sum()
       let transferred_min_cross = match child_style.aspect_ratio {
         Some(ratio) if ratio > 0.0 && item.cross_is_auto =>
-          if child_style.box_sizing == @types.BorderBox {
+          if child_style.box_sizing is @types.BorderBox {
             item.final_main * ratio
           } else {
             let content_main = item.final_main -
@@ -7979,7 +7979,7 @@ fn compute_internal(
   // Handle align-content: Stretch - distribute extra space to lines
   // NOTE: Stretch applies to line SIZE even in single-line containers
   let line_count = flex_lines.length()
-  if style.align_content == @types.Stretch &&
+  if style.align_content is @types.Stretch &&
     cross_free_space > 0.0 &&
     line_count > 0 {
     // Distribute extra cross space equally among lines
@@ -8042,7 +8042,7 @@ fn compute_internal(
     }
   } else {
     // Column containers align lines on the inline axis.
-    style.direction == @style.Direction::Ltr
+    style.direction is @style.Direction::Ltr
   }
   let effective_align_content_for_position = if logical_start_is_min_cross ||
     align_content_is_physical {
@@ -8057,7 +8057,7 @@ fn compute_internal(
   // In vertical-rl row containers, the cross axis physical min/max are mirrored
   // relative to flex-relative start/end. Flip only flex-relative keywords here.
   let effective_align_content_for_position = if direction_is_row &&
-    style.writing_mode == @style.WritingMode::VerticalRl {
+    style.writing_mode is @style.WritingMode::VerticalRl {
     match effective_align_content_for_position {
       @types.FlexStart => @types.Alignment::FlexEnd
       @types.FlexEnd => @types.Alignment::FlexStart
@@ -8070,7 +8070,7 @@ fn compute_internal(
     effective_align_content_for_position, cross_free_space, line_count,
   )
   // For Stretch, cross_free_space was distributed to lines, so use 0 for line_gap
-  let effective_line_gap = if style.align_content == @types.Stretch {
+  let effective_line_gap = if style.align_content is @types.Stretch {
     0.0
   } else {
     line_gap
@@ -8102,7 +8102,7 @@ fn compute_internal(
   }
   let uses_reversed_position = is_wrap_reverse && is_flex_relative_align
   let mirrors_vertical_rl_row_lines = direction_is_row &&
-    style.writing_mode == @style.WritingMode::VerticalRl &&
+    style.writing_mode is @style.WritingMode::VerticalRl &&
     !is_wrap_reverse
   let mut cross_pos = if mirrors_vertical_rl_row_lines {
     line_start_offset + total_lines_cross
@@ -8186,9 +8186,9 @@ fn compute_internal(
     // - map logical start/end by writing-mode + direction
     let logical_start_is_min_main = if direction_is_row {
       if style.writing_mode.is_vertical() {
-        style.direction == @style.Direction::Ltr
+        style.direction is @style.Direction::Ltr
       } else {
-        style.direction == @style.Direction::Ltr
+        style.direction is @style.Direction::Ltr
       }
     } else {
       match style.writing_mode {
@@ -8322,8 +8322,8 @@ fn compute_internal(
         @alignment.resolve_align_self(child.style.align_self, style.align_items)
       }
       let uses_column_baseline_side_fallback = !is_row &&
-        raw_effective_align == @types.Baseline &&
-        child.style.writing_mode == @style.WritingMode::HorizontalTb
+        raw_effective_align is @types.Baseline &&
+        child.style.writing_mode is @style.WritingMode::HorizontalTb
       let effective_align = resolve_flex_item_cross_alignment(
         is_row,
         raw_effective_align,
@@ -8496,8 +8496,8 @@ fn compute_internal(
                   }
                 }
                 @types.Auto => {
-                  let child_is_table = child_style.display == @types.Table ||
-                    child_style.display == @types.InlineTable
+                  let child_is_table = child_style.display is @types.Table ||
+                    child_style.display is @types.InlineTable
                   if child_is_table {
                     let table_min_cross = compute_min_content_main_size(
                       child,
@@ -8795,7 +8795,7 @@ fn compute_internal(
 
       // Relative positioning offsets apply only to position:relative.
       let child_style = child.style
-      let (child_x, child_y) = if child_style.position == @types.Relative {
+      let (child_x, child_y) = if child_style.position is @types.Relative {
         let (x_offset, y_offset) = @core.resolve_relative_inset_offsets(
           child_style.inset,
           content_width,
@@ -8865,7 +8865,7 @@ fn compute_internal(
             }
           _ => false
         }
-        let child_is_inline_block = child.style.display == @types.InlineBlock
+        let child_is_inline_block = child.style.display is @types.InlineBlock
         let child_is_table = match child.style.display {
           @types.Table | @types.InlineTable => true
           _ => false
@@ -8997,7 +8997,7 @@ fn compute_internal(
           match ctx.available_height {
             Some(ah) =>
               if use_available_width &&
-                ctx.sizing_mode == @layout_types.Definite {
+                ctx.sizing_mode is @layout_types.Definite {
                 ah
               } else {
                 parent_height * p
@@ -9038,7 +9038,7 @@ fn compute_internal(
           match ctx.available_height {
             Some(ah) =>
               if use_available_width &&
-                ctx.sizing_mode == @layout_types.Definite {
+                ctx.sizing_mode is @layout_types.Definite {
                 ah
               } else {
                 parent_height * pct + px
@@ -9079,7 +9079,7 @@ fn compute_internal(
           match ctx.available_height {
             Some(ah) =>
               if use_available_width &&
-                ctx.sizing_mode == @layout_types.Definite {
+                ctx.sizing_mode is @layout_types.Definite {
                 ah
               } else {
                 @types.apply_math_op(
@@ -9272,12 +9272,12 @@ fn compute_internal(
     let child_style = child.style
 
     // Only process absolutely positioned children
-    if child_style.position != @types.Absolute {
+    if !(child_style.position is @types.Absolute) {
       continue
     }
 
     // Skip display:none children - create zero-sized layout
-    if child_style.display == @types.Display::None {
+    if child_style.display is @types.Display::None {
       indexed_layouts.push({
         dom_index: i,
         layout: @absolute.create_zero_layout(child.id),
@@ -9412,7 +9412,7 @@ fn compute_internal(
         )
         let center_aligned_auto_main = params.inset_left is None &&
           params.inset_right is None &&
-          style.justify_content == @types.Center
+          style.justify_content is @types.Center
         let shrink_fit_available_width = if center_aligned_auto_main {
           let expanded = container_width + margin.left + margin.right
           if expanded > container_width {
@@ -9667,12 +9667,12 @@ fn compute_internal(
     let child_style = child.style
 
     // Only process fixed positioned children
-    if child_style.position != @types.Fixed {
+    if !(child_style.position is @types.Fixed) {
       continue
     }
 
     // Skip display:none children - create zero-sized layout
-    if child_style.display == @types.Display::None {
+    if child_style.display is @types.Display::None {
       indexed_layouts.push({
         dom_index: i,
         layout: @absolute.create_zero_layout(child.id),
@@ -9852,17 +9852,17 @@ fn compute_internal(
     let child = children[i]
     let child_style = child.style
     // Skip absolute/fixed children (already processed above)
-    if child_style.position == @types.Absolute ||
-      child_style.position == @types.Fixed {
+    if child_style.position is @types.Absolute ||
+      child_style.position is @types.Fixed {
       continue
     }
     // Add zero-sized layout for display:none children
-    if child_style.display == @types.Display::None {
+    if child_style.display is @types.Display::None {
       indexed_layouts.push({ dom_index: i, layout: create_hidden_layout(child) })
       continue
     }
     // Handle display:contents children - build wrapper with collected layouts
-    if child_style.display == @types.Contents {
+    if child_style.display is @types.Contents {
       match contents_layouts.get(i) {
         Some(layouts_with_ancestors) => {
           // Rebuild nested display:contents wrappers using ancestor paths.
@@ -9926,11 +9926,11 @@ fn compute_internal(
             let dom_index = il.dom_index
             if dom_index >= 0 && dom_index < child_count {
               let child_style = children[dom_index].style
-              if child_style.position == @types.Absolute ||
-                child_style.position == @types.Fixed {
+              if child_style.position is @types.Absolute ||
+                child_style.position is @types.Fixed {
                 continue
               }
-              if child_style.display == @types.Display::None {
+              if child_style.display is @types.Display::None {
                 continue
               }
             }
@@ -10050,8 +10050,8 @@ fn compute_internal(
     for il in indexed_layouts {
       if il.dom_index >= 0 && il.dom_index < child_count {
         let child = children[il.dom_index]
-        if child.style.position == @types.Absolute ||
-          child.style.position == @types.Fixed ||
+        if child.style.position is @types.Absolute ||
+          child.style.position is @types.Fixed ||
           flex_abs_cb_applies(child.style) {
           adjusted.push(il.layout)
         } else {

--- a/layout/grid/grid.mbt
+++ b/layout/grid/grid.mbt
@@ -2965,7 +2965,7 @@ fn try_compute_simple_block_intrinsic_height(
   cache : GridIntrinsicCache,
   dispatch : @node.DispatchFn,
 ) -> Double? {
-  if child.style.position != @types.Static ||
+  if !(child.style.position is @types.Static) ||
     child.measure is Some(_) ||
     child.style.writing_mode.is_vertical() {
     return None
@@ -2988,19 +2988,19 @@ fn try_compute_simple_block_intrinsic_height(
   let mut total_height = pt + pb + bt + bb
   for grand_child in child.children {
     let grand_style = grand_child.style
-    if grand_style.display == @types.Display::None {
+    if grand_style.display is @types.Display::None {
       continue
     }
     match grand_style.display {
       @types.Block | @types.Flex | @types.InlineFlex => ()
       _ => return None
     }
-    if grand_style.display == @types.Contents ||
+    if grand_style.display is @types.Contents ||
       @inline.is_inline_level(grand_style.display) ||
       grand_child.id == "br" {
       return None
     }
-    if grand_style.position != @types.Static ||
+    if !(grand_style.position is @types.Static) ||
       grand_child.measure is Some(_) ||
       grand_style.writing_mode.is_vertical() {
       return None
@@ -5057,11 +5057,11 @@ fn place_grid_items(
   for i = 0; i < children.length(); i = i + 1 {
     let child = children[i]
     let style = child.style
-    if style.display == @types.Display::None {
+    if style.display is @types.Display::None {
       continue
     }
     // Skip absolute positioned items - they don't participate in grid placement
-    if style.position == @types.Absolute || style.position == @types.Fixed {
+    if style.position is @types.Absolute || style.position is @types.Fixed {
       continue
     }
 
@@ -5122,11 +5122,11 @@ fn place_grid_items(
   for i = 0; i < children.length(); i = i + 1 {
     let child = children[i]
     let style = child.style
-    if style.display == @types.Display::None {
+    if style.display is @types.Display::None {
       continue
     }
     // Skip absolute positioned items
-    if style.position == @types.Absolute || style.position == @types.Fixed {
+    if style.position is @types.Absolute || style.position is @types.Fixed {
       continue
     }
 
@@ -5179,10 +5179,10 @@ fn place_grid_items(
   for i = 0; i < children.length(); i = i + 1 {
     let child = children[i]
     let style = child.style
-    if style.display == @types.Display::None {
+    if style.display is @types.Display::None {
       continue
     }
-    if style.position == @types.Absolute || style.position == @types.Fixed {
+    if style.position is @types.Absolute || style.position is @types.Fixed {
       continue
     }
     let has_explicit_column = style_has_explicit_column(style)
@@ -5227,11 +5227,11 @@ fn place_grid_items(
   for i = 0; i < children.length(); i = i + 1 {
     let child = children[i]
     let style = child.style
-    if style.display == @types.Display::None {
+    if style.display is @types.Display::None {
       continue
     }
     // Skip absolute positioned items
-    if style.position == @types.Absolute || style.position == @types.Fixed {
+    if style.position is @types.Absolute || style.position is @types.Fixed {
       continue
     }
 

--- a/layout/inline/inline.mbt
+++ b/layout/inline/inline.mbt
@@ -2990,11 +2990,11 @@ pub fn should_establish_ifc(children : Array[@node.Node]) -> Bool {
   let mut has_inline = false
   for child in children {
     // Skip absolute positioned children
-    if child.style.position == @types.Absolute {
+    if child.style.position is @types.Absolute {
       continue
     }
     // Skip display:none
-    if child.style.display == @types.Display::None {
+    if child.style.display is @types.Display::None {
       continue
     }
     if child.id == "br" || @node.str_has_prefix(child.id, "#text") {

--- a/renderer/renderer/absolute_positioning.mbt
+++ b/renderer/renderer/absolute_positioning.mbt
@@ -214,6 +214,17 @@ fn apply_zoom_and_scale(
   let child_parent_scale_x = total_scale_x / effective_zoom // Remove node zoom, will be re-applied
   let child_parent_scale_y = total_scale_y / effective_zoom
 
+  // Nothing here scales, translates or otherwise moves this box: no inherited
+  // zoom or scale, no zoom of its own, and an identity transform. Every field
+  // this function would compute for such a node is then the field it was given.
+  // Combined with `children_changed` below, this drives the fast path at the
+  // end of the function.
+  let node_is_unscaled = parent_zoom == 1.0 &&
+    parent_scale_x == 1.0 &&
+    parent_scale_y == 1.0 &&
+    node.style.zoom == 1.0 &&
+    node.style.transform.is_none()
+
   // Scale the layout dimensions
   let scaled_width = layout.width * total_scale_x
   let scaled_height = layout.height * total_scale_y
@@ -271,6 +282,10 @@ fn apply_zoom_and_scale(
 
   // Process children with updated parent zoom and scale
   let scaled_children : Array[@layout_types.Layout] = []
+  // Whether any child came back as a different record than the one already in
+  // `layout.children` -- a scaled subtree, or an absolutely-positioned child
+  // shifted onto its real containing block.
+  let mut children_changed = false
   let mut child_node_cursor = 0
   for i = 0; i < layout.children.length(); i = i + 1 {
     let child_layout = layout.children[i]
@@ -282,7 +297,7 @@ fn apply_zoom_and_scale(
     let mut scan_index = child_node_cursor
     while scan_index < node.children.length() {
       let candidate = node.children[scan_index]
-      if candidate.style.display == @types.Display::None {
+      if candidate.style.display is @types.Display::None {
         scan_index = scan_index + 1
         continue
       }
@@ -312,7 +327,7 @@ fn apply_zoom_and_scale(
       current_abs_containing_block_global_y, current_abs_containing_block_width,
       current_abs_containing_block_height,
     )
-    if child_node.style.position == @types.Absolute {
+    if child_node.style.position is @types.Absolute {
       let inset_left_auto = is_auto_inset(child_node.style.inset.left)
       let inset_right_auto = is_auto_inset(child_node.style.inset.right)
       let inset_top_auto = is_auto_inset(child_node.style.inset.top)
@@ -459,14 +474,26 @@ fn apply_zoom_and_scale(
       } else {
         0.0
       }
+      children_changed = true
       scaled_children.push({
         ..scaled_child,
         x: scaled_child.x + adjust_x + cb_size_adjust_x + align_adjust_x,
         y: scaled_child.y + adjust_y + cb_size_adjust_y + align_adjust_y,
       })
     } else {
+      if !physical_equal(scaled_child, child_layout) {
+        children_changed = true
+      }
       scaled_children.push(scaled_child)
     }
+  }
+  // Fast path: this box does not move and neither did anything below it, so the
+  // record built below would equal `layout` field for field. Hand `layout` back
+  // instead. A document with no zoom and no transforms -- the common case --
+  // takes this at every node, which turns the whole walk from a deep copy of
+  // the layout tree into a read of it.
+  if node_is_unscaled && !children_changed {
+    return layout
   }
   // Scale margin, padding, border
   let scaled_margin : @types.Rect[Double] = {


### PR DESCRIPTION
#339 の続きで挙げていた 1（`apply_zoom_and_scale`）と 2（`Display` の `==`）の2件。

**先に結論**: 削れた作業量は決定論的に大きい（enum 比較の関数呼び出しが −73%、レイアウトツリーの全コピーが1回まるごと消える）が、**wall clock は 1〜3% 程度**でこのランナーのノイズ床（±2%）とほぼ同じ。速いから入れる、ではなく「同じ出力をより少ない仕事で出せる」から入れる、という位置づけ。

## 1. zoom/transform ウォークがレイアウトツリーを毎回ディープコピーしていた

`apply_zoom_and_scale` は訪れたノードごとに `Layout` レコード・children 配列・margin/padding/border の `Rect[Double]` 3つを作り直すので、render のたびに **レイアウトツリーの完全なコピー**を下流に渡していた。`render_large_2k5`（2.5k ノード）で計測したところ、**8,173 回の呼び出しが全部 identity ケース**（継承 zoom = 1、自身の zoom なし、identity transform）。つまり入力とフィールド単位で同一のものを作り直していた。

ただし単純にスキップはできない — このウォークは absolute 配置の子を本来の containing block に寄せる処理も兼ねている。なので bottom-up の fast path にした: **自身がスケールも変形もせず、かつどの子も別レコードとして返ってこなかった**（`physical_equal`）とき `layout` をそのまま返す。スケールされた部分木や containing block 補正を受けた abspos の子は物理的に入力と別オブジェクトなので、このフラグは安全側に倒れる。

## 2. payload なし enum の `==` は関数呼び出しになる

`x == @types.Display::None` は比較にコンパイルされない。derive した `Eq` 経由で `Display::equal`（20 variant の switch）への **呼び出し**になり、`x != ...` はさらに `not_equal` ラッパーを挟んで **2 回**になる。パターン形式 `x is @types.Display::None` は `x === 17` にインライン展開される（debug / release 両方で確認）。`match` は元から後者なので、これは純粋に演算子の選択の問題。

`render_large_2k5` の 10 render で `Display::equal` 407,352 回、`Position::equal` 364,430 回。ノードあたり毎 render 15〜16 回。

呼び出し元を集計したら **92% が 18 関数に集中**していたので、ワークスペース全体の ~1,200 箇所ではなく**その 18 関数の中だけ**（5 ファイル、`==` 199 + `!=` 23）を変換した。残りは構造的に cold なので意図的に放置 — あの裾野は diff に見合わない。

## 決定論的カウンタ（`render_large_2k5` × 10 render、ビルド済みバンドルを計装）

| Counter | Before | After | Delta |
|---------|--------|-------|-------|
| `Display::equal` 呼び出し | 407,352 | 175,186 | **-57.0%** |
| `Position::equal` 呼び出し | 364,430 | 34,386 | **-90.6%** |
| `Layout` レコード生成 | 58,971 | 50,798 | -13.9% |
| `Rect[Double]` 生成 | 87,551 | 63,032 | -28.0% |

`Layout` の −8,173 は zoom ウォークの呼び出し回数ちょうど、`Rect` の −24,519 はその 3 倍ちょうど。

## Wall clock（21 回インターリーブ、median of medians）

| Benchmark | Before | After | Delta |
|-----------|--------|-------|-------|
| `deep_flex_d6` | 6.71 ms | 6.51 ms | -3.0% |
| `dashboard_layout` | 1.13 ms | 1.11 ms | -1.8% |
| `render_flat_1000` | 25.30 ms | 25.16 ms | -0.6% |
| `render_dash_med` | 7.40 ms | 7.59 ms | +2.6% |
| `parse_simple_100` (control) | 36.90 µs | 36.33 µs | -1.6% |
| `parse_simple_1000` (control) | 397.24 µs | 397.79 µs | +0.1% |
| `match_non_idx_1k` (control) | 32.15 µs | 32.85 µs | +2.2% |

コントロールからノイズ床は ±2% 程度で、はっきり超えているのは `deep_flex_d6` だけ。

**ついでの教訓**: 同じ2つの変更を 11 回スイープで測ったときは `dashboard_layout` が **−10.8%** と出たが、21 回にしたら **−1.8%** に潰れた。#339 で足した `ab-bench.mjs` を使っていても、反復数が足りなければ普通に二桁の嘘をつく。この件も `benchmarks/BASELINE.md` に書き残した。

## 意味論について

`x is Ctor`（payload なしコンストラクタ）が受け入れる値は `x == Ctor` と厳密に同じ。payload を持つ variant が混ざった enum の payload なしコンストラクタ（`Dimension` の `@types.Auto` など）でも同じ。純粋な演算子の入れ替え。

## 検証

- `moon check --target js`: 0 errors、警告数も main と同じ 682
- `moon test --target js`: 3639/3641 — 失敗2件は main と同じ既存のもの（browser の mutation records、sixel img スナップショット）
- `pnpm test:node`: この環境でビルド成果物がなくて落ちる既存 11 件以外すべて green
- `moonfmt` の drift は変更前後で各ファイル同数（新たな drift を持ち込んでいない）
- `.mbti` は変更なし（公開シグネチャに触れていない）。`moon info` が全体に出す toolchain drift 137 ファイルは別件として持ち込んでいない — なお `dom/html` と `renderer/renderer` の `.mbti` は main 時点ですでに実装から遅れている（`InTemplate`、`clear_text_metrics_record_replay` など）ので、これも別途

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114XoakYgfkaMBMwWr9WmMT

---
_Generated by [Claude Code](https://claude.ai/code/session_0114XoakYgfkaMBMwWr9WmMT)_