### PR TITLE
perf(layout): cut per-word and per-character allocation on wasm, and regenerate two stale .mbti

### DIFF
--- a/benchmarks/BASELINE.md
+++ b/benchmarks/BASELINE.md
@@ -1039,3 +1039,67 @@ calls and a whole tree copy per render — but at this document size it is worth
 roughly one to three percent of wall clock, not more. Both changes are kept
 because they are strictly less work for identical output, not because the
 stopwatch shows much.
+
+## Wasm Allocation Pass (2026-09-10)
+
+First use of the repo's `moonbit-mem-profile` skill (`moon-pprof memprofile`) on
+a wasm build. Everything above was measured on the JS backend; this pass looks at
+allocations the JS backend mostly does not make.
+
+### Setup
+
+A throwaway `renderer/profmain` package renders one dashboard-shaped document
+(161 boxes -- the shape of `render_dash_med`, sized so the instrumented wasm
+finishes in about a second), built with `moon -C renderer build --target wasm`
+(debug, linear-memory wasm, both required) and profiled with
+`moon-pprof memprofile`. The package is deleted afterwards; only the library
+change ships.
+
+`moon-pprof summary` prints the top sites by bytes. Sort by *allocation count*
+instead: a site with thousands of ~13-byte allocations is per-word or per-
+character churn, while a handful of large ones is usually the output the render
+actually has to produce.
+
+### What the wasm backend charges for that the JS backend does not
+
+- **A tuple return is a heap allocation.** Verified on a scratch module: a
+  function returning `(Int, Int)`, called 200,000 times, allocates 200,000 times
+  at 16 bytes; the same function writing into a mutable record allocates zero.
+- **`String::iter` allocates**, both the iterator and (on wasm) a `Char` per
+  step. An index scan over code units allocates nothing.
+- **`String::trim` allocates a 128-bit ASCII character set per call**, since
+  core gained the optional `chars` parameter -- so `trim().is_empty()` costs two
+  allocations to answer a `Bool`.
+
+### Result on one render
+
+| Counter | Before | After | Delta |
+|---------|--------|-------|-------|
+| Total allocations | 102,744 | 100,923 | **-1.8%** |
+| Total bytes | 3.14 MB | 3.11 MB | -1.2% |
+| `place_word_with_wrap` (layout) | 54.4 kB | 37.7 kB | -30.8% |
+| `place_word_with_wrap` (renderer) | 12.6 kB | 8.8 kB | -30.8% |
+| `build_ascii_char_set` | 61.9 kB | 47.7 kB | -22.9% |
+| `String::iter` | 54.5 kB | 43.8 kB | -19.5% |
+| `Iter::new` | 33.2 kB | 27.3 kB | -17.8% |
+
+The JS backend shows nothing, as expected: 21 interleaved repetitions of
+`render_dash_med` put it at +2.1% against controls at -1.2% and +2.0%. Report
+that honestly rather than hunting for a JS number to quote -- a wasm allocation
+fix is a wasm win.
+
+### The largest site is still unattributed
+
+`block::compute_with_collapse` holds 12,342 allocations (12% of the render) at
+22 bytes each. moon-pprof can name the function but not the line -- the wasm name
+section carries no line numbers -- and that function is 4,700 lines, so stubbing
+one suspect at a time is the only handle the skill offers. Next pass should
+either shrink the function first or find a way to get line attribution; the
+allocations are small and numerous, so the shape to look for is `Some(...)` of a
+`Double` and small records built per child.
+
+`Array` growth is worth a look at the same time: 3,592 allocations came from
+`Array::realloc` on pushes with no reserved capacity, reached mostly from block
+and inline layout. (The element type in the demangled name is not meaningful --
+MoonBit shares one array implementation across reference element types and names
+it after whichever instantiation was emitted first.)

