### PR TITLE
docs(bench): record why the subtree-layout memo was rejected

### DIFF
--- a/benchmarks/BASELINE.md
+++ b/benchmarks/BASELINE.md
@@ -1182,3 +1182,98 @@ shape: 303 of 400 calls exist only to answer an intrinsic-size question and
 throw the rest away. Memoizing that answer per (node, constraint) is the same
 move that worked for the box model in #339, and it would remove the allocations
 rather than shrink them.
+
+## Memoizing the repeated subtree walk (2026-09-10)
+
+The lever proposed above was tried and **rejected**. It works — the repeats are
+real and large — but paying for them in retained heap costs more than the
+recomputation it saves. Recorded here so the next pass starts from the numbers
+instead of the idea.
+
+### The duplication is real
+
+Keying every `compute_with_collapse` call of one dashboard render by
+`(uid, available_width, available_height, sizing_mode, viewport, stretch)`:
+
+| | |
+|---|---|
+| calls | 289 |
+| distinct keys | 145 |
+| repeats | 144 (**49.8%**) |
+| multiplicity | every duplicated key appears exactly twice, never more |
+
+Diffing the two stacks of each duplicate pair from the outermost frame, the
+dominant divergence (72 of 144) is one level of flex:
+
+```
+flex.compute_internal.inner
+  A: flex.compute_min_content_main_size ...
+  B: flex.compute_nested.inner          ...
+```
+
+Sizing a box and laying it out are the same walk run twice. Grid does the same
+thing when `adjust_block_tracks_for_content_items` re-lays a track's items.
+
+### Where to put the cache
+
+`@block.compute_with_collapse` is the wrong level -- it is entered thousands of
+times per render, so a miss is charged constantly. `@dispatch.compute` is the
+one boundary every layout mode recurses through, so a hit there skips a whole
+mixed flex/grid/block subtree, and it is entered rarely:
+
+| bench | dispatcher entries / render | repeats |
+|---|---|---|
+| `render_dash_med` | 102 | **47.1%** |
+| `layout_only_dash` | 77 | **31.2%** |
+| `layout_only_large` (2,500 boxes) | 140 | 0% |
+| `grid_10x10` | **1** | 0% |
+
+A per-render cache there (armed by `compute_layout_in_context`, keyed by `uid`
+with the constraint matched field by field) cut real work on the dashboards
+exactly as predicted.
+
+### Why it was rejected
+
+It also cost 3-5% on block-flow pages, and the cost is **retention, not
+lookup**. Two isolation builds settle it:
+
+| variant | `layout_only_large` | `layout_only_dash` |
+|---|---|---|
+| cache present, never armed | -0.7% | +0.0% |
+| armed, lookups only (storage disabled) | **+0.1%** | +0.5% |
+| armed, storing | **+5.1%** | -6.1% |
+
+Storing is the whole cost. A CPU profile of `layout_only_large` agrees: +9.4%
+samples spread diffusely across a dozen layout frames with GC up 12 --- the
+signature of a bigger live heap, not a hot new path. Holding 140 subtree
+layouts of a 2,500-box page alive for the duration of a render is what that
+buys.
+
+Four independent 21-25 rep interleaved sweeps: `layout_only_dash` -6 to -7%
+every time, `layout_only_large` +2.7 to +5.1% every time, and the full-render
+benchmarks moving no further than their own controls (`render_large_2k5` came
+back -9.2%, -3.9% and +4.3% on different sweeps, against controls that moved up
+to 4.1% -- it carries no signal here).
+
+Two cautions from this round. `grid_10x10` reproduced +6.6% to +8.7% across
+sweeps, and it is not real: that benchmark enters the dispatcher **once** per
+render, a direct micro-benchmark puts the added work at 114 ns against its
+153 us, and its CPU profile shows total samples *down* 5.8%. Benchmarks in the
+100-200 us range produce reproducible double-digit artifacts under the per-process
+harness -- pair them with a control of similar duration, or discount them.
+And `render_*` benchmarks rebuild the node tree each iteration while
+`layout_only_*` reuse one, so the two are not interchangeable readings of the
+same tree.
+
+### What would actually fix it
+
+No cheap signal at the dispatcher separates "will be reused" from "won't":
+display is `Block` for everything that reaches block layout, leaf calls never
+repeat but barely reach the dispatcher, and gating on a flex/grid ancestor does
+not discriminate at all (the 2,500-box page makes 138 of its 140 dispatcher
+entries under a flex or grid container and repeats none of them).
+
+So the fix belongs where the duplication is created, not behind a cache: flex
+answering `compute_min_content_main_size` with a full child layout that
+`compute_nested` then immediately repeats. Removing that second walk is free of
+retention because there is nothing to retain.