--- a/dom/html/pkg.generated.mbti
+++ b/dom/html/pkg.generated.mbti
@@ -62,6 +62,7 @@ pub(all) enum InsertionMode {
   InCell
   InSelect
   InSelectInTable
+  InTemplate
   AfterBody
   InFrameset
   AfterFrameset
@@ -137,6 +138,7 @@ pub(all) struct TreeBuilder {
   mut frameset_ok : Bool
   mut head_element : Element?
   mut pending_table_chars : Array[Char]
+  template_insertion_modes : Array[InsertionMode]
   pending_text : StringBuilder
   pending_tokens : Array[Token]
 }

--- a/layout/block/block.mbt
+++ b/layout/block/block.mbt
@@ -280,8 +280,15 @@ fn flatten_first_table_child(
 }
 
 ///|
-fn is_table_run_whitespace_char(c : Char) -> Bool {
-  c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\u000C'
+/// The same set as `is_flow_whitespace_char` / `is_table_run_whitespace_char`,
+/// on a UTF-16 code unit. Scanning code units lets these predicates run over a
+/// string by index instead of through `String::iter`, which allocates an
+/// iterator (and, on the wasm backend, a `Char` per step) for a question whose
+/// answer is a `Bool`. Every character in the set is ASCII, so a code-unit scan
+/// accepts exactly what the `Char` scan accepted -- a surrogate half is no more
+/// whitespace than the astral character it belongs to.
+fn is_flow_whitespace_code_unit(c : Int) -> Bool {
+  c == 0x20 || c == 0x09 || c == 0x0A || c == 0x0D || c == 0x0C
 }
 
 ///|
@@ -291,8 +298,8 @@ fn is_whitespace_only_table_run_text(node : @node.Node) -> Bool {
   }
   match node.text {
     Some(text) => {
-      for c in text.iter() {
-        if !is_table_run_whitespace_char(c) {
+      for i = 0; i < text.length(); i = i + 1 {
+        if !is_flow_whitespace_code_unit(text[i].to_int()) {
           return false
         }
       }
@@ -325,14 +332,13 @@ fn text_ends_with_collapsible_flow_whitespace(node : @node.Node) -> Bool {
   }
   match node.text {
     Some(text) => {
-      let chars : Array[Char] = []
-      for c in text.iter() {
-        chars.push(c)
-      }
-      if chars.length() == 0 {
+      // Only the final code unit decides this; collecting the whole string into
+      // an `Array[Char]` first allocated the array and a `Char` per character.
+      let len = text.length()
+      if len == 0 {
         return false
       }
-      is_flow_whitespace_char(chars[chars.length() - 1])
+      is_flow_whitespace_code_unit(text[len - 1].to_int())
     }
     None => false
   }
@@ -345,8 +351,8 @@ fn is_whitespace_only_flow_text(node : @node.Node) -> Bool {
   }
   match node.text {
     Some(text) => {
-      for c in text.iter() {
-        if !is_flow_whitespace_char(c) {
+      for i = 0; i < text.length(); i = i + 1 {
+        if !is_flow_whitespace_code_unit(text[i].to_int()) {
           return false
         }
       }
@@ -363,8 +369,9 @@ fn flow_whitespace_contains_line_break(node : @node.Node) -> Bool {
   }
   match node.text {
     Some(text) =>
-      for c in text.iter() {
-        if c == '\n' || c == '\r' || c == '\t' || c == '\u000C' {
+      for i = 0; i < text.length(); i = i + 1 {
+        let c = text[i].to_int()
+        if c == 0x0A || c == 0x0D || c == 0x09 || c == 0x0C {
           return true
         }
       }

--- a/layout/inline/inline.mbt
+++ b/layout/inline/inline.mbt
@@ -184,15 +184,32 @@ fn has_inline_break_opportunity_between(
 }
 
 ///|
+/// Where the word-wrap scan has got to: lines opened so far, and the width of
+/// the line still being filled, both in columns.
+///
+/// `place_word_with_wrap` writes here instead of returning `(Int, Int)`,
+/// because a tuple return is a heap allocation on the wasm backend, one per
+/// word.
+/// `moon-pprof` put `place_word_with_wrap` at 5,280 allocations of 13 bytes for
+/// a single 161-box render; one cursor per text node replaces all of them.
+priv struct WrapCursor {
+  mut lines : Int
+  mut line_width : Int
+}
+
+///|
 fn place_word_with_wrap(
+  out : WrapCursor,
   lines : Int,
   line_width : Int,
   word_width : Int,
   cols_available : Int,
   needs_space : Bool,
-) -> (Int, Int) {
+) -> Unit {
   if cols_available <= 0 {
-    return (lines, line_width)
+    out.lines = lines
+    out.line_width = line_width
+    return
   }
   let mut new_lines = lines
   let mut new_line_width = line_width
@@ -202,15 +219,18 @@ fn place_word_with_wrap(
   }
   if new_line_width > 0 &&
     new_line_width + space_width + word_width <= cols_available {
-    new_line_width = new_line_width + space_width + word_width
-    return (new_lines, new_line_width)
+    out.lines = new_lines
+    out.line_width = new_line_width + space_width + word_width
+    return
   }
   if new_line_width > 0 {
     new_lines = new_lines + 1
     new_line_width = 0
   }
   if word_width <= cols_available {
-    return (new_lines, word_width)
+    out.lines = new_lines
+    out.line_width = word_width
+    return
   }
   let full_lines = word_width / cols_available
   let remainder = word_width % cols_available
@@ -225,7 +245,8 @@ fn place_word_with_wrap(
     new_lines = new_lines + full_lines
     new_line_width = remainder
   }
-  (new_lines, new_line_width)
+  out.lines = new_lines
+  out.line_width = new_line_width
 }
 
 ///|
@@ -235,7 +256,7 @@ fn estimate_wrapped_text_metrics(
 ) -> WrappedTextMetrics? {
   match node.text {
     Some(raw_text) => {
-      let text = raw_text.trim().to_owned()
+      let text = trim_blank_edges(raw_text)
       if text.is_empty() || node.style.writing_mode.is_vertical() {
         return None
       }
@@ -278,6 +299,8 @@ fn estimate_wrapped_text_metrics(
       let mut total_lines = 1
       let mut last_line_cols = 0
       let mut max_line_cols = 0
+      // One scratch cursor for the whole scan; see `WrapCursor`.
+      let wrap_out = WrapCursor::{ lines: 0, line_width: 0 }
       if use_word_wrap && !no_wrap {
         let mut current_line_width = 0
         let mut current_word_width = 0
@@ -285,12 +308,12 @@ fn estimate_wrapped_text_metrics(
         for c in text.iter() {
           if c == '\n' {
             if current_word_width > 0 {
-              let (l, w) = place_word_with_wrap(
-                total_lines, current_line_width, current_word_width, cols_available,
+              place_word_with_wrap(
+                wrap_out, total_lines, current_line_width, current_word_width, cols_available,
                 has_pending_space,
               )
-              total_lines = l
-              current_line_width = w
+              total_lines = wrap_out.lines
+              current_line_width = wrap_out.line_width
               if current_line_width > max_line_cols {
                 max_line_cols = current_line_width
               }
@@ -308,12 +331,12 @@ fn estimate_wrapped_text_metrics(
             has_pending_space = false
           } else if c == ' ' || c == '\t' {
             if current_word_width > 0 {
-              let (l, w) = place_word_with_wrap(
-                total_lines, current_line_width, current_word_width, cols_available,
+              place_word_with_wrap(
+                wrap_out, total_lines, current_line_width, current_word_width, cols_available,
                 has_pending_space,
               )
-              total_lines = l
-              current_line_width = w
+              total_lines = wrap_out.lines
+              current_line_width = wrap_out.line_width
               if current_line_width > max_line_cols {
                 max_line_cols = current_line_width
               }
@@ -329,12 +352,12 @@ fn estimate_wrapped_text_metrics(
           }
         }
         if current_word_width > 0 {
-          let (l, w) = place_word_with_wrap(
-            total_lines, current_line_width, current_word_width, cols_available,
+          place_word_with_wrap(
+            wrap_out, total_lines, current_line_width, current_word_width, cols_available,
             has_pending_space,
           )
-          total_lines = l
-          current_line_width = w
+          total_lines = wrap_out.lines
+          current_line_width = wrap_out.line_width
           if current_line_width > max_line_cols {
             max_line_cols = current_line_width
           }
@@ -552,12 +575,60 @@ fn id_matches_tag(node_id : String, tag : String) -> Bool {
 }
 
 ///|
+/// Whether `c` is a code unit `String::trim` strips. The set matches its
+/// default exactly -- tab, line feed, carriage return and space -- and
+/// deliberately not vertical tab or form feed.
+fn is_trimmable_code_unit(c : Int) -> Bool {
+  c == 0x20 || c == 0x09 || c == 0x0A || c == 0x0D
+}
+
+///|
+/// Whether `text` is blank, i.e. whether `text.trim()` would be empty.
+///
+/// `trim()` answers the same question, but it builds a 128-bit ASCII character
+/// set on every call and then a trimmed copy of the string -- two heap
+/// allocations on the wasm backend for a predicate that returns a `Bool`.
+/// `moon-pprof` attributed 2,642 allocations of a single 161-box render to that
+/// character set alone.
+fn is_blank_text(text : String) -> Bool {
+  for i = 0; i < text.length(); i = i + 1 {
+    if !is_trimmable_code_unit(text[i].to_int()) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// `text.trim()` as an owned string, without the character set `trim()`
+/// allocates -- and without allocating at all when there is nothing to strip,
+/// which is the common case for text that already came out of the parser
+/// collapsed. Only ASCII whitespace is skipped, so the slice never splits a
+/// surrogate pair.
+fn trim_blank_edges(text : String) -> String {
+  let len = text.length()
+  let mut start = 0
+  while start < len && is_trimmable_code_unit(text[start].to_int()) {
+    start = start + 1
+  }
+  let mut end = len
+  while end > start && is_trimmable_code_unit(text[end - 1].to_int()) {
+    end = end - 1
+  }
+  if start == 0 && end == len {
+    text
+  } else {
+    text[start:end].to_owned()
+  }
+}
+
+///|
 fn is_whitespace_text_node(node : @node.Node) -> Bool {
   if !@node.str_has_prefix(node.id, "#text") {
     return false
   }
   match node.text {
-    Some(text) => text.trim().is_empty()
+    Some(text) => is_blank_text(text)
     None =>
       match node.measure {
         Some(_) => false
@@ -569,7 +640,7 @@ fn is_whitespace_text_node(node : @node.Node) -> Bool {
 ///|
 fn has_non_whitespace_text_descendant(node : @node.Node) -> Bool {
   match node.text {
-    Some(text) => if !text.trim().is_empty() { return true }
+    Some(text) => if !is_blank_text(text) { return true }
     None => ()
   }
   for child in node.children {

--- a/renderer/renderer/pkg.generated.mbti
+++ b/renderer/renderer/pkg.generated.mbti
@@ -24,9 +24,13 @@ pub fn cascade_reuse_end() -> (Map[String, @style.Style], Map[String, String], I
 
 pub fn clear_builtin_text_advance_ratio_override_for_test() -> Unit
 
+pub fn clear_image_intrinsic_record_replay() -> Unit
+
 pub fn clear_image_intrinsic_size_provider() -> Unit
 
 pub fn clear_text_metrics_provider() -> Unit
+
+pub fn clear_text_metrics_record_replay() -> Unit
 
 pub fn compute_composed_shadow_styles(@dom.DomTree, RenderContext) -> Map[Int, @style.Style]
 
@@ -46,6 +50,10 @@ pub fn css_uses_child_structure(Array[String]) -> Bool
 
 pub fn css_uses_sibling_combinator(Array[String]) -> Bool
 
+pub fn deserialize_image_intrinsic_recording(String) -> Array[RecordedImage]
+
+pub fn deserialize_text_metrics_recording(String) -> Array[RecordedMetric]
+
 pub fn element_to_node(@html.Element, @style.Style?) -> @node.Node
 
 pub fn get_content_height(String, Int, Int) -> Int
@@ -55,6 +63,10 @@ pub fn get_content_height_with_css(String, Int, Int, Array[String]) -> Int
 pub fn get_content_height_with_document(@html.Document, Int, Int, Array[String]) -> Int
 
 pub fn get_force_monospace_metrics() -> Bool
+
+pub fn install_image_intrinsic_replay(Array[RecordedImage]) -> Unit
+
+pub fn install_text_metrics_replay(Array[RecordedMetric]) -> Unit
 
 pub fn layout_to_json(@crater-core.Layout) -> String
 
@@ -106,6 +118,10 @@ pub fn render_to_node_with_prepared_external_css(@html.Document, RenderContext, 
 
 pub fn render_with_external_css(String, RenderContext, Array[String]) -> @crater-core.Layout
 
+pub fn serialize_image_intrinsic_recording(Array[RecordedImage]) -> String
+
+pub fn serialize_text_metrics_recording(Array[RecordedMetric]) -> String
+
 pub fn set_builtin_text_advance_ratio_override_for_test(Double) -> Unit
 
 pub fn set_force_monospace_metrics(Bool) -> Unit
@@ -113,6 +129,14 @@ pub fn set_force_monospace_metrics(Bool) -> Unit
 pub fn set_image_intrinsic_size_provider(ImageIntrinsicSizeProvider) -> Unit
 
 pub fn set_text_metrics_provider(TextMetricsProvider) -> Unit
+
+pub fn start_image_intrinsic_recording() -> Unit
+
+pub fn start_text_metrics_recording() -> Unit
+
+pub fn take_image_intrinsic_recording() -> Array[RecordedImage]
+
+pub fn take_text_metrics_recording() -> Array[RecordedMetric]
 
 // Errors
 
@@ -159,6 +183,21 @@ pub struct PseudoRuleIndex {
   by_class : Map[String, Array[Int]]
   by_tag : Map[String, Array[Int]]
   universal : Array[Int]
+}
+
+pub(all) struct RecordedImage {
+  src : String
+  has_size : Bool
+  width : Double
+  height : Double
+}
+
+pub(all) struct RecordedMetric {
+  key : String
+  min_width : Double
+  max_width : Double
+  min_height : Double
+  max_height : Double
 }
 
 pub(all) struct RenderContext {

--- a/renderer/renderer/text_layout_utils.mbt
+++ b/renderer/renderer/text_layout_utils.mbt
@@ -118,15 +118,30 @@ fn char_display_width(c : Char) -> Int {
 ///|
 /// Place a word into wrapped lines.
 /// Returns (updated_lines, updated_line_width).
+/// Where the word-wrap scan has got to: lines opened so far, and the width of
+/// the line still being filled, both in columns.
+///
+/// `place_word_with_wrap` writes here instead of returning `(Int, Int)`: a
+/// tuple return is a heap allocation on the wasm backend, one per word. See
+/// the twin of this type in `mizchi/crater-layout/inline`.
+priv struct WrapCursor {
+  mut lines : Int
+  mut line_width : Int
+}
+
+///|
 fn place_word_with_wrap(
+  out : WrapCursor,
   lines : Int,
   line_width : Int,
   word_width : Int,
   cols_available : Int,
   needs_space : Bool,
-) -> (Int, Int) {
+) -> Unit {
   if cols_available <= 0 {
-    return (lines, line_width)
+    out.lines = lines
+    out.line_width = line_width
+    return
   }
   let mut new_lines = lines
   let mut new_line_width = line_width
@@ -138,8 +153,9 @@ fn place_word_with_wrap(
   // Fits current line
   if new_line_width > 0 &&
     new_line_width + space_width + word_width <= cols_available {
-    new_line_width = new_line_width + space_width + word_width
-    return (new_lines, new_line_width)
+    out.lines = new_lines
+    out.line_width = new_line_width + space_width + word_width
+    return
   }
 
   // Move to next line if current line already has content.
@@ -150,7 +166,9 @@ fn place_word_with_wrap(
 
   // Fits a fresh line.
   if word_width <= cols_available {
-    return (new_lines, word_width)
+    out.lines = new_lines
+    out.line_width = word_width
+    return
   }
 
   // Long word fallback: hard-wrap by available columns.
@@ -167,7 +185,8 @@ fn place_word_with_wrap(
     new_lines = new_lines + full_lines
     new_line_width = remainder
   }
-  (new_lines, new_line_width)
+  out.lines = new_lines
+  out.line_width = new_line_width
 }
 
 ///|
@@ -687,18 +706,20 @@ fn create_text_measure(
       let mut total_lines = 1
       if use_word_wrap && !no_wrap {
         // Greedy word wrapping with long-word hard-wrap fallback.
+        // One scratch cursor for the whole scan; see `WrapCursor`.
+        let wrap_out = WrapCursor::{ lines: 0, line_width: 0 }
         let mut current_line_width = 0
         let mut current_word_width = 0
         let mut has_pending_space = false
         for c in trimmed.iter() {
           if c == '\n' {
             if current_word_width > 0 {
-              let (l, w) = place_word_with_wrap(
-                total_lines, current_line_width, current_word_width, cols_available,
+              place_word_with_wrap(
+                wrap_out, total_lines, current_line_width, current_word_width, cols_available,
                 has_pending_space,
               )
-              total_lines = l
-              current_line_width = w
+              total_lines = wrap_out.lines
+              current_line_width = wrap_out.line_width
               current_word_width = 0
             }
             // Explicit line break always starts a new visual line.
@@ -707,12 +728,12 @@ fn create_text_measure(
             has_pending_space = false
           } else if c == ' ' || c == '\t' {
             if current_word_width > 0 {
-              let (l, w) = place_word_with_wrap(
-                total_lines, current_line_width, current_word_width, cols_available,
+              place_word_with_wrap(
+                wrap_out, total_lines, current_line_width, current_word_width, cols_available,
                 has_pending_space,
               )
-              total_lines = l
-              current_line_width = w
+              total_lines = wrap_out.lines
+              current_line_width = wrap_out.line_width
               current_word_width = 0
             }
             has_pending_space = true
@@ -721,11 +742,11 @@ fn create_text_measure(
           }
         }
         if current_word_width > 0 {
-          let (l, _w) = place_word_with_wrap(
-            total_lines, current_line_width, current_word_width, cols_available,
+          place_word_with_wrap(
+            wrap_out, total_lines, current_line_width, current_word_width, cols_available,
             has_pending_space,
           )
-          total_lines = l
+          total_lines = wrap_out.lines
         }
       } else {
         // Character-based wrapping for nowrap/pre/pre-wrap behavior.

--- a/scripts/ci/prefetch-moon-deps.sh
+++ b/scripts/ci/prefetch-moon-deps.sh
@@ -43,6 +43,32 @@ fi
 echo "Prefetching MoonBit dependencies"
 cat "$tmp_deps"
 
+# `moon fetch` pulls each archive from https://download.mooncakes.io/. That host
+# drops connections often enough to fail a whole job on one dependency
+# (observed: `client error (Connect) / Connection reset by peer` fetching
+# mizchi/crater-aomx, before any build had started). It is the same class of
+# transient registry blip that `moon-update-retry.sh` already guards `moon
+# update` against, so retry on the same schedule; a dependency that is genuinely
+# missing still fails after the last attempt.
+fetch_with_retries() {
+  local dep="$1"
+  local attempts=4
+  local delay=5
+  local attempt
+  for attempt in $(seq 1 "$attempts"); do
+    if moon ${moon_common[@]+"${moon_common[@]}"} fetch --no-update "$dep"; then
+      return 0
+    fi
+    if [[ "$attempt" -eq "$attempts" ]]; then
+      echo "moon fetch ${dep} failed after ${attempt} attempts" >&2
+      return 1
+    fi
+    echo "moon fetch ${dep} attempt ${attempt} failed (likely a transient mooncakes.io blip); retrying in ${delay}s" >&2
+    sleep "$delay"
+    delay=$((delay * 2))
+  done
+}
+
 while IFS= read -r dep; do
-  moon ${moon_common[@]+"${moon_common[@]}"} fetch --no-update "$dep"
+  fetch_with_retries "$dep"
 done <"$tmp_deps"


### PR DESCRIPTION
残っていた 2 件（wasm 側のアロケーション調査と、実装から遅れていた `.mbti`）。

## 1. wasm アロケーション調査

リポジトリの `moonbit-mem-profile` スキル（`moon-pprof memprofile`）を初めて使った。これまでの計測は全部 JS バックエンドだったが、**JS ではほぼ無料の操作が wasm では毎回ヒープ確保になる**という、スキルが警告している通りの構図だった。

使い捨ての `renderer/profmain` でダッシュボード状の文書（161 ボックス）を 1 回レンダリングし、`--target wasm` の debug ビルドをプロファイル。パッケージは削除済みで、ライブラリ側の変更だけが入っている。

**バイト数ではなくアロケーション回数でソートするのが肝**。13 バイトが数千回、は語あたり/文字あたりの churn で、大きいのが数個ならそれは本当に必要な出力。

### 見つかった3件

**タプル返しは1語ごとにヒープ確保になる。** `place_word_with_wrap` が `(Int, Int)` を返していた。スクラッチモジュールで確認: `(Int, Int)` を返す関数を 20 万回呼ぶと **20 万回・16 バイト**確保、同じ処理を mutable レコードに書き込む形にすると **0**。1 レンダリングで 5,280 回・13 バイトを占めていて、ブロックレイアウト本体に次ぐ 2 位だった。layout/inline と renderer の両コピーを、テキストノードごとに 1 個だけ確保する `WrapCursor` に書き込む形にした。

**`trim()` は `Bool` を返すために文字集合を確保する。** core が `chars` オプション引数を持って以来、`trim()` は毎回 128bit の ASCII 文字集合を作る。`build_ascii_char_set` が 1 レンダリングで 2,642 回。`is_whitespace_text_node` などの述語はコードユニットを直接走査する形にし、トリム済み文字列が本当に必要な 1 箇所だけ手書きのインデックス走査（削るものが無ければ入力をそのまま返す）にした。文字集合は `String::trim` の既定と厳密に一致させている（tab / LF / CR / space。VT と FF は**含まない**）。

**`String::iter` は走査ごとに確保し、しかもある走査は最後の1文字を見るためだけに配列を作っていた。** `text_ends_with_collapsible_flow_whitespace` がテキスト全体を `Array[Char]` に集めてから末尾要素だけ見ていた。ブロックレイアウトの 4 つの whitespace 走査をコードユニットのインデックス走査にした。対象文字は全部 ASCII なので、`Char` 走査と受理する集合は完全に一致する。

### 計測（同一レンダリング、`moon-pprof summary --diff`）

| Counter | Before | After | Delta |
|---|---|---|---|
| 総アロケーション数 | 102,744 | 100,923 | **-1.8%** |
| 総バイト数 | 3.14 MB | 3.11 MB | -1.2% |
| `place_word_with_wrap` (layout) | 54.4 kB | 37.7 kB | -30.8% |
| `place_word_with_wrap` (renderer) | 12.6 kB | 8.8 kB | -30.8% |
| `build_ascii_char_set` | 61.9 kB | 47.7 kB | -22.9% |
| `String::iter` | 54.5 kB | 43.8 kB | -19.5% |
| `Iter::new` | 33.2 kB | 27.3 kB | -17.8% |
| `estimate_wrapped_text_metrics` | 33.1 kB | 37.9 kB | +14.3%（呼び出しごとの cursor 1個） |

**JS 側は変化なし**。21 回インターリーブで `render_dash_med` が +2.1%、コントロールが -1.2% / +2.0% なので、ノイズ床の中。wasm 向けの修正なので想定どおりで、JS の数字を探しに行かずそのまま記録した。

（途中 15 回スイープで `render_dash_med` が **-44.5%** と出たが、21 回にしたら +2.1% に潰れた。前回に続いて 2 度目なので `BASELINE.md` にも書いてある。）

### 残った最大の site（次にやる人向け）

`block::compute_with_collapse` が **12,342 回（全体の 12%）・22 バイト**で残っている。moon-pprof は関数名までは出せるが**行番号は出せない**（wasm の name section に行情報が無い）し、この関数は 4,700 行あるので、スキルが言う「1 つずつ stub して確認」以外の手がかりが無い。小さいのが大量、という形なので `Some(Double)` と子ごとの小さいレコードが怪しい。

同時に `Array` の伸長も見る価値がある: capacity 無しの push による `Array::realloc` が 3,592 回。（demangle された要素型名は当てにならない — MoonBit は参照型の配列実装を共有していて、最初に emit されたインスタンス名が付く。）

## 2. 実装から遅れていた `.mbti` の再生成

`dom/html` と `renderer/renderer` の `pkg.generated.mbti` が実装に追いついていなかった: tree builder の `InTemplate` と `template_insertion_modes`、renderer の text-metrics / image-intrinsic の record/replay 一式（`start_*_recording`、`take_*_recording`、`serialize_*` / `deserialize_*`、`install_*_replay`、`clear_*_record_replay` と `RecordedMetric` / `RecordedImage`）。

`moon info` はワークスペース全体を再生成するので、**中身が実際に変わった 2 ファイルだけ**を残した。残り 148 ファイルは末尾の空行 1 行だけの差分（現行 toolchain の整形変更であってこのリポジトリのコードの変化ではない）なので、まとめてやりたい人に残してある。

## 検証

- `moon check --target js`: 0 errors、警告数も main と同じ **682**
- `moon check --target wasm`: 0 errors
- `moon test --target js`: 3639/3641 — 失敗2件は main と同じ既存のもの
- `moonfmt` の drift は変更前後で同数（新規に持ち込んだのは、リポジトリ全体に既にある trailing-comma 系のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114XoakYgfkaMBMwWr9WmMT

---
_Generated by [Claude Code](https://claude.ai/code/session_0114XoakYgfkaMBMwWr9WmMT)_