### PR DESCRIPTION
#342 の最後に「次は (node, constraint) でメモ化」と書きました。**作って測って、却下しました。** コード変更はゼロで、`benchmarks/BASELINE.md` に数字だけ残します。

## 重複は本物でした

ダッシュボード1レンダリング分の `compute_with_collapse` 呼び出しを、`(uid, available_width, available_height, sizing_mode, viewport, stretch)` でキー化:

| | |
|---|---|
| 呼び出し | 289 |
| 異なるキー | 145 |
| 重複 | 144（**49.8%**） |
| 多重度 | 重複キーは**必ずちょうど2回**、3回以上は無し |

重複ペアの2本のスタックを**外側から**diff すると、支配的な分岐点（144中72）は flex の1段でした:

```
flex.compute_internal.inner
  A: flex.compute_min_content_main_size ...
  B: flex.compute_nested.inner          ...
```

**サイズを測るのとレイアウトするのが同じ walk の2回実行**です。grid も `adjust_block_tracks_for_content_items` で同じことをしています。

## 置き場所は `@dispatch.compute`

`@block.compute_with_collapse` は1レンダリングで数千回入るので、ミスの代金を常に払うことになります。`@dispatch.compute` は**全レイアウトモードが再帰する唯一の境界**なので、1ヒットで flex/grid/block 混在のサブツリー丸ごとを飛ばせて、しかも入る回数が少ない:

| bench | dispatcher 入場 / render | 重複率 |
|---|---|---|
| `render_dash_med` | 102 | **47.1%** |
| `layout_only_dash` | 77 | **31.2%** |
| `layout_only_large`（2,500 box） | 140 | 0% |
| `grid_10x10` | **1** | 0% |

ここに per-render キャッシュを置くと、ダッシュボードの実作業は予想通り減りました（289 → 145 呼び出し）。

## それでも却下した理由

block-flow 主体のページで 3〜5% 遅くなり、その原因は**引きではなく保持**でした。切り分けビルド2本で確定します:

| variant | `layout_only_large` | `layout_only_dash` |
|---|---|---|
| キャッシュはあるが arm しない | -0.7% | +0.0% |
| arm するが**格納しない**（引きだけ） | **+0.1%** | +0.5% |
| arm して格納する | **+5.1%** | -6.1% |

格納が全コストです。CPU プロファイルも同じことを言っていて、`layout_only_large` は +9.4% サンプルが十数個のレイアウトフレームに**拡散**し、GC が +12 — ホットな新経路ではなく**live heap が大きくなった時の形**です。2,500 box ページのサブツリーレイアウト 140 本をレンダリング中ずっと生かしておく、というのがその代金でした。

21〜25回インターリーブを4本: `layout_only_dash` は毎回 -6〜-7%、`layout_only_large` は毎回 +2.7〜+5.1%、フルレンダリング系は自分のコントロール以上に動きませんでした。

## 測定上の注意（2つ、doc に残しました）

- **`grid_10x10` の +6.6%〜+8.7% は偽物**です。あのベンチは dispatcher に**1レンダリングにつき1回**しか入らず、追加分をマイクロベンチで直接測ると 153µs に対して 114ns、CPU プロファイルは総サンプル -5.8%。**100〜200µs 帯のベンチはこのプロセス単位ハーネスで再現性のある2桁の嘘をつきます** — 同程度の長さのコントロールと組にするか、割り引いて読むこと。
- `render_*` は毎イテレーション node ツリーを作り直し、`layout_only_*` は1本を使い回します。同じツリーの読み替えにはなりません。

## 本当の直し方

dispatcher には「再利用される/されない」を安く見分ける手掛かりがありませんでした。block レイアウトに来る時点で display は全部 `Block`、leaf は重複しないが dispatcher にほとんど来ない、flex/grid 祖先での gate も**全く効かない**（2,500 box ページは 140 入場のうち 138 が flex/grid 配下で、重複ゼロ）。

なので直す場所はキャッシュの裏ではなく**重複を作っている側** — flex が `compute_min_content_main_size` を子の完全レイアウトで答え、それを `compute_nested` が即座にもう一度やる、そこです。2回目の walk を無くせば保持するものが無いので、コストもありません。

## 検証

- コード変更なし（`benchmarks/BASELINE.md` のみ）
- 却下したキャッシュ自体は `moon check --target js` 0 errors / `moon test --target js` 3639/3641（失敗2件は main と同じ既存）まで通した上で捨てています

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114XoakYgfkaMBMwWr9WmMT

---
_Generated by [Claude Code](https://claude.ai/code/session_0114XoakYgfkaMBMwWr9WmMT)